### PR TITLE
Revert "Applied helm values naming convention"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,7 +105,7 @@ dev-storage-deploy: dev ## Deploy kof-storage helm chart to the K8s cluster spec
 dev-ms-deploy-aws: dev ## Deploy Mothership helm chart to the K8s cluster specified in ~/.kube/config for a remote storage cluster
 	cp -f $(TEMPLATES_DIR)/kof-mothership/values.yaml dev/mothership-values.yaml
 	@$(YQ) eval -i '.kcm.installTemplates = true' dev/mothership-values.yaml
-	@$(YQ) eval -i '.kcm.kof.clusterProfiles.kofAwsDnsSecrets = {"matchLabels": {"k0rdent.mirantis.com/kof-aws-dns-secrets": "true"}, "secrets": ["external-dns-aws-credentials"]}' dev/mothership-values.yaml
+	@$(YQ) eval -i '.kcm.kof.clusterProfiles.kof-aws-dns-secrets = {"matchLabels": {"k0rdent.mirantis.com/kof-aws-dns-secrets": "true"}, "secrets": ["external-dns-aws-credentials"]}' dev/mothership-values.yaml
 	@$(YQ) eval -i '.grafana.logSources = [{"name": "$(USER)-aws-storage", "url": "https://vmauth.$(STORAGE_DOMAIN)/vls", "type": "victoriametrics-logs-datasource", "auth": {"credentials_secret_name": "storage-vmuser-credentials", "username_key": "username", "password_key": "password"}}]' dev/mothership-values.yaml
 	@$(YQ) eval -i '.promxy.config.serverGroups = [{"clusterName": "$(USER)-aws-storage", "targets": ["vmauth.$(STORAGE_DOMAIN):443"], "auth": {"credentials_secret_name": "storage-vmuser-credentials", "create_secret": true, "username_key": "username", "password_key": "password"}}]' dev/mothership-values.yaml
 

--- a/charts/kof-mothership/Chart.yaml
+++ b/charts/kof-mothership/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: kof-mothership
 description: A Helm chart that deploys Grafana, Promxy, and VictoriaMetrics.
-version: 0.1.9
+version: 0.1.10
 appVersion: "1.0"
 dependencies:
   - name: grafana-operator

--- a/charts/kof-mothership/values.yaml
+++ b/charts/kof-mothership/values.yaml
@@ -21,7 +21,7 @@ kcm:
       storage:
         version: 0.1.4
     clusterProfiles:
-      kofStorageSecrets:
+      kof-storage-secrets:
         matchLabels:
           k0rdent.mirantis.com/kof-storage-secrets: "true"
         secrets:

--- a/charts/kof-storage/Chart.lock
+++ b/charts/kof-storage/Chart.lock
@@ -7,9 +7,9 @@ dependencies:
   version: 0.40.4
 - name: victoria-logs-single
   repository: https://victoriametrics.github.io/helm-charts/
-  version: 0.8.12
+  version: 0.8.13
 - name: external-dns
   repository: https://kubernetes-sigs.github.io/external-dns/
   version: 1.15.0
-digest: sha256:e4ba96403921fa721337ab6cb4a005fe205407c01badf77a91b7f9549dfb5737
-generated: "2025-01-13T15:11:53.857929+02:00"
+digest: sha256:9d2ba5ad9077958a76657e5907caa24ff7095bfc8c23a88c936a6e8fa9116076
+generated: "2025-01-16T18:49:52.244186+01:00"


### PR DESCRIPTION
This reverts commit ea983ea9d6dbe49c21968b6af13c26021d03ec3e from https://github.com/k0rdent/kof/pull/31 because:

[WARNING] `templates/sveltos/copy-secrets-cluster-profile.yaml`: object name does not conform to Kubernetes naming requirements: `"kofStorageSecrets": metadata.name: Invalid value: "kofStorageSecrets"`: a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. example.com, regex used for validation is `[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*`)
