### PR TITLE
Removed grafana plugins loader as it's now officially supported

### DIFF
--- a/charts/kof-mothership/templates/grafana/grafana.yaml
+++ b/charts/kof-mothership/templates/grafana/grafana.yaml
@@ -21,31 +21,6 @@ spec:
         spec:
           securityContext:
             fsGroup: 472
-          initContainers:
-            - name: "load-vm-ds-plugin"
-              image: "curlimages/curl:latest"
-              command: [ "/bin/sh" ]
-              workingDir: "/var/lib/grafana"
-              securityContext:
-                runAsUser: 472
-                runAsNonRoot: true
-                runAsGroup: 472
-              args:
-                - "-c"
-                - |
-                  set -ex
-                  mkdir -p /var/lib/grafana/plugins/
-                  ver=$(curl -s https://api.github.com/repos/VictoriaMetrics/victoriametrics-datasource/releases/latest | grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+' | head -1)
-                  curl -L https://github.com/VictoriaMetrics/victoriametrics-datasource/releases/download/$ver/victoriametrics-metrics-datasource-$ver.tar.gz -o /var/lib/grafana/plugins/vm-plugin.tar.gz
-                  vlver=$(curl -s https://api.github.com/repos/VictoriaMetrics/victorialogs-datasource/releases/latest | grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+' | head -1)
-                  curl -L https://github.com/VictoriaMetrics/victorialogs-datasource/releases/download/$vlver/victoriametrics-logs-datasource-$vlver.tar.gz -o /var/lib/grafana/plugins/vl-plugin.tar.gz
-                  tar -xf /var/lib/grafana/plugins/vl-plugin.tar.gz -C /var/lib/grafana/plugins/
-                  tar -xf /var/lib/grafana/plugins/vm-plugin.tar.gz -C /var/lib/grafana/plugins/
-                  rm /var/lib/grafana/plugins/vm-plugin.tar.gz
-                  rm /var/lib/grafana/plugins/vl-plugin.tar.gz
-              volumeMounts:
-                - name: grafana-data
-                  mountPath: /var/lib/grafana
           volumes:
             - name: grafana-data
               persistentVolumeClaim:
@@ -63,10 +38,6 @@ spec:
                     secretKeyRef:
                       key: GF_SECURITY_ADMIN_PASSWORD
                       name: {{ .Values.grafana.security.credentials_secret_name }}
-  config:
-    plugins:
-      allow_loading_unsigned_plugins: victoriametrics-datasource,victoriametrics-logs-datasource
-      
   ingress:
     metadata:
       annotations:

--- a/charts/kof-storage/templates/grafana/grafana.yaml
+++ b/charts/kof-storage/templates/grafana/grafana.yaml
@@ -27,30 +27,6 @@ spec:
         spec:
           securityContext:
             fsGroup: 472
-          initContainers:
-            - name: "load-vm-ds-plugin"
-              image: "curlimages/curl:latest"
-              command: [ "/bin/sh" ]
-              workingDir: "/var/lib/grafana"
-              securityContext:
-                runAsUser: 472
-                runAsNonRoot: true
-                runAsGroup: 472
-              args:
-                - "-c"
-                - |
-                  set -ex
-                  mkdir -p /var/lib/grafana/plugins/
-                  ver=$(curl -s https://api.github.com/repos/VictoriaMetrics/victoriametrics-datasource/releases/latest | grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+' | head -1)
-                  curl -L https://github.com/VictoriaMetrics/victoriametrics-datasource/releases/download/$ver/victoriametrics-metrics-datasource-$ver.tar.gz -o /var/lib/grafana/plugins/vm-plugin.tar.gz
-                  vlver=$(curl -s https://api.github.com/repos/VictoriaMetrics/victorialogs-datasource/releases/latest | grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+' | head -1)
-                  curl -L https://github.com/VictoriaMetrics/victorialogs-datasource/releases/download/$vlver/victoriametrics-logs-datasource-$vlver.tar.gz -o /var/lib/grafana/plugins/vl-plugin.tar.gz
-                  tar -xf /var/lib/grafana/plugins/vl-plugin.tar.gz -C /var/lib/grafana/plugins/
-                  tar -xf /var/lib/grafana/plugins/vm-plugin.tar.gz -C /var/lib/grafana/plugins/
-                  rm /var/lib/grafana/plugins/vm-plugin.tar.gz
-              volumeMounts:
-                - name: grafana-data
-                  mountPath: /var/lib/grafana
           volumes:
           - name: grafana-data
             persistentVolumeClaim:
@@ -68,9 +44,6 @@ spec:
                     secretKeyRef:
                       key: GF_SECURITY_ADMIN_PASSWORD
                       name: {{ .Values.grafana.security.credentials_secret_name }}
-  config:
-    plugins:
-      allow_loading_unsigned_plugins: victoriametrics-datasource,victoriametrics-logs-datasource
 {{- if .Values.grafana.ingress.enabled }}
   ingress:
     metadata:

--- a/docs/DEV.md
+++ b/docs/DEV.md
@@ -13,6 +13,12 @@ Install cli tools
 make cli-install
 ```
 
+Install helm charts into a local registry
+
+```bash
+make helm-push
+```
+
 ## Local deployment (without K0rdent)
 
 Install into local clusters these helm charts using Makefile
@@ -31,12 +37,6 @@ kubectl --namespace kof port-forward svc/grafana-vm-service 3000:3000
 ```
 
 ## Managed clusters deployment with K0rdent in AWS
-
-Install helm charts into a local registry
-
-```bash
-make helm-push
-```
 
 Define your DNS zone (automatically managed by external-dns)
 


### PR DESCRIPTION
1. Fix readme as all repos dependencies have to be updated before installing any chart.

2. Removed plugins loader due to officially supported: https://grafana.com/grafana/plugins/all-plugins/?search=victoria