### PR TITLE
Run, promxy, run! Bonus: support of kcm 0.1.0

### DIFF
--- a/charts/kof-mothership/templates/k0rdent/catalog/ingress-nginx.yaml
+++ b/charts/kof-mothership/templates/k0rdent/catalog/ingress-nginx.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.kcm.installTemplates }}
+# https://github.com/k0rdent/catalog/blob/main/charts/ingress-nginx/ingress-nginx-service-template-4.11.3/templates/service-template.yaml
+apiVersion: k0rdent.mirantis.com/v1alpha1
+kind: ServiceTemplate
+metadata:
+  name: ingress-nginx-4-11-3
+  namespace: {{ .Values.kcm.namespace }}
+spec:
+  helm:
+    chartSpec:
+      chart: ingress-nginx
+      version: 4.11.3
+      interval: 10m0s
+      sourceRef:
+        kind: HelmRepository
+        name: k0rdent-catalog
+{{- end }}

--- a/charts/kof-mothership/templates/promxy/_helpers.tpl
+++ b/charts/kof-mothership/templates/promxy/_helpers.tpl
@@ -2,7 +2,7 @@
 {{/*
 Expand the name of the chart.
 */}}
-{{- define "chart.name" -}}
+{{- define "promxy.name" -}}
 {{- default .Chart.Name .Values.promxy.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
@@ -11,7 +11,7 @@ Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 If release name contains chart name it will be used as a full name.
 */}}
-{{- define "chart.fullname" -}}
+{{- define "promxy.fullname" -}}
 {{- if .Values.promxy.fullnameOverride -}}
 {{- .Values.promxy.fullnameOverride | trunc 63 | trimSuffix "-" -}}
 {{- else -}}
@@ -27,16 +27,16 @@ If release name contains chart name it will be used as a full name.
 {{/*
 Create chart name and version as used by the chart label.
 */}}
-{{- define "chart.chart" -}}
+{{- define "promxy.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*
 Common labels
 */}}
