### PR TITLE
Replaced `kof-child-cluster` ClusterProfile with a MultiClusterService

### DIFF
--- a/charts/kof-mothership/templates/k0rdent/kof/svctmpl.yaml
+++ b/charts/kof-mothership/templates/k0rdent/kof/svctmpl.yaml
@@ -6,6 +6,9 @@ kind: ServiceTemplate
 metadata:
   name: kof-{{ $name }}-{{ $values.version | replace "." "-" }}
   namespace: {{ $.Values.kcm.namespace }}
+  annotations:
+    # To avoid `ServiceTemplate not found` in `MultiClusterService/ClusterDeployment`:
+    helm.sh/hook: pre-install
 spec:
   helm:
     chartSpec:

--- a/charts/kof-mothership/templates/sveltos/child-cluster-profile.yaml
+++ b/charts/kof-mothership/templates/sveltos/child-cluster-profile.yaml
@@ -1,78 +1,60 @@
-apiVersion: config.projectsveltos.io/v1beta1
-kind: ClusterProfile
+apiVersion: k0rdent.mirantis.com/v1alpha1
+kind: MultiClusterService
 metadata:
   name: kof-child-cluster
 spec:
   clusterSelector:
     matchLabels:
       k0rdent.mirantis.com/kof-cluster-role: child
-  helmCharts:
+  serviceSpec:
+    priority: 100
+    services:
 
-    - repositoryName:   k0rdent-catalog
-      repositoryURL:    oci://ghcr.io/k0rdent/catalog/charts
-      chartName:        cert-manager
-      chartVersion:     1.16.2
-      releaseName:      cert-manager
-      releaseNamespace: kof
-      helmChartAction:  Install
-      values: |
-        cert-manager:
-          crds:
-            enabled: true
+      - name: cert-manager
+        namespace: kof
+        template: cert-manager-1-16-2
+        values: |
+          cert-manager:
+            crds:
+              enabled: true
 
-    - repositoryName:   kof
-      repositoryURL:    {{ .Values.kcm.kof.repo.url }}
-      {{- if .Values.kcm.kof.repo.insecure }}
-      registryCredentialsConfig:
-        plainHTTP: true
-      {{- end }}
-      chartName:        kof-operators
-      chartVersion:     {{ .Values.kcm.kof.charts.operators.version }}
-      releaseName:      kof-operators
-      releaseNamespace: kof
-      helmChartAction:  Install
+      - name: kof-operators
+        namespace: kof
+        template: kof-operators-{{ .Values.kcm.kof.charts.operators.version | replace "." "-" }}
 
-    - repositoryName:   kof
-      repositoryURL:    {{ .Values.kcm.kof.repo.url }}
-      {{- if .Values.kcm.kof.repo.insecure }}
-      registryCredentialsConfig:
-        plainHTTP: true
-      {{- end }}
-      chartName:        kof-collectors
-      chartVersion:     {{ .Values.kcm.kof.charts.collectors.version }}
-      releaseName:      kof-collectors
-      releaseNamespace: kof
-      helmChartAction:  Install
-      values: |
-        {{/*
-          Sveltos reads the label of the *child* cluster for now.
+      - name: kof-collectors
+        namespace: kof
+        template: kof-collectors-{{ .Values.kcm.kof.charts.collectors.version | replace "." "-" }}
+        values: |
+          {{/*
+            We read the label of the **child** cluster for now.
 
-          Upcoming `kof-operator` should read it from the *regional* cluster instead,
-          and create this `ClusterProfile` dynamically.
-        */}}
-        global:
-          clusterName: {{`{{ .Cluster.metadata.name }}`}}
-        opencost:
-          enabled: true
+            Upcoming `kof-operator` should read it from the **regional** cluster instead,
+            and create this `MultiClusterService` dynamically.
+          */}}
+          global:
+            clusterName: {{`{{ .Cluster.metadata.name }}`}}
           opencost:
