### PR TITLE
Using `.global.storageClass` in the mothership Grafana

### DIFF
--- a/charts/kof-storage/templates/grafana/grafana.yaml
+++ b/charts/kof-storage/templates/grafana/grafana.yaml
@@ -15,6 +15,7 @@ spec:
       resources:
         requests:
           storage: 200Mi
+      storageClassName: {{ .Values.global.storageClass }}
   deployment:
     spec:
       template:


### PR DESCRIPTION
Part of https://github.com/k0rdent/kof/issues/81

Related to https://github.com/k0rdent/kof/pull/74 and https://github.com/k0rdent/docs/pull/73