### PR TITLE
helm-docs for kof-mothership values

### DIFF
--- a/.github/workflows/helm-docs.yaml
+++ b/.github/workflows/helm-docs.yaml
@@ -1,0 +1,14 @@
+name: Generate Helm documentation
+on:
+  - pull_request
+jobs:
+  generate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+      - name: Run helm-docs
+        uses: losisin/helm-docs-github-action@v1
+        with:
+          git-push: true

--- a/.github/workflows/helm-docs.yaml
+++ b/.github/workflows/helm-docs.yaml
@@ -12,4 +12,6 @@ jobs:
       - name: Run helm-docs
         uses: losisin/helm-docs-github-action@v1
         with:
+          chart-search-root: charts/kof-mothership
+          template-files: charts/kof-mothership/README.md.gotmpl
           git-push: true

--- a/.github/workflows/helm-docs.yaml
+++ b/.github/workflows/helm-docs.yaml
@@ -4,8 +4,7 @@ on:
 jobs:
   generate:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
+    # Don't use `permissions: contents: write` as it applies to base repo only.
     steps:
       - uses: actions/checkout@v4
         with:
@@ -16,4 +15,8 @@ jobs:
         with:
           chart-search-root: charts/kof-mothership
           template-files: charts/kof-mothership/README.md.gotmpl
-          git-push: true
+          fail-on-diff: true
+          # Don't use `git-push: true` because `pull_request` event is sent to the base repo only,
+          # and its token cannot push to the forked repo branch.
+          # A workaround with repo-scoped `Personal access tokens` of ALL contributors
+          # stored as secrets in the base repo and mapped to `head.repo` is an overkill.

--- a/.github/workflows/helm-docs.yaml
+++ b/.github/workflows/helm-docs.yaml
@@ -4,6 +4,8 @@ on:
 jobs:
   generate:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/helm-docs.yaml
+++ b/.github/workflows/helm-docs.yaml
@@ -7,6 +7,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.ref }}
       - name: Run helm-docs
         uses: losisin/helm-docs-github-action@v1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,7 @@
+# `pre-commit` is optional!
+# If you don't want to review the diff locally,
+# `.github/workflows/helm-docs.yaml` can add a commit to your PR.
+#
 # Usage:
 #   python3 -m pip install pre-commit
 #   pre-commit install --install-hooks

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,19 @@
+# Usage:
+#   python3 -m pip install pre-commit
+#   pre-commit install
+#   pre-commit install-hooks
+#   git commit
+#
+# If it fails because `files were modified by this hook` then:
+# * Review and `git add` the changes.
+# * `git commit` again, it should pass.
+
+repos:
+  - repo: https://github.com/norwoodj/helm-docs
+    rev:  v1.14.2
+    hooks:
+      - id: helm-docs-container
+        entry: jnorwood/helm-docs:v1.14.2
+        args:
+          - -c=charts/kof-mothership
+          - -t=charts/kof-mothership/README.md.gotmpl

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,6 @@
 # Usage:
 #   python3 -m pip install pre-commit
-#   pre-commit install
-#   pre-commit install-hooks
+#   pre-commit install --install-hooks
 #   git commit
 #
 # If it fails because `files were modified by this hook` then:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,8 @@
-# `pre-commit` is optional!
-# If you don't want to review the diff locally,
-# `.github/workflows/helm-docs.yaml` can add a commit to your PR.
+# `pre-commit` is optional.
+# You can just install `helm-docs` and run it manually.
+#
+# See comments in `.github/workflows/helm-docs.yaml`
+# re limitations of pushing to forked repo, so it just fails on diff.
 #
 # Usage:
 #   python3 -m pip install pre-commit