-            prometheus:
+            enabled: true
+            opencost:
+              prometheus:
+                username_key: username
+                password_key: password
+                existingSecretName: storage-vmuser-credentials
+                external:
+                  url: https://vmauth.{{`{{ index .Cluster.metadata.labels "k0rdent.mirantis.com/kof-regional-domain" }}`}}/vm/select/0/prometheus
+              exporter:
+                defaultClusterId: {{`{{ .Cluster.metadata.name }}`}}
+          kof:
+            logs:
               username_key: username
               password_key: password
-              existingSecretName: storage-vmuser-credentials
-              external:
-                url: https://vmauth.{{`{{ index .Cluster.metadata.labels "k0rdent.mirantis.com/kof-regional-domain" }}`}}/vm/select/0/prometheus
-            exporter:
-              defaultClusterId: {{`{{ .Cluster.metadata.name }}`}}
-        kof:
-          logs:
-            username_key: username
-            password_key: password
-            credentials_secret_name: storage-vmuser-credentials
-            endpoint: https://vmauth.{{`{{ index .Cluster.metadata.labels "k0rdent.mirantis.com/kof-regional-domain" }}`}}/vls/insert/opentelemetry/v1/logs
-          metrics:
-            username_key: username
-            password_key: password
-            credentials_secret_name: storage-vmuser-credentials
-            endpoint: https://vmauth.{{`{{ index .Cluster.metadata.labels "k0rdent.mirantis.com/kof-regional-domain" }}`}}/vm/insert/0/prometheus/api/v1/write
-          traces:
-            endpoint: https://jaeger.{{`{{ index .Cluster.metadata.labels "k0rdent.mirantis.com/kof-regional-domain" }}`}}/collector
+              credentials_secret_name: storage-vmuser-credentials
+              endpoint: https://vmauth.{{`{{ index .Cluster.metadata.labels "k0rdent.mirantis.com/kof-regional-domain" }}`}}/vls/insert/opentelemetry/v1/logs
+            metrics:
+              username_key: username
+              password_key: password
+              credentials_secret_name: storage-vmuser-credentials
+              endpoint: https://vmauth.{{`{{ index .Cluster.metadata.labels "k0rdent.mirantis.com/kof-regional-domain" }}`}}/vm/insert/0/prometheus/api/v1/write
+            traces:
+              endpoint: https://jaeger.{{`{{ index .Cluster.metadata.labels "k0rdent.mirantis.com/kof-regional-domain" }}`}}/collector

