### PR TITLE
Fix kcm value in helm chart demo values

### DIFF
--- a/demo/demo-mothership-values.yaml
+++ b/demo/demo-mothership-values.yaml
@@ -2,7 +2,7 @@ global:
   clusterLabel: clusterName
   storageClass: standard
   clusterName: mothership
-hmc:
+kcm:
   installTemplates: true
 victoriametrics:
   enabled: enabled


### PR DESCRIPTION
This fixes a problem in the demo values where hmc wasn’t renamed to kcm, which was stopping ServiceTemplates from being created.