### PR TITLE
Add opentelemetry autoinstrumentation example of go program for grafana

### DIFF
--- a/charts/kof-collectors/templates/opentelemetry/instrumentation.yaml
+++ b/charts/kof-collectors/templates/opentelemetry/instrumentation.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.kof.instrumentation.enabled }}
+apiVersion: opentelemetry.io/v1alpha1
+kind: Instrumentation
+metadata:
+  name: kof-instrumentation
+  namespace: {{ .Release.Namespace }}
+spec:
+  exporter:
+    endpoint: "http://{{ .Release.Name}}-node-exporter-collector:4318"
+  propagators:
+    - tracecontext
+    - baggage
+  sampler:
+    type: parentbased_traceidratio
+    argument: "1"
+  go:
+    image: ghcr.io/open-telemetry/opentelemetry-go-instrumentation/autoinstrumentation-go:v0.19.0-alpha
+    resourceRequirements:
+      limits:
+        memory: 128Mi
+      requests:
+        memory: 128Mi
+{{- end }}

--- a/charts/kof-collectors/templates/opentelemetry/node-collector.yaml
+++ b/charts/kof-collectors/templates/opentelemetry/node-collector.yaml
@@ -142,13 +142,20 @@ spec:
           authenticator: basicauth/logs
         logs_endpoint: {{ .Values.kof.logs.endpoint }}
       debug:
-        verbosity: detailed
+        verbosity: basic
 
     service:
       extensions:
         - basicauth/metrics
         - basicauth/logs
       pipelines:
+        traces:
+          receivers:
+            - otlp
+          processors:
+            - batch
+          exporters:
+            - debug
         logs:
           exporters:
             - otlphttp

--- a/charts/kof-collectors/values.yaml
+++ b/charts/kof-collectors/values.yaml
@@ -12,6 +12,8 @@ kof:
     credentials_secret_name: grafana-admin-credentials
     username_key: GF_SECURITY_ADMIN_USER
     password_key: GF_SECURITY_ADMIN_PASSWORD
+  instrumentation:
+    enabled: true
 prometheus-node-exporter:
   enabled: true
   hostNetwork: false

--- a/charts/kof-operators/templates/opentelemetry/clusterroles/opentelemetry-operator-manager.yaml
+++ b/charts/kof-operators/templates/opentelemetry/clusterroles/opentelemetry-operator-manager.yaml
@@ -22,19 +22,23 @@ rules:
   - update
   - watch
 - apiGroups:
+  - "events.k8s.io"
+  resources:
+  - events
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - ""
   resources:
   - events
   verbs:
-  - create
-  - patch
-- apiGroups:
-  - ""
-  resources:
-  - namespaces
-  verbs:
+  - get
   - list
   - watch
+  - create
+  - patch
 - apiGroups:
   - apps
   resources:
@@ -54,6 +58,8 @@ rules:
   - extensions
   resources:
   - replicasets
+  - daemonsets
+  - deployments
   verbs:
   - get
   - list
@@ -99,8 +105,14 @@ rules:
   - ""
   resources:
   - nodes
+  - nodes/spec
+  - pods/status
   - namespaces
+  - namespaces/status
   - secrets
+  - replicationcontrollers
+  - replicationcontrollers/status
+  - resourcequotas
   verbs:
   - get
   - list
@@ -109,6 +121,7 @@ rules:
   - batch
   resources:
   - jobs
+  - cronjobs
   verbs:
   - get
   - list

--- a/charts/kof-operators/values.yaml
+++ b/charts/kof-operators/values.yaml
@@ -6,6 +6,8 @@ opentelemetry-operator:
     collectorImage:
       repository: "otel/opentelemetry-collector-contrib"
     createRbacPermissions: true
+    extraArgs:
+      - "--enable-go-instrumentation=true"
   clusterRole:
     create: false
   admissionWebhooks:

--- a/charts/kof-storage/templates/grafana/grafana.yaml
+++ b/charts/kof-storage/templates/grafana/grafana.yaml
@@ -17,6 +17,12 @@ spec:
   deployment:
     spec:
       template:
+{{- if .Values.grafana.autoinstrumentation.enabled }}
+        metadata:
+          annotations:
+            instrumentation.opentelemetry.io/inject-go: "{{ .Release.Namespace }}/kof-instrumentation"
+            instrumentation.opentelemetry.io/otel-go-auto-target-exe: "/usr/share/grafana/bin/grafana"
+{{- end }}
         spec:
           securityContext:
             fsGroup: 472

--- a/charts/kof-storage/values.yaml
+++ b/charts/kof-storage/values.yaml
@@ -52,6 +52,8 @@ grafana:
   ingress:
     enabled: true
     host: grafana.hmc0.example.net
+  autoinstrumentation:
+    enabled: true
 victoria-metrics-operator:
   enabled: true
   crds:


### PR DESCRIPTION
Closes https://github.com/K0rdent/kof/issues/6

hmc-controller autoinstrumentation doesn't work as the [fix](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/1471) for net library is unreleased yet
https://github.com/open-telemetry/opentelemetry-go-instrumentation/blob/main/CHANGELOG.md