--- a/docs/DEV.md
+++ b/docs/DEV.md
@@ -45,52 +45,56 @@ Apply [Grafana](https://docs.k0rdent.io/head/admin-kof/#grafana) section.
 
 This is a full-featured option.
 
-`export AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`
-as in [kcm dev docs](https://github.com/k0rdent/kcm/blob/main/docs/dev.md#aws-provider-setup)
-and run:
+* `export AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`
+  as in [kcm dev docs](https://github.com/k0rdent/kcm/blob/main/docs/dev.md#aws-provider-setup)
+  and run:
+  ```bash
+  cd ../kcm
+  make dev-creds-apply
+  cd ../kof
+  ```
 
-```bash
-cd ../kcm
-make dev-creds-apply
-cd ../kof
-```
+* Apply [DNS auto-config](https://docs.k0rdent.io/head/admin-kof/#dns-auto-config) and run:
+  ```bash
+  export KOF_DNS=kof.example.com
+  ```
 
-Apply [DNS auto-config](https://docs.k0rdent.io/head/admin-kof/#dns-auto-config) and run:
+* Deploy `kof-mothership` chart to local management cluster:
+  ```bash
+  make dev-ms-deploy-cloud
+  ```
 
-```bash
-export KOF_DNS=kof.example.com
-```
+  * If it fails with `the template is not valid` and no more details,
+    ensure all templates are `VALID`:
+    ```bash
+    kubectl get clustertmpl -A
+    kubectl get svctmpl -A
+    ```
+    and retry the `make dev-ms-deploy-cloud` - reconcile does it automatically.
 
-Deploy `kof-mothership` chart to local management cluster:
+* Wait for all pods to show that they're `Running`:
+  ```bash
+  kubectl get pod -n kof
+  ```
 
-```bash
-make dev-ms-deploy-cloud
-kubectl get pod -n kof
-```
+* Deploy regional and child clusters to AWS:
+  ```bash
+  make dev-regional-deploy-cloud
+  make dev-child-deploy-cloud
+  ```
 
-Wait for all pods to show that they're `Running`.
+* To verify, run:
+  ```bash
+  REGIONAL_CLUSTER_NAME=$USER-aws-standalone-regional
+  CHILD_CLUSTER_NAME=$USER-aws-standalone-child
 
-Deploy regional and child clusters to AWS:
-
-```bash
-make dev-regional-deploy-cloud
-make dev-child-deploy-cloud
-```
-
-To verify, run:
-
-```bash
-REGIONAL_CLUSTER_NAME=$USER-aws-standalone-regional
-CHILD_CLUSTER_NAME=$USER-aws-standalone-child
-
-clusterctl describe cluster --show-conditions all -n kcm-system $REGIONAL_CLUSTER_NAME
-clusterctl describe cluster --show-conditions all -n kcm-system $CHILD_CLUSTER_NAME
-```
-
-...and apply these sections:
-* [Verification](https://docs.k0rdent.io/head/admin-kof/#verification)
-* [Sveltos](https://docs.k0rdent.io/head/admin-kof/#sveltos)
-* [Grafana](https://docs.k0rdent.io/head/admin-kof/#grafana)
+  clusterctl describe cluster --show-conditions all -n kcm-system $REGIONAL_CLUSTER_NAME
+  clusterctl describe cluster --show-conditions all -n kcm-system $CHILD_CLUSTER_NAME
+  ```
+  wait for all `READY` to become `True` and then apply:
+  * [Verification](https://docs.k0rdent.io/head/admin-kof/#verification)
+  * [Sveltos](https://docs.k0rdent.io/head/admin-kof/#sveltos)
+  * [Grafana](https://docs.k0rdent.io/head/admin-kof/#grafana)
 
 ## Uninstall
 
@@ -101,5 +105,5 @@ helm uninstall --wait --cascade foreground -n kof kof-mothership && \
 helm uninstall --wait --cascade foreground -n kof kof-operators && \
 kubectl delete namespace kof --wait --cascade=foreground
 
-cd kcm && make dev-destroy
+cd ../kcm && make dev-destroy
 ```


### PR DESCRIPTION
Closes https://github.com/k0rdent/kof/issues/107

* Replaced `kof-child-cluster` `ClusterProfile` added in https://github.com/k0rdent/kof/pull/101
  with a `MultiClusterService`.
* Found we cannot replace [copy-secrets-cluster-profile](https://github.com/k0rdent/kof/blob/198b370231a8e7c117b95a8ad5fd95658f04f49c/charts/kof-mothership/templates/sveltos/copy-secrets-cluster-profile.yaml)
  because [MultiClusterService supports](https://github.com/k0rdent/kcm/blob/39e7480ae7a02bb06b07b6d752a2e651f8ddc8ff/api/v1alpha1/multiclusterservice_types.go#L124-L129) just `clusterSelector` and `serviceSpec`,
  while we also need `templateResourceRefs` and `policyRefs` in this case.
  * We may replace this `ClusterProfile` with the upcoming `kof-operator` later if needed.
* Verified there are no other `ClusterProfile`-s in `kof` yet.
* Tested end-to-end including Grafana, it works, proof of auto-config:
  ```
  KUBECONFIG=dev/child-kubeconfig kubectl get OpenTelemetryCollector \
    -n kof kof-collectors-node-exporter -o yaml | grep https:

      logs_endpoint: https://vmauth.dryzhkov-aws-standalone-regional.REDACTED.com/vls/insert/opentelemetry/v1/logs
      endpoint: https://jaeger.dryzhkov-aws-standalone-regional.REDACTED.com/collector
      endpoint: https://vmauth.dryzhkov-aws-standalone-regional.REDACTED.com/vm/insert/0/prometheus/api/v1/write
  ```
