### PR TITLE
Fixed uninstallation, now VM objects are deleted

### DIFF
--- a/charts/kof-mothership/values.yaml
+++ b/charts/kof-mothership/values.yaml
@@ -68,6 +68,8 @@ victoria-metrics-operator:
   enabled: true
   crds:
     plain: true
+    cleanup:
+      enabled: true
 cluster-api-visualizer:
   enabled: true
 sveltos-dashboard:

--- a/charts/kof-storage/values.yaml
+++ b/charts/kof-storage/values.yaml
@@ -73,6 +73,8 @@ victoria-metrics-operator:
   enabled: true
   crds:
     plain: true
+    cleanup:
+      enabled: true
 victoria-logs-single:
   enabled: true
   server:


### PR DESCRIPTION
* Closes https://github.com/k0rdent/kof/issues/83
* Related to https://github.com/k0rdent/docs/pull/73
* Based on https://github.com/VictoriaMetrics/helm-charts/blob/ab4b3d4b5c3286f2c1484acc19c2366a1bc4e6e6/charts/victoria-metrics-operator/values.yaml#L39-L41
* Tests:
```
helm uninstall --wait --cascade foreground -n kof kof-mothership

  These resources were kept due to the resource policy:
  [ServiceTemplate] cert-manager-1-16-2
  [ServiceTemplate] ingress-nginx-4-11-3

  release "kof-mothership" uninstalled

kubectl get job -n kof

  NAME                                                    STATUS     COMPLETIONS   DURATION   AGE
  kof-mothership-victoria-metrics-operator-cleanup-hook   Complete   1/1           25s        5m43s

kubectl get pods -n kof --selector=job-name=kof-mothership-victoria-metrics-operator-cleanup-hook

  NAME                                                          READY   STATUS      RESTARTS   AGE
  kof-mothership-victoria-metrics-operator-cleanup-hook-wptd6   0/1     Completed   0          3m43s

kubectl logs -n kof kof-mothership-victoria-metrics-operator-cleanup-hook-wptd6

  vmalert.operator.victoriametrics.com "cluster" deleted
  vmalertmanager.operator.victoriametrics.com "cluster" deleted
  vmcluster.operator.victoriametrics.com "cluster" deleted
  vmrule.operator.victoriametrics.com "etcd" deleted
  vmrule.operator.victoriametrics.com "general.rules" deleted
  vmrule.operator.victoriametrics.com "k8s.rules.containercpulimits" deleted
  vmrule.operator.victoriametrics.com "k8s.rules.containercpurequests" deleted
  vmrule.operator.victoriametrics.com "k8s.rules.containercpuusagesecondstotal" deleted
  vmrule.operator.victoriametrics.com "k8s.rules.containermemorycache" deleted
  vmrule.operator.victoriametrics.com "k8s.rules.containermemorylimits" deleted
  vmrule.operator.victoriametrics.com "k8s.rules.containermemoryrequests" deleted
  vmrule.operator.victoriametrics.com "k8s.rules.containermemoryrss" deleted
  vmrule.operator.victoriametrics.com "k8s.rules.containermemoryswap" deleted
  vmrule.operator.victoriametrics.com "k8s.rules.containermemoryworkingsetbytes" deleted
  vmrule.operator.victoriametrics.com "k8s.rules.podowner" deleted
  vmrule.operator.victoriametrics.com "kube-prometheus-general.rules" deleted
  vmrule.operator.victoriametrics.com "kube-prometheus-node-recording.rules" deleted
  vmrule.operator.victoriametrics.com "kube-state-metrics" deleted
  vmrule.operator.victoriametrics.com "kubelet.rules" deleted
  vmrule.operator.victoriametrics.com "kubernetes-apps" deleted
  vmrule.operator.victoriametrics.com "kubernetes-resources" deleted
  vmrule.operator.victoriametrics.com "kubernetes-storage" deleted
  vmrule.operator.victoriametrics.com "kubernetes-system" deleted
  vmrule.operator.victoriametrics.com "kubernetes-system-apiserver" deleted
  vmrule.operator.victoriametrics.com "kubernetes-system-kubelet" deleted
  vmrule.operator.victoriametrics.com "node-exporter" deleted
  vmrule.operator.victoriametrics.com "node-exporter.rules" deleted
  vmrule.operator.victoriametrics.com "node-network" deleted
  vmrule.operator.victoriametrics.com "node.rules" deleted

helm uninstall --wait --cascade foreground -n kof kof-operators

  release "kof-operators" uninstalled

kubectl delete namespace kof --wait --cascade=foreground

  namespace "kof" deleted
```