--- a/charts/kof-mothership/README.md
+++ b/charts/kof-mothership/README.md
@@ -18,7 +18,7 @@ A Helm chart that deploys Grafana, Promxy, and VictoriaMetrics.
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | cluster-api-visualizer | object | `{"enabled":true}` | [Docs](https://github.com/Jont828/cluster-api-visualizer/tree/main/helm#configurable-values) |
-| global<br>.clusterLabel | string | `"clusterName"` | Name of the label identifying where the data point comes from. |
+| global<br>.clusterLabel | string | `"clusterName"` | Name of the label identifying where the time series data points come from. |
 | global<br>.clusterName | string | `"mothership"` | Value of this label. |
 | global<br>.random_password_length | int | `12` | Length of the auto-generated passwords for Grafana and VictoriaMetrics. |
 | global<br>.random_username_length | int | `8` | Length of the auto-generated usernames for Grafana and VictoriaMetrics. |

--- a/charts/kof-mothership/README.md
+++ b/charts/kof-mothership/README.md
@@ -1,0 +1,74 @@
+# kof-mothership
+
+![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-informational?style=flat-square) ![AppVersion: 0.1.1](https://img.shields.io/badge/AppVersion-0.1.1-informational?style=flat-square)
+
+A Helm chart that deploys Grafana, Promxy, and VictoriaMetrics.
+
+## Requirements
+
+| Repository | Name | Version |
+|------------|------|---------|
+| https://projectsveltos.github.io/dashboard-helm-chart | sveltos-dashboard | 0.44.* |
+| https://victoriametrics.github.io/helm-charts/ | victoria-metrics-operator | 0.36.* |
+| oci://ghcr.io/grafana/helm-charts | grafana-operator | v5.13.0 |
+| oci://ghcr.io/k0rdent/cluster-api-visualizer/charts | cluster-api-visualizer | 1.4.0 |
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| cluster-api-visualizer | object | `{"enabled":true}` | [Docs](https://github.com/Jont828/cluster-api-visualizer/tree/main/helm#configurable-values) |
+| global<br>.clusterLabel | string | `"clusterName"` | Name of the label identifying where the data point comes from.? |
+| global<br>.clusterName | string | `"mothership"` | Value of this label. |
+| global<br>.random_password_length | int | `12` | Length of the auto-generated passwords for Grafana and VictoriaMetrics. |
+| global<br>.random_username_length | int | `8` | Length of the auto-generated usernames for Grafana and VictoriaMetrics. |
+| global<br>.storageClass | string | `""` | Name of the storage class used by Grafana, `vmstorage` (long-term storage of raw time series data), and `vmselect` (cache of query results). Keep it unset or empty to leverage the advantages of [default storage class](https://kubernetes.io/docs/concepts/storage/storage-classes/#default-storageclass). |
+| grafana<br>.alerts<br>.enabled | bool | `true` | Creates [VMRule](https://docs.victoriametrics.com/operator/resources/vmrule/)-s based on [files/rules/](files/rules/). |
+| grafana<br>.enabled | bool | `true` | Enables Grafana. |
+| grafana<br>.ingress<br>.enabled | bool | `false` | Enables an ingress to access Grafana without port-forwarding. |
+| grafana<br>.ingress<br>.host | string | `"grafana.example.net"` | Domain name Grafana will be available at. |
+| grafana<br>.logSources | list | `[]` | Old option to add `GrafanaDatasource`-s. Please add them as in [the docs](https://docs.k0rdent.io/head/admin-kof/#regional-cluster) instead. |
+| grafana<br>.security<br>.create_secret | bool | `true` | Enables auto-creation of Grafana username/password. |
+| grafana<br>.security<br>.credentials_secret_name | string | `"grafana-admin-credentials"` | Name of secret for Grafana username/password. |
+| grafana<br>.storage<br>.size | string | `"200Mi"` | Size of storage for Grafana. |
+| grafana<br>.version | string | `"10.4.7"` | Version of Grafana to use. |
+| kcm<br>.installTemplates | bool | `false` | Auto-installs `ServiceTemplate`-s like `cert-manager` and `kof-storage` to reference them from Regional and Child `ClusterDeployment`-s. |
+| kcm<br>.kof<br>.charts | object | `{"collectors":{"version":"0.1.1"},`<br>`"operators":{"version":"0.1.1"},`<br>`"storage":{"version":"0.1.1"}}` | Versions of `kof-*` helm charts and related `ServiceTemplate`-s auto-installed by `kcm.installTemplates`. |
+| kcm<br>.kof<br>.clusterProfiles | object | `{"kof-storage-secrets":{"create_secrets":true,`<br>`"matchLabels":{"k0rdent.mirantis.com/kof-storage-secrets":"true"},`<br>`"secrets":["storage-vmuser-credentials"]}}` | Names of secrets auto-distributed to clusters with matching labels. |
+| kcm<br>.kof<br>.repo | object | `{"insecure":false,`<br>`"name":"kof",`<br>`"type":"oci",`<br>`"url":"oci://ghcr.io/k0rdent/kof/charts"}` | Repo of `kof-*` helm charts. |
+| kcm<br>.namespace | string | `"kcm-system"` | K8s namespace created on installation of k0rdent/kcm. |
+| kcm<br>.serviceMonitor<br>.enabled | bool | `true` | Enables the "KCM Controller Manager" Grafana dashboard. |
+| promxy<br>.configmapReload<br>.resources<br>.limits | object | `{"cpu":0.02,`<br>`"memory":"20Mi"}` | Maximum resources available for the `promxy-server-configmap-reload` container in the pods of `kof-mothership-promxy` deployment. |
+| promxy<br>.configmapReload<br>.resources<br>.requests | object | `{"cpu":0.02,`<br>`"memory":"20Mi"}` | Minimum resources required for the `promxy-server-configmap-reload` container in the pods of `kof-mothership-promxy` deployment. |
+| promxy<br>.enabled | bool | `true` | Enables `kof-mothership-promxy` deployment. |
+| promxy<br>.extraArgs | object | `{"log-level":"info"}` | Extra command line arguments passed to the `/bin/promxy`. |
+| promxy<br>.image | object | `{"pullPolicy":"IfNotPresent",`<br>`"repository":"quay.io/jacksontj/promxy",`<br>`"tag":"latest"}` | Promxy image to use. |
+| promxy<br>.ingress | object | `{"annotations":{},`<br>`"enabled":false,`<br>`"extraLabels":{},`<br>`"hosts":["example.com"],`<br>`"ingressClassName":"nginx",`<br>`"path":"/",`<br>`"pathType":"Prefix",`<br>`"tls":[]}` | Config of `kof-mothership-promxy` [Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/). |
+| promxy<br>.operator<br>.image | object | `{"pullPolicy":"IfNotPresent",`<br>`"repository":"ghcr.io/k0rdent/kof/promxy-operator-controller",`<br>`"tag":"latest"}` | Image of the promxy operator. |
+| promxy<br>.operator<br>.rbac<br>.create | bool | `true` | Creates the `kof-mothership-promxy-operator` cluster role and binds it to the service account of promxy. |
+| promxy<br>.operator<br>.resources<br>.limits | object | `{"cpu":"100m",`<br>`"memory":"64Mi"}` | Maximum resources available for promxy operator. |
+| promxy<br>.operator<br>.resources<br>.requests | object | `{"cpu":"100m",`<br>`"memory":"64Mi"}` | Minimum resources required for promxy operator. |
+| promxy<br>.replicaCount | int | `1` | Number of replicated promxy pods. |
+| promxy<br>.resources<br>.limits | object | `{"cpu":"100m",`<br>`"memory":"128Mi"}` | Maximum resources available for the `promxy` container in the pods of `kof-mothership-promxy` deployment. |
+| promxy<br>.resources<br>.requests | object | `{"cpu":"100m",`<br>`"memory":"128Mi"}` | Minimum resources required for the `promxy` container in the pods of `kof-mothership-promxy` deployment. |
+| promxy<br>.service | object | `{"annotations":{},`<br>`"clusterIP":"",`<br>`"enabled":true,`<br>`"externalIPs":[],`<br>`"extraLabels":{},`<br>`"loadBalancerIP":"",`<br>`"loadBalancerSourceRanges":[],`<br>`"servicePort":8082,`<br>`"type":"ClusterIP"}` | Config of `kof-mothership-promxy` [Service](https://kubernetes.io/docs/concepts/services-networking/service/). |
+| promxy<br>.serviceAccount<br>.annotations | object | `{}` | Annotations for the service account of promxy. |
+| promxy<br>.serviceAccount<br>.create | bool | `true` | Creates a service account for promxy. |
+| promxy<br>.serviceAccount<br>.name | string | `nil` | Name for the service account of promxy. If not set, it is generated as `kof-mothership-promxy`. |
+| sveltos-dashboard | object | `{"enabled":true}` | [Docs](https://projectsveltos.github.io/dashboard-helm-chart/#values) |
+| sveltos<br>.grafanaDashboard | bool | `true` | Adds Sveltos dashboard to Grafana. |
+| sveltos<br>.serviceMonitors | bool | `true` | Creates `ServiceMonitor`-s for Sveltos `sc-manager` and `addon-controller`. |
+| victoria-metrics-operator | object | `{"crds":{"cleanup":{"enabled":true},`<br>`"plain":true},`<br>`"enabled":true}` | [Docs](https://github.com/VictoriaMetrics/helm-charts/tree/master/charts/victoria-metrics-operator#parameters) |
+| victoriametrics<br>.enabled | bool | `true` | Enables VictoriaMetrics. |
+| victoriametrics<br>.vmalert<br>.enabled | bool | `true` | Enables VictoriaMetrics alerts. |
+| victoriametrics<br>.vmalert<br>.remoteRead | string | `""` | `url` in [VMAlertRemoteReadSpec](https://docs.victoriametrics.com/operator/api/#vmalertremotereadspec). It is auto-configured by kof if you keep it empty. |
+| victoriametrics<br>.vmalert<br>.vmalertmanager<br>.config | string | `""` | `configRawYaml` of [VMAlertmanagerSpec](https://docs.victoriametrics.com/operator/api/#vmalertmanagerspec). Check examples [here](https://github.com/k0rdent/kof/blob/main/docs/alerts.md). |
+| victoriametrics<br>.vmcluster<br>.enabled | bool | `true` | Enables high-available and fault-tolerant version of VictoriaMetrics database. |
+| victoriametrics<br>.vmcluster<br>.replicaCount | int | `1` | The number of replicas for components of cluster. |
+| victoriametrics<br>.vmcluster<br>.replicationFactor | int | `1` | The number of replicas for each metric. |
+| victoriametrics<br>.vmcluster<br>.retentionPeriod | string | `"1"` | Days to retain the data. |
+| victoriametrics<br>.vmcluster<br>.vmselect<br>.storage<br>.size | string | `"2Gi"` | Query results cache size. |
+| victoriametrics<br>.vmcluster<br>.vmstorage<br>.storage<br>.size | string | `"10Gi"` | Long-term storage size of raw time series data. |
+
+----------------------------------------------
+Autogenerated from chart metadata using [helm-docs v1.14.2](https://github.com/norwoodj/helm-docs/releases/v1.14.2)

--- a/charts/kof-mothership/README.md
+++ b/charts/kof-mothership/README.md
@@ -18,7 +18,7 @@ A Helm chart that deploys Grafana, Promxy, and VictoriaMetrics.
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | cluster-api-visualizer | object | `{"enabled":true}` | [Docs](https://github.com/Jont828/cluster-api-visualizer/tree/main/helm#configurable-values) |
-| global<br>.clusterLabel | string | `"clusterName"` | Name of the label identifying where the data point comes from.? |
+| global<br>.clusterLabel | string | `"clusterName"` | Name of the label identifying where the data point comes from. |
 | global<br>.clusterName | string | `"mothership"` | Value of this label. |
 | global<br>.random_password_length | int | `12` | Length of the auto-generated passwords for Grafana and VictoriaMetrics. |
 | global<br>.random_username_length | int | `8` | Length of the auto-generated usernames for Grafana and VictoriaMetrics. |

--- a/charts/kof-mothership/README.md
+++ b/charts/kof-mothership/README.md
@@ -41,7 +41,7 @@ A Helm chart that deploys Grafana, Promxy, and VictoriaMetrics.
 | promxy<br>.configmapReload<br>.resources<br>.limits | object | `{"cpu":0.02,`<br>`"memory":"20Mi"}` | Maximum resources available for the `promxy-server-configmap-reload` container in the pods of `kof-mothership-promxy` deployment. |
 | promxy<br>.configmapReload<br>.resources<br>.requests | object | `{"cpu":0.02,`<br>`"memory":"20Mi"}` | Minimum resources required for the `promxy-server-configmap-reload` container in the pods of `kof-mothership-promxy` deployment. |
 | promxy<br>.enabled | bool | `true` | Enables `kof-mothership-promxy` deployment. |
-| promxy<br>.extraArgs | object | `{"log-level":"info"}` | Extra command line arguments passed to the `/bin/promxy`. |
+| promxy<br>.extraArgs | object | `{"log-level":"info"}` | Extra command line arguments passed as `--key=value` to the `/bin/promxy`. |
 | promxy<br>.image | object | `{"pullPolicy":"IfNotPresent",`<br>`"repository":"quay.io/jacksontj/promxy",`<br>`"tag":"latest"}` | Promxy image to use. |
 | promxy<br>.ingress | object | `{"annotations":{},`<br>`"enabled":false,`<br>`"extraLabels":{},`<br>`"hosts":["example.com"],`<br>`"ingressClassName":"nginx",`<br>`"path":"/",`<br>`"pathType":"Prefix",`<br>`"tls":[]}` | Config of `kof-mothership-promxy` [Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/). |
 | promxy<br>.operator<br>.image | object | `{"pullPolicy":"IfNotPresent",`<br>`"repository":"ghcr.io/k0rdent/kof/promxy-operator-controller",`<br>`"tag":"latest"}` | Image of the promxy operator. |

--- a/charts/kof-mothership/README.md.gotmpl
+++ b/charts/kof-mothership/README.md.gotmpl
@@ -1,0 +1,38 @@
+{{- /*
+  Copy of `defaultDocumentationTemplate` from
+  https://github.com/norwoodj/helm-docs/blob/master/pkg/document/template.go
+  with `chart.valuesTable` redefined to avoid horizontal scrolling.
+*/}}
+
+{{- define "chart.valuesTable" }}
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+  {{- range .Values }}
+    {{- "\n| "}}{{ .Key | replace "." "<br>." }}
+    {{- " | "}}{{ .Type }}
+    {{- " | "}}{{ (default .Default .AutoDefault) | replace "," ",`<br>`" }}
+    {{- " | "}}{{ default .Description .AutoDescription }}
+    {{- " | "}}
+  {{- end }}
+{{- end }}
+
+{{- template "chart.header" . }}
+{{ template "chart.deprecationWarning" . }}
+
+{{ template "chart.badgesSection" . }}
+
+{{ template "chart.description" . }}
+
+{{ template "chart.homepageLine" . }}
+
+{{ template "chart.maintainersSection" . }}
+
+{{ template "chart.sourcesSection" . }}
+
+{{ template "chart.requirementsSection" . }}
+
+{{ template "chart.valuesSection" . }}
+
+{{- if not .SkipVersionFooter }}
+{{ template "helm-docs.versionFooter" . }}
+{{- end }}

--- a/charts/kof-mothership/templates/grafana/grafana.yaml
+++ b/charts/kof-mothership/templates/grafana/grafana.yaml
@@ -44,6 +44,7 @@ spec:
                 - name: GF_INSTALL_PLUGINS
                   value: "victoriametrics-logs-datasource,victoriametrics-metrics-datasource"
 
+  {{- if .Values.grafana.ingress.enabled }}
   ingress:
     metadata:
       annotations:
@@ -66,4 +67,5 @@ spec:
         - hosts:
             - {{ .Values.grafana.ingress.host | quote }}
           secretName: grafana-cluster-tls
+  {{- end }}
 {{- end }}

--- a/charts/kof-mothership/templates/promxy/_helpers.tpl
+++ b/charts/kof-mothership/templates/promxy/_helpers.tpl
@@ -10,6 +10,8 @@ Expand the name of the chart.
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 If release name contains chart name it will be used as a full name.
+NOTE that despite the naming `promxy.fullname` it does not include the "promxy" string,
+it is just "kof-mothership" at the moment.
 */}}
 {{- define "promxy.fullname" -}}
 {{- if .Values.promxy.fullnameOverride -}}

--- a/charts/kof-mothership/templates/promxy/role.yaml
+++ b/charts/kof-mothership/templates/promxy/role.yaml
@@ -3,7 +3,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ include "promxy.fullname" . }}-operator
+  name: {{ include "promxy.fullname" . }}-promxy-operator
 rules:
 - apiGroups:
   - ""

--- a/charts/kof-mothership/templates/promxy/role_binding.yaml
+++ b/charts/kof-mothership/templates/promxy/role_binding.yaml
@@ -4,11 +4,11 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app.kubernetes.io/name: promxy-operator
-  name: {{ include "promxy.fullname" . }}-operator
+  name: {{ include "promxy.fullname" . }}-promxy-operator
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ include "promxy.fullname" . }}-operator
+  name: {{ include "promxy.fullname" . }}-promxy-operator
 subjects:
 - kind: ServiceAccount
   name: {{ include "promxy.serviceAccountName" . }}

--- a/charts/kof-mothership/values.yaml
+++ b/charts/kof-mothership/values.yaml
@@ -1,23 +1,44 @@
 global:
+  # -- Name of the label identifying where the data point comes from.
   clusterLabel: clusterName
+  # -- Value of this label.
   clusterName: mothership
+
+  # -- Name of the storage class used by Grafana,
+  # `vmstorage` (long-term storage of raw time series data),
+  # and `vmselect` (cache of query results).
+  # Keep it unset or empty to leverage the advantages of
+  # [default storage class](https://kubernetes.io/docs/concepts/storage/storage-classes/#default-storageclass).
+  storageClass: ""
+
+  # -- Length of the auto-generated usernames for Grafana and VictoriaMetrics.
   random_username_length: 8
+
+  # -- Length of the auto-generated passwords for Grafana and VictoriaMetrics.
   random_password_length: 12
 
-  # https://kubernetes.io/docs/concepts/storage/storage-classes/#default-storageclass
-  # storageClass: ebs-csi-default-sc
-
 kcm:
-  installTemplates: false
-  serviceMonitor:
-    enabled: true
+  # -- K8s namespace created on installation of k0rdent/kcm.
   namespace: kcm-system
+
+  # -- Auto-installs `ServiceTemplate`-s like `cert-manager` and `kof-storage`
+  # to reference them from Regional and Child `ClusterDeployment`-s.
+  installTemplates: false
+
+  serviceMonitor:
+    # -- Enables the "KCM Controller Manager" Grafana dashboard.
+    enabled: true
+
   kof:
+    # -- Repo of `kof-*` helm charts.
     repo:
       name: kof
       type: oci
       url: oci://ghcr.io/k0rdent/kof/charts
       insecure: false
+
+    # -- Versions of `kof-*` helm charts and related `ServiceTemplate`-s
+    # auto-installed by `kcm.installTemplates`.
     charts:
       operators:
         version: "0.1.1"
@@ -25,6 +46,8 @@ kcm:
         version: "0.1.1"
       storage:
         version: "0.1.1"
+
+    # -- Names of secrets auto-distributed to clusters with matching labels.
     clusterProfiles:
       kof-storage-secrets:
         matchLabels:
@@ -32,80 +55,157 @@ kcm:
         create_secrets: true
         secrets:
           - storage-vmuser-credentials
+
 victoriametrics:
+  # -- Enables VictoriaMetrics.
   enabled: true
+
   vmcluster:
+    # -- Enables high-available and fault-tolerant version of VictoriaMetrics database.
     enabled: true
+
+    # -- The number of replicas for each metric.
     replicationFactor: 1
+
+    # -- The number of replicas for components of cluster.
     replicaCount: 1
-    retentionPeriod: "1" # retention period in days
+
+    # -- Days to retain the data.
+    retentionPeriod: "1"
+
     vmselect:
       storage:
+        # -- Query results cache size.
         size: 2Gi
+
     vmstorage:
       storage:
+        # -- Long-term storage size of raw time series data.
         size: 10Gi
+
   vmalert:
+    # -- Enables VictoriaMetrics alerts.
     enabled: true
+
+    # -- `url` in [VMAlertRemoteReadSpec](https://docs.victoriametrics.com/operator/api/#vmalertremotereadspec).
+    # It is auto-configured by kof if you keep it empty.
     remoteRead: ""
+
     vmalertmanager:
-      config: |
+      # -- `configRawYaml` of [VMAlertmanagerSpec](https://docs.victoriametrics.com/operator/api/#vmalertmanagerspec).
+      # Check examples [here](https://github.com/k0rdent/kof/blob/main/docs/alerts.md).
+      config: ""
+
 grafana:
+  # -- Enables Grafana.
   enabled: true
+
   ingress:
+    # -- Enables an ingress to access Grafana without port-forwarding.
     enabled: false
+
+    # -- Domain name Grafana will be available at.
     host: grafana.example.net
+
   alerts:
+    # -- Creates [VMRule](https://docs.victoriametrics.com/operator/resources/vmrule/)-s
+    # based on [files/rules/](files/rules/).
     enabled: true
+
+  # -- Old option to add `GrafanaDatasource`-s.
+  # Please add them as in [the docs](https://docs.k0rdent.io/head/admin-kof/#regional-cluster) instead.
   logSources: []
+
   security:
+    # -- Name of secret for Grafana username/password.
     credentials_secret_name: grafana-admin-credentials
+
+    # -- Enables auto-creation of Grafana username/password.
     create_secret: true
+
   storage:
+    # -- Size of storage for Grafana.
     size: 200Mi
+
+  # -- Version of Grafana to use.
   version: "10.4.7"
+
+# -- [Docs](https://github.com/VictoriaMetrics/helm-charts/tree/master/charts/victoria-metrics-operator#parameters)
 victoria-metrics-operator:
   enabled: true
   crds:
     plain: true
     cleanup:
       enabled: true
+
+# -- [Docs](https://github.com/Jont828/cluster-api-visualizer/tree/main/helm#configurable-values)
 cluster-api-visualizer:
   enabled: true
+
+# -- [Docs](https://projectsveltos.github.io/dashboard-helm-chart/#values)
 sveltos-dashboard:
   enabled: true
+
 sveltos:
+  # -- Creates `ServiceMonitor`-s for Sveltos `sc-manager` and `addon-controller`.
   serviceMonitors: true
+
+  # -- Adds Sveltos dashboard to Grafana.
   grafanaDashboard: true
+
 promxy:
-  replicaCount: 1
+  # -- Enables `kof-mothership-promxy` deployment.
   enabled: true
+
+  # -- Number of replicated promxy pods.
+  replicaCount: 1
+
+  # -- Promxy image to use.
   image:
     repository: quay.io/jacksontj/promxy
     tag: "latest"
     pullPolicy: IfNotPresent
+
   serviceAccount:
+    # -- Creates a service account for promxy.
     create: true
+
+    # -- Annotations for the service account of promxy.
     annotations: {}
-    # If not set, generated using the fullname template
+
+    # -- Name for the service account of promxy.
+    # If not set, it is generated as `kof-mothership-promxy`.
     name:
+
   operator:
     rbac:
+      # -- Creates the `kof-mothership-promxy-operator` cluster role
+      # and binds it to the service account of promxy.
       create: true
+
+    # -- Image of the promxy operator.
     image:
       repository: ghcr.io/k0rdent/kof/promxy-operator-controller
       tag: "latest"
       pullPolicy: IfNotPresent
+
     resources:
+
+      # -- Minimum resources required for promxy operator.
       requests:
         cpu: 100m
         memory: 64Mi
+
+      # -- Maximum resources available for promxy operator.
       limits:
         cpu: 100m
         memory: 64Mi
+
+  # -- Config of `kof-mothership-promxy`
+  # [Service](https://kubernetes.io/docs/concepts/services-networking/service/).
   service:
-    type: ClusterIP
     enabled: true
+    type: ClusterIP
     servicePort: 8082
     annotations: {}
     extraLabels: {}
@@ -113,6 +213,9 @@ promxy:
     externalIPs: []
     loadBalancerIP: ""
     loadBalancerSourceRanges: []
+
+  # -- Config of `kof-mothership-promxy`
+  # [Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/).
   ingress:
     enabled: false
     ingressClassName: nginx
@@ -123,23 +226,35 @@ promxy:
     hosts:
       - example.com
     tls: []
+
   resources:
+
+    # -- Minimum resources required for the `promxy` container
+    # in the pods of `kof-mothership-promxy` deployment.
     requests:
       cpu: 100m
       memory: 128Mi
+
+    # -- Maximum resources available for the `promxy` container
+    # in the pods of `kof-mothership-promxy` deployment.
     limits:
       cpu: 100m
       memory: 128Mi
+
+  # -- Extra command line arguments passed to the `/bin/promxy`.
   extraArgs:
     log-level: "info"
-  config:
-    remoteWriteUrl: http://vminsert-cluster:8480/insert/0/prometheus/api/v1/write
+
   configmapReload:
     resources:
+      # -- Minimum resources required for the `promxy-server-configmap-reload` container
+      # in the pods of `kof-mothership-promxy` deployment.
       requests:
         cpu: 0.02
         memory: 20Mi
+
+      # -- Maximum resources available for the `promxy-server-configmap-reload` container
+      # in the pods of `kof-mothership-promxy` deployment.
       limits:
         cpu: 0.02
         memory: 20Mi
-

--- a/charts/kof-mothership/values.yaml
+++ b/charts/kof-mothership/values.yaml
@@ -241,7 +241,7 @@ promxy:
       cpu: 100m
       memory: 128Mi
 
-  # -- Extra command line arguments passed to the `/bin/promxy`.
+  # -- Extra command line arguments passed as `--key=value` to the `/bin/promxy`.
   extraArgs:
     log-level: "info"
 

--- a/charts/kof-mothership/values.yaml
+++ b/charts/kof-mothership/values.yaml
@@ -1,5 +1,5 @@
 global:
-  # -- Name of the label identifying where the time series data comes from.
+  # -- Name of the label identifying where the time series data points come from.
   clusterLabel: clusterName
   # -- Value of this label.
   clusterName: mothership

--- a/charts/kof-mothership/values.yaml
+++ b/charts/kof-mothership/values.yaml
@@ -1,5 +1,5 @@
 global:
-  # -- Name of the label identifying where the data point comes from.
+  # -- Name of the label identifying where the time series data comes from.
   clusterLabel: clusterName
   # -- Value of this label.
   clusterName: mothership

--- a/charts/kof-storage/Chart.lock
+++ b/charts/kof-storage/Chart.lock
@@ -10,6 +10,6 @@ dependencies:
   version: 0.8.16
 - name: external-dns
   repository: https://kubernetes-sigs.github.io/external-dns/
-  version: 1.15.1
-digest: sha256:447fac3a8fd4ecfe378d99a22ccc6a050c6fe598915801e383cf34139248473f
-generated: "2025-02-10T12:26:54.221935+02:00"
+  version: 1.15.2
+digest: sha256:237c34b83592415ca5b0106be231599904bb2c035bc5c64f940c917fdb70bd78
+generated: "2025-02-17T15:08:49.322899+01:00"

--- a/demo/demo-mothership-values.yaml
+++ b/demo/demo-mothership-values.yaml
@@ -76,5 +76,3 @@ promxy:
       memory: 128Mi
   extraArgs:
     log-level: "info"
-  config:
-    remoteWriteUrl: http://vminsert-cluster:8480/insert/0/prometheus/api/v1/write


### PR DESCRIPTION
Shaun has suggested - https://github.com/k0rdent/olddocs/issues/92#issuecomment-2647585965

> The values options for the mothership template are unclear without going looking through the templates themselves

This PR adds the [helm-docs](https://github.com/norwoodj/helm-docs) for `kof-mothership` chart values and the `pre-commit` hook.

Rendered markdown:  
https://github.com/k0rdent/kof/blob/3348e33107a4ae97e9655e28e3091e0da753d485/charts/kof-mothership/README.md

Open source suggestion: https://github.com/norwoodj/helm-docs/pull/106#issuecomment-2659793069

Also fixed few minor issues, see the diff.