### PR TITLE
Replaced some "No data" with "None, that's good" based on description

### DIFF
--- a/charts/kof-mothership/Chart.yaml
+++ b/charts/kof-mothership/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: kof-mothership
 description: A Helm chart that deploys Grafana, Promxy, and VictoriaMetrics.
-version: 0.1.10
+version: 0.1.11
 appVersion: "1.0"
 dependencies:
   - name: grafana-operator

--- a/charts/kof-mothership/files/dashboards/kubernetes-views-global.yaml
+++ b/charts/kof-mothership/files/dashboards/kubernetes-views-global.yaml
@@ -1395,6 +1395,7 @@ panels:
   description: No data is generally a good thing here.
   fieldConfig:
     defaults:
+      noValue: "None, that's good"
       color:
         mode: palette-classic
       custom:
@@ -1478,6 +1479,7 @@ panels:
   description: No data is generally a good thing here.
   fieldConfig:
     defaults:
+      noValue: "None, that's good"
       color:
         mode: palette-classic
       custom:
@@ -1738,6 +1740,7 @@ panels:
   description: No data is generally a good thing here.
   fieldConfig:
     defaults:
+      noValue: "None, that's good"
       color:
         mode: palette-classic
       custom:
@@ -1818,6 +1821,7 @@ panels:
   description: No data is generally a good thing here.
   fieldConfig:
     defaults:
+      noValue: "None, that's good"
       color:
         mode: palette-classic
       custom:

--- a/charts/kof-mothership/files/dashboards/kubernetes-views-namespaces.yaml
+++ b/charts/kof-mothership/files/dashboards/kubernetes-views-namespaces.yaml
@@ -896,6 +896,7 @@ panels:
   description: No data is generally a good thing here.
   fieldConfig:
     defaults:
+      noValue: "None, that's good"
       color:
         mode: palette-classic
       custom:
@@ -976,6 +977,7 @@ panels:
   description: No data is generally a good thing here.
   fieldConfig:
     defaults:
+      noValue: "None, that's good"
       color:
         mode: palette-classic
       custom:


### PR DESCRIPTION
Part of https://github.com/k0rdent/kof/issues/11

Set `panels[].fieldConfig.defaults.noValue: "None, that's good"`
where `panels[].description: "No data is generally a good thing here."`

## Confusing `No data` before the fix:

![Screenshot 2025-01-17 at 18 30 12](https://github.com/user-attachments/assets/3373b29a-e8ff-4c27-9987-41e54600d034)

## Helpful message after the fix:

![Screenshot 2025-01-17 at 18 31 58](https://github.com/user-attachments/assets/140046d2-70e1-4e4d-8098-6ff8f3ca7c34)

