### PR TITLE
Fix node collector crash due to unhandled error

### DIFF
--- a/charts/kof-collectors/templates/opentelemetry/node-collector.yaml
+++ b/charts/kof-collectors/templates/opentelemetry/node-collector.yaml
@@ -50,6 +50,7 @@ spec:
           id: extract_metadata_from_filepath
           regex: '^.*\/(?P<namespace>[^_]+)_(?P<pod_name>[^_]+)_(?P<uid>[a-f0-9\-]{36})\/(?P<container_name>[^\._]+)\/(?P<restart_count>\d+)\.log$'
           parse_from: attributes["log.file.path"]
+          on_error: drop_quiet
         - type: move
           from: attributes.container_name
           to: resource["k8s.container.name"]
@@ -70,16 +71,14 @@ spec:
           id: extract_log_level
           regex: '(?i)(?P<log_level>(panic|fatal|crit|alert|emerg|err(?:or)?|warn(?:ing)?|info|debug|notice|trace|[EFDWI]\d{4}))'
           parse_from: body
+          on_error: send_quiet
 
         - type: regex_parser
           id: extract_short_letter
+          if: '("log_level" in attributes)'
           parse_from: attributes["log_level"]
           regex: '(?i)(?P<log_level>[EFDWI])\d{4}'
-
-        - type: move
-          id: unify_short_letter
-          from: attributes.short_letter
-          to: attributes.log_level
+          on_error: send_quiet
 
         - type: add
           if: '!("log_level" in attributes)'


### PR DESCRIPTION
We cannot guarantee that all data processed is correct, so we have to drop on errors