-{{- define "chart.labels" -}}
-helm.sh/chart: {{ include "chart.chart" . }}
-{{ include "chart.selectorLabels" . }}
+{{- define "promxy.labels" -}}
+helm.sh/chart: {{ include "promxy.chart" . }}
+{{ include "promxy.selectorLabels" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
@@ -46,17 +46,17 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{/*
 Selector labels
 */}}
-{{- define "chart.selectorLabels" -}}
-app.kubernetes.io/name: {{ include "chart.name" . }}
+{{- define "promxy.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "promxy.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
 
 {{/*
 Create the name of the service account to use
 */}}
-{{- define "chart.serviceAccountName" -}}
+{{- define "promxy.serviceAccountName" -}}
 {{- if .Values.promxy.serviceAccount.create -}}
-    {{ default (printf "%s-promxy" (include "chart.fullname" .)) .Values.promxy.serviceAccount.name }}
+    {{ default (printf "%s-promxy" (include "promxy.fullname" .)) .Values.promxy.serviceAccount.name }}
 {{- else -}}
     {{ default "default" .Values.promxy.serviceAccount.name }}
 {{- end -}}
@@ -65,11 +65,11 @@ Create the name of the service account to use
 {{/*
 Defins the name of secret
 */}}
-{{- define "chart.secretname" -}}
+{{- define "promxy.secretname" -}}
 {{- if .Values.promxy.secret -}}
 {{- .Values.promxy.secret -}}
 {{- else -}}
-{{- include "chart.fullname" . -}}-promxy-config
+{{- include "promxy.fullname" . -}}-promxy-config
 {{- end -}}
 {{- end -}}
 

--- a/charts/kof-mothership/templates/promxy/ingress.yaml
+++ b/charts/kof-mothership/templates/promxy/ingress.yaml
@@ -10,16 +10,16 @@ metadata:
 {{ toYaml .Values.promxy.ingress.annotations | indent 4 }}
 {{- end }}
   labels:
-  {{- include "chart.labels" . | nindent 4 }}
+  {{- include "promxy.labels" . | nindent 4 }}
   {{ with .Values.promxy.ingress.extraLabels }}
 {{ toYaml . | indent 4 }}
   {{ end }}
-  name: {{ template "chart.fullname" . }}-promxy
+  name: {{ template "promxy.fullname" . }}-promxy
   namespace: {{ .Release.Namespace }}
 spec:
   ingressClassName: {{ .Values.promxy.ingress.ingressClassName }}
   rules:
-  {{- $serviceName := include "chart.fullname" . }}
+  {{- $serviceName := include "promxy.fullname" . }}
   {{- range .Values.promxy.ingress.hosts }}
   - host: {{ . | quote }}
     http:

--- a/charts/kof-mothership/templates/promxy/operator-deployment.yaml
+++ b/charts/kof-mothership/templates/promxy/operator-deployment.yaml
@@ -2,10 +2,10 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "chart.fullname" . }}-promxy-operator
+  name: {{ include "promxy.fullname" . }}-promxy-operator
   namespace: {{ .Release.Namespace }}
   labels:
-    {{- include "chart.labels" . | nindent 4 }}
+    {{- include "promxy.labels" . | nindent 4 }}
     {{- if .Values.promxy.operator.extraLabels}}
     {{ toYaml .Values.promxy.operator.extraLabels | nindent 4 }}
     {{- end}}
@@ -21,12 +21,12 @@ spec:
   {{- end }}
   selector:
     matchLabels:
-      app.kubernetes.io/name: {{ include "chart.name" . }}
+      app.kubernetes.io/name: {{ include "promxy.name" . }}
       app.kubernetes.io/instance: {{ .Release.Name }}-operator
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: {{ include "chart.name" . }}
+        app.kubernetes.io/name: {{ include "promxy.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}-operator
         {{- if .Values.promxy.operator.extraLabels}}
         {{ toYaml .Values.promxy.operator.extraLabels | nindent 8 }}
@@ -36,7 +36,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
     {{- end }}
-      serviceAccountName: {{ include "chart.serviceAccountName" . }}
+      serviceAccountName: {{ include "promxy.serviceAccountName" . }}
     {{- if .Values.promxy.operator.nodeSelector }}
       nodeSelector:
         {{- toYaml .Values.promxy.operator.nodeSelector | nindent 8 }}

--- a/charts/kof-mothership/templates/promxy/promxy-config.yaml
+++ b/charts/kof-mothership/templates/promxy/promxy-config.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.promxy.enabled }}
+  {{- $secret_namespace := $.Release.Namespace }}
+  {{- $secret_name := include "chart.secretname" . }}
+  {{- $secret := lookup "v1" "Secret" $secret_namespace $secret_name }}
+  {{- $secret_key := "config.yaml" }}
+  {{- $secret_value := "" }}
+  {{- if $secret }}
+    {{- $secret_value = index $secret.data $secret_key | b64dec }}
+  {{- end }}
+kind: Secret
+apiVersion: v1
+metadata:
+  name: {{ $secret_name }}
+  namespace: {{ $secret_namespace }}
+stringData:
+  {{ $secret_key }}: {{ $secret_value | quote }}
+type: Opaque
+{{- end }}

--- a/charts/kof-mothership/templates/promxy/promxy-config.yaml
+++ b/charts/kof-mothership/templates/promxy/promxy-config.yaml
@@ -1,7 +1,6 @@
 {{- if .Values.promxy.enabled }}
-  {{- $secret_namespace := $.Release.Namespace }}
   {{- $secret_name := include "chart.secretname" . }}
-  {{- $secret := lookup "v1" "Secret" $secret_namespace $secret_name }}
+  {{- $secret := lookup "v1" "Secret" $.Release.Namespace $secret_name }}
   {{- $secret_key := "config.yaml" }}
   {{- $secret_value := "" }}
   {{- if $secret }}
@@ -11,7 +10,7 @@ kind: Secret
 apiVersion: v1
 metadata:
   name: {{ $secret_name }}
-  namespace: {{ $secret_namespace }}
+  namespace: {{ $.Release.Namespace }}
 stringData:
   {{ $secret_key }}: {{ $secret_value | quote }}
 type: Opaque

--- a/charts/kof-mothership/templates/promxy/promxy-config.yaml
+++ b/charts/kof-mothership/templates/promxy/promxy-config.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.promxy.enabled }}
-  {{- $secret_name := include "chart.secretname" . }}
+  {{- $secret_name := include "promxy.secretname" . }}
   {{- $secret := lookup "v1" "Secret" $.Release.Namespace $secret_name }}
   {{- $secret_key := "config.yaml" }}
   {{- $secret_value := "" }}

--- a/charts/kof-mothership/templates/promxy/promxy-deployment.yaml
+++ b/charts/kof-mothership/templates/promxy/promxy-deployment.yaml
@@ -2,10 +2,10 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "chart.fullname" . }}-promxy
+  name: {{ include "promxy.fullname" . }}-promxy
   namespace: {{ .Release.Namespace }}
   labels:
-    {{- include "chart.labels" . | nindent 4 }}
+    {{- include "promxy.labels" . | nindent 4 }}
     {{- if .Values.promxy.extraLabels}}
     {{ toYaml .Values.promxy.extraLabels | nindent 4 }}
     {{- end}}
@@ -21,11 +21,11 @@ spec:
   {{- end }}
   selector:
     matchLabels:
-      {{- include "chart.selectorLabels" . | nindent 6 }}
+      {{- include "promxy.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       labels:
-        {{- include "chart.selectorLabels" . | nindent 8 }}
+        {{- include "promxy.selectorLabels" . | nindent 8 }}
         {{- if .Values.promxy.extraLabels}}
         {{ toYaml .Values.promxy.extraLabels | nindent 8 }}
         {{- end}}
@@ -38,7 +38,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
     {{- end }}
-      serviceAccountName: {{ include "chart.serviceAccountName" . }}
+      serviceAccountName: {{ include "promxy.serviceAccountName" . }}
     {{- if .Values.promxy.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.promxy.nodeSelector | indent 8 }}
@@ -114,5 +114,5 @@ spec:
       volumes:
       - name: config
         secret:
-          secretName: {{ include "chart.secretname" .}}
+          secretName: {{ include "promxy.secretname" .}}
 {{- end }}

--- a/charts/kof-mothership/templates/promxy/role.yaml
+++ b/charts/kof-mothership/templates/promxy/role.yaml
@@ -3,7 +3,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ include "chart.fullname" . }}-operator
+  name: {{ include "promxy.fullname" . }}-operator
 rules:
 - apiGroups:
   - ""

--- a/charts/kof-mothership/templates/promxy/role_binding.yaml
+++ b/charts/kof-mothership/templates/promxy/role_binding.yaml
@@ -4,13 +4,13 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app.kubernetes.io/name: promxy-operator
-  name: {{ include "chart.fullname" . }}-operator
+  name: {{ include "promxy.fullname" . }}-operator
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ include "chart.fullname" . }}-operator
+  name: {{ include "promxy.fullname" . }}-operator
 subjects:
 - kind: ServiceAccount
