### PR TITLE
Fix of `validation.multiclusterservice: ServiceTemplate cert-manager-1-16-2 not found`

### DIFF
--- a/charts/kof-mothership/templates/k0rdent/catalog/_helpers.tpl
+++ b/charts/kof-mothership/templates/k0rdent/catalog/_helpers.tpl
@@ -11,6 +11,8 @@ metadata:
   namespace: {{ .Values.kcm.namespace }}
   annotations:
     helm.sh/resource-policy: keep
+    # To avoid `ServiceTemplate not found` in `MultiClusterService/ClusterDeployment`:
+    helm.sh/hook: pre-install
 spec:
   helm:
     chartSpec:

--- a/charts/kof-mothership/templates/k0rdent/kof/helm-repo.yaml
+++ b/charts/kof-mothership/templates/k0rdent/kof/helm-repo.yaml
@@ -6,6 +6,9 @@ metadata:
   namespace: {{ .Values.kcm.namespace }}
   labels:
     k0rdent.mirantis.com/managed: "true"
+  annotations:
+    # To avoid `HelmRepository not found` in `MultiClusterService/ClusterDeployment`:
+    helm.sh/hook: pre-install
 spec:
   url: {{ .Values.kcm.kof.repo.url }}
   insecure: {{ .Values.kcm.kof.repo.insecure }}

--- a/charts/kof-mothership/templates/k0rdent/kof/wait-valid-svctmpl.yaml
+++ b/charts/kof-mothership/templates/k0rdent/kof/wait-valid-svctmpl.yaml
@@ -1,0 +1,22 @@
+# This job is required for now to avoid the error
+# `admission webhook "validation.multiclusterservice.k0rdent.mirantis.com"
+# denied the request: the MultiClusterService is invalid:
+# the template is not valid:`
+# because `helm.sh/hook: pre-install` in `ServiceTemplate`-s installs them first,
+# but they still need some time to get `VALID` status.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: kof-wait-valid-svctmpl
+  annotations:
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "10"
+    "helm.sh/hook-delete-policy": hook-succeeded
+spec:
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: main
+          image: busybox
+          command: ["/bin/sleep", "10"]

--- a/docs/DEV.md
+++ b/docs/DEV.md
@@ -65,12 +65,12 @@ This is a full-featured option.
   ```
 
   * If it fails with `the template is not valid` and no more details,
-    ensure all templates are `VALID`:
+    ensure all templates became `VALID`:
     ```bash
     kubectl get clustertmpl -A
     kubectl get svctmpl -A
     ```
-    and retry the `make dev-ms-deploy-cloud` - reconcile does it automatically.
+    and then retry.
 
 * Wait for all pods to show that they're `Running`:
   ```bash


### PR DESCRIPTION
Part of https://github.com/k0rdent/kof/issues/107

This PR fixes the `not found` in https://github.com/k0rdent/kof/actions/runs/13584319097/job/37975900948
related to https://github.com/k0rdent/kof/pull/120

After the fix it failed with another error - `the template is not valid`:
https://github.com/k0rdent/kof/actions/runs/13587191647/job/37984685820?pr=121

This happens because the `ServiceTemplate` needs some time to get `VALID` status,
can be checked with `kubectl get svctmpl -A`

I've asked to add auto-retry to `MultiClusterService`,
and added a pre-install helm hook to wait for `VALID` in this PR.

Now it fails with `HelmRepository not found`:
https://github.com/k0rdent/kof/actions/runs/13588099907/job/37987516531?pr=121

Fixing in the same way and testing:
https://github.com/k0rdent/kof/actions/runs/13588542268/job/37988852559?pr=121