### PR TITLE
Use-or-create service templates kof depends on

### DIFF
--- a/charts/kof-mothership/templates/k0rdent/catalog/_helpers.tpl
+++ b/charts/kof-mothership/templates/k0rdent/catalog/_helpers.tpl
@@ -1,0 +1,25 @@
+{{- define "catalog.serviceTemplate" }}
+  {{- if .Values.kcm.installTemplates }}
+    {{- $template_name := printf "%s-%s" .templateChart (.templateVersion | replace "." "-") }}
+    {{- $template := lookup "k0rdent.mirantis.com/v1alpha1" "ServiceTemplate" .Values.kcm.namespace $template_name }}
+    {{- if (not $template) }}
+---
+apiVersion: k0rdent.mirantis.com/v1alpha1
+kind: ServiceTemplate
+metadata:
+  name: {{ $template_name }}
+  namespace: {{ .Values.kcm.namespace }}
+  annotations:
+    helm.sh/resource-policy: keep
+spec:
+  helm:
+    chartSpec:
+      chart: {{ .templateChart }}
+      version: {{ .templateVersion }}
+      interval: 10m0s
+      sourceRef:
+        kind: HelmRepository
+        name: k0rdent-catalog
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/kof-mothership/templates/k0rdent/catalog/cert-manager.yaml
+++ b/charts/kof-mothership/templates/k0rdent/catalog/cert-manager.yaml
@@ -1,19 +1,5 @@
-{{- if .Values.kcm.installTemplates }}
-# https://github.com/k0rdent/catalog/blob/main/charts/cert-manager/cert-manager-service-template-1.16.2/templates/service-template.yaml
-apiVersion: k0rdent.mirantis.com/v1alpha1
-kind: ServiceTemplate
-metadata:
-  name: cert-manager-1-16-2
-  namespace: {{ .Values.kcm.namespace }}
-  annotations:
-    helm.sh/resource-policy: keep
-spec:
-  helm:
-    chartSpec:
-      chart: cert-manager
-      version: 1.16.2
-      interval: 10m0s
-      sourceRef:
-        kind: HelmRepository
-        name: k0rdent-catalog
-{{- end }}
+{{- include "catalog.serviceTemplate" (dict
+  "templateChart" "cert-manager"
+  "templateVersion" "1.16.2"
+  "Values" .Values
+) }}

--- a/charts/kof-mothership/templates/k0rdent/catalog/ingress-nginx.yaml
+++ b/charts/kof-mothership/templates/k0rdent/catalog/ingress-nginx.yaml
@@ -1,19 +1,5 @@
-{{- if .Values.kcm.installTemplates }}
-# https://github.com/k0rdent/catalog/blob/main/charts/ingress-nginx/ingress-nginx-service-template-4.11.3/templates/service-template.yaml
-apiVersion: k0rdent.mirantis.com/v1alpha1
-kind: ServiceTemplate
-metadata:
-  name: ingress-nginx-4-11-3
-  namespace: {{ .Values.kcm.namespace }}
-  annotations:
-    helm.sh/resource-policy: keep
-spec:
-  helm:
-    chartSpec:
-      chart: ingress-nginx
-      version: 4.11.3
-      interval: 10m0s
-      sourceRef:
-        kind: HelmRepository
-        name: k0rdent-catalog
-{{- end }}
+{{- include "catalog.serviceTemplate" (dict
+  "templateChart" "ingress-nginx"
+  "templateVersion" "4.11.3"
+  "Values" .Values
+) }}


### PR DESCRIPTION
Part of https://github.com/k0rdent/kof/issues/60

## Summary

* We had our own service templates for `cert-manager` and `ingress-nginx`
  because at some point they were moved from `kcm` to `k0rdent/catalog`.

* Now they're installed with `kcm` again, so `kof-mothership` installation fails.

## Before the fix

```
helm install -f mothership-values.yaml -n kof kof-mothership \
    oci://ghcr.io/k0rdent/kof/charts/kof-mothership --version 0.1.0
Pulled: ghcr.io/k0rdent/kof/charts/kof-mothership:0.1.0
Digest: sha256:35baa81751027d1a6fd38ce229d04b220e1999a824021a5672cf72c252e203f4

Error: INSTALLATION FAILED: Unable to continue with install:
ServiceTemplate "cert-manager-1-16-2" in namespace "kcm-system" exists
and cannot be imported into the current release:
invalid ownership metadata; annotation validation error:
key "meta.helm.sh/release-name" must equal "kof-mothership": current value is "kcm-0-1-0-tpl";
annotation validation error:
key "meta.helm.sh/release-namespace" must equal "kof": current value is "kcm-system"
```

## After the fix

* Will test end-to-end after merge and release.
* Local smoke-test via `make helm-push` and `make dev-ms-deploy-cloud` succeeds.