-  name: {{ include "chart.serviceAccountName" . }}
+  name: {{ include "promxy.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
 {{- end }}

--- a/charts/kof-mothership/templates/promxy/service.yaml
+++ b/charts/kof-mothership/templates/promxy/service.yaml
@@ -7,7 +7,7 @@ metadata:
 {{ toYaml . | indent 4}}
 {{- end }}
   labels:
-    {{- include "chart.labels" . | nindent 4 }}
+    {{- include "promxy.labels" . | nindent 4 }}
     {{- if .Values.promxy.extraLabels}}
     {{ toYaml .Values.promxy.extraLabels | nindent 4 }}
     {{- end}}
@@ -36,6 +36,6 @@ spec:
       protocol: TCP
       targetPort: http
   selector:
-    {{- include "chart.selectorLabels" . | nindent 4 }}
+    {{- include "promxy.selectorLabels" . | nindent 4 }}
   type: "{{ .Values.promxy.service.type }}"
 {{- end }}

--- a/charts/kof-mothership/templates/promxy/serviceaccount.yaml
+++ b/charts/kof-mothership/templates/promxy/serviceaccount.yaml
@@ -2,10 +2,10 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "chart.serviceAccountName" . }}
+  name: {{ include "promxy.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
   labels:
-    {{- include "chart.labels" . | nindent 4 }}
+    {{- include "promxy.labels" . | nindent 4 }}
     {{- if .Values.promxy.extraLabels}}
     {{ toYaml .Values.promxy.extraLabels | nindent 4 }}
     {{- end}}

--- a/charts/kof-mothership/templates/sveltos/service-monitors.yaml
+++ b/charts/kof-mothership/templates/sveltos/service-monitors.yaml
@@ -6,7 +6,7 @@ metadata:
   name: {{ .Release.Name }}-sveltos-sc-manager
   namespace: {{ .Release.Namespace }}
   labels:
-    {{- include "chart.labels" . | nindent 4 }}
+    {{- include "promxy.labels" . | nindent 4 }}
 spec:
   endpoints:
   - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
@@ -28,7 +28,7 @@ metadata:
   name: {{ .Release.Name }}-sveltos-addon-controller
   namespace: {{ .Release.Namespace }}
   labels:
-    {{- include "chart.labels" . | nindent 4 }}
+    {{- include "promxy.labels" . | nindent 4 }}
 spec:
   endpoints:
   - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token

--- a/demo/cluster/aws-standalone-managed.yaml
+++ b/demo/cluster/aws-standalone-managed.yaml
@@ -21,7 +21,7 @@ spec:
     workersNumber: 3
     clusterLabels:
       k0rdent.mirantis.com/kof-storage-secrets: "true"
-  template: aws-standalone-cp-0-0-6
+  template: aws-standalone-cp-0-1-0
   serviceSpec:
     priority: 100
     services:

--- a/demo/cluster/aws-standalone-storage.yaml
+++ b/demo/cluster/aws-standalone-storage.yaml
@@ -22,7 +22,7 @@ spec:
     clusterLabels:
       k0rdent.mirantis.com/kof-storage-secrets: "true"
       k0rdent.mirantis.com/kof-aws-dns-secrets: "true"
-  template: aws-standalone-cp-0-0-6
+  template: aws-standalone-cp-0-1-0
   serviceSpec:
     priority: 100
     services:


### PR DESCRIPTION
Related to https://github.com/k0rdent/docs/pull/94 and https://github.com/k0rdent/docs/issues/92

# promxy

* **Before** the fix:
  * **[Official docs draft](https://github.com/k0rdent/docs/blob/2dce80fcbc28f794b264e69661139a417480e417/docs/kof.md#management-cluster)** of `kof-mothership` had to explain this "known issue":  
    "All pods should be `Running` except the `kof-mothership-promxy`:  
    it is waiting for `kof-mothership-promxy-config` secret  
    that will be auto-created and updated by `kof-mothership-promxy-operator`  
    on deployment of storage clusters below."

* **After** the fix:

```
make helm-push
make dev-ms-deploy-cloud

  REVISION: 4


kubectl get pod -A | grep promxy

  kof                  kof-mothership-promxy-5f8bbc8469-zbg74                         2/2     Running   0          4m51s
  kof                  kof-mothership-promxy-operator-5f9d95557d-b7wcr                1/1     Running   0          75m


kubectl get secret -n kof kof-mothership-promxy-config -o yaml

  apiVersion: v1
  data:
    config.yaml: ""
  kind: Secret
  metadata:
    annotations:
      meta.helm.sh/release-name: kof-mothership
      meta.helm.sh/release-namespace: kof
    creationTimestamp: "2025-01-31T14:47:48Z"
    labels:
      app.kubernetes.io/managed-by: Helm
    name: kof-mothership-promxy-config
    namespace: kof
    resourceVersion: "42738"
    uid: 2d7811e0-2986-4cfc-a4a0-f97ee3f7c142
  type: Opaque


make dev-storage-deploy-cloud

kubectl get secret -n kof kof-mothership-promxy-config -o yaml

  apiVersion: v1
  data:
    config.yaml: REDACTED,md5=be5fcab8a9549634ef5a756a52c2511b
  kind: Secret
  metadata:
    creationTimestamp: "2025-01-31T14:47:48Z"
    resourceVersion: "47805"
    uid: 2d7811e0-2986-4cfc-a4a0-f97ee3f7c142
    ...


make dev-ms-deploy-cloud

  REVISION: 5


kubectl get secret -n kof kof-mothership-promxy-config -o yaml

  apiVersion: v1
  data:
    config.yaml: REDACTED,md5=be5fcab8a9549634ef5a756a52c2511b
  kind: Secret
  metadata:
    creationTimestamp: "2025-01-31T14:47:48Z"
    resourceVersion: "78164"
    uid: 2d7811e0-2986-4cfc-a4a0-f97ee3f7c142
    ...
```

# kcm 0.1.0

* **Before** the fix:

```
make helm-push
make dev-ms-deploy-cloud
make dev-storage-deploy-cloud

  ServiceTemplate.k0rdent.mirantis.com "ingress-nginx-4-11-3" not found
```

* It was moved from kcm to k0rdent/catalog helm repo, which is now [provided by kcm](https://github.com/k0rdent/kcm/blob/98bd2b2b8b91f979354d80a677d037b005996b32/templates/provider/kcm-templates/Chart.yaml).

* **After** the fix:

```
kubectl get servicetemplate -A | grep ingress-nginx

  # None


make helm-push
make dev-ms-deploy-cloud
kubectl get servicetemplate -A | grep ingress-nginx

  kcm-system   ingress-nginx-4-11-3   true

make dev-storage-deploy-cloud
make dev-managed-deploy-cloud

  # OK
```
