### PR TITLE
Update service values as catalog charts are wrappers of upstream charts

### DIFF
--- a/demo/cluster/aws-eks-managed.yaml
+++ b/demo/cluster/aws-eks-managed.yaml
@@ -25,8 +25,9 @@ spec:
         namespace: kof
         template: cert-manager-1-16-2
         values: |
-          crds:
-            enabled: true
+          cert-manager:
+            crds:
+              enabled: true
       - template: kof-operators
         name: kof-operators
         namespace: kof

--- a/demo/cluster/aws-eks-storage.yaml
+++ b/demo/cluster/aws-eks-storage.yaml
@@ -29,8 +29,9 @@ spec:
         namespace: cert-manager
         template: cert-manager-1-16-2
         values: |
-          crds:
-            enabled: true
+          cert-manager:
+            crds:
+              enabled: true
       - name: kof-storage
         namespace: kof
         template: kof-storage

--- a/demo/cluster/aws-standalone-managed.yaml
+++ b/demo/cluster/aws-standalone-managed.yaml
@@ -29,8 +29,9 @@ spec:
         namespace: kof
         template: cert-manager-1-16-2
         values: |
-          crds:
-            enabled: true
+          cert-manager:
+            crds:
+              enabled: true
       - template: kof-operators
         name: kof-operators
         namespace: kof

--- a/demo/cluster/aws-standalone-storage.yaml
+++ b/demo/cluster/aws-standalone-storage.yaml
@@ -33,8 +33,9 @@ spec:
         namespace: cert-manager
         template: cert-manager-1-16-2
         values: |
-          crds:
-            enabled: true
+          cert-manager:
+            crds:
+              enabled: true
       - name: kof-storage
         namespace: kof
         template: kof-storage


### PR DESCRIPTION
## Before the fix

```
KUBECONFIG=dev/aws-standalone-managed-kubeconfig helm list -A --pending

  NAME        	NAMESPACE	REVISION	UPDATED                                	STATUS         	CHART              	APP VERSION
  cert-manager	kof      	17      	2025-02-04 13:41:25.528868884 +0000 UTC	pending-install	cert-manager-1.16.2	1.16.2     


KUBECONFIG=dev/aws-standalone-managed-kubeconfig kubectl logs -n kof cert-manager-startupapicheck-g992k

  I0204 13:49:04.423461       1 api.go:103] "Not ready" logger="cert-manager.startupapicheck.checkAPI"
  err="the cert-manager CRDs are not yet installed on the Kubernetes API server"
  underlyingError="error finding the scope of the object: failed to get restmapping:
  no matches for kind \"CertificateRequest\" in version \"cert-manager.io/v1\""


KUBECONFIG=dev/aws-standalone-managed-kubeconfig kubectl get certificaterequest -A

  error: the server doesn't have a resource type "certificaterequest"


kubectl get clusterdeployment -n kcm-system dryzhkov-aws-standalone-managed -o yaml

      services:
      - name: cert-manager
  namespace: kof
  template: cert-manager-1-16-2
  values: |
    crds:
      enabled: true


KUBECONFIG=dev/aws-standalone-managed-kubeconfig helm get values -n kof cert-manager

  USER-SUPPLIED VALUES:
  crds:
    enabled: true
```

## After the fix

```
KUBECONFIG=dev/aws-standalone-managed-kubeconfig helm list -A --pending
KUBECONFIG=dev/aws-standalone-storage-kubeconfig helm list -A --pending

  # None


KUBECONFIG=dev/aws-standalone-managed-kubeconfig helm list -A | grep cert
KUBECONFIG=dev/aws-standalone-storage-kubeconfig helm list -A | gre
p cert

  cert-manager                	kof        	1       	2025-02-04 15:15:35.082040513 +0000 UTC	deployed	cert-manager-1.16.2               	1.16.2 


KUBECONFIG=dev/aws-standalone-managed-kubeconfig kubectl get certificaterequest -A

  NAMESPACE   NAME                                                  APPROVED   DENIED   READY   ISSUER                                                   REQUESTER                                AGE
  kof         kof-operators-opentelemetry-operator-serving-cert-1   True                True    kof-operators-opentelemetry-operator-selfsigned-issuer   system:serviceaccount:kof:cert-manager   15m


KUBECONFIG=dev/aws-standalone-storage-kubeconfig kubectl get certificaterequest -A

  NAMESPACE   NAME                    APPROVED   DENIED   READY   ISSUER             REQUESTER                                         AGE
  kof         grafana-cluster-tls-1   True                True    letsencrypt-prod   system:serviceaccount:cert-manager:cert-manager   18m
  kof         vmauth-tls-1            True                True    letsencrypt-prod   system:serviceaccount:cert-manager:cert-manager   17m

```

* Sveltos in "storage" and "managed" clusters is all-green, OK.
