### PR TITLE
Remove public IPs from storage cluster deployment

### DIFF
--- a/demo/cluster/aws-standalone-regional.yaml
+++ b/demo/cluster/aws-standalone-regional.yaml
@@ -13,7 +13,7 @@ spec:
     controlPlane:
       instanceType: t3.large
     controlPlaneNumber: 1
-    publicIP: true
+    publicIP: false
     region: us-east-2
     worker:
       instanceType: t3.medium


### PR DESCRIPTION
Public IP is not required