### PR TITLE
Replaced `serviceSpec` in **regional** cluster with auto-config via `clusterLabels`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -142,15 +142,10 @@ dev-regional-deploy-cloud: dev ## Deploy regional cluster using k0rdent
 	cp -f demo/cluster/$(CLOUD_CLUSTER_TEMPLATE)-regional.yaml dev/$(CLOUD_CLUSTER_TEMPLATE)-regional.yaml
 	@$(YQ) eval -i '.metadata.name = "$(REGIONAL_CLUSTER_NAME)"' dev/$(CLOUD_CLUSTER_TEMPLATE)-regional.yaml # set the same name for all documents in yaml
 	@$(YQ) eval -i 'select(documentIndex == 0).spec.config.region = "$(CLOUD_CLUSTER_REGION)"' dev/$(CLOUD_CLUSTER_TEMPLATE)-regional.yaml
+	@$(YQ) eval -i 'select(documentIndex == 0).spec.config.clusterLabels["k0rdent.mirantis.com/kof-dns-region"] = "$(CLOUD_CLUSTER_REGION)"' dev/$(CLOUD_CLUSTER_TEMPLATE)-regional.yaml
+	@$(YQ) eval -i 'select(documentIndex == 0).spec.config.clusterLabels["k0rdent.mirantis.com/kof-regional-domain"] = "$(REGIONAL_DOMAIN)"' dev/$(CLOUD_CLUSTER_TEMPLATE)-regional.yaml
+	@$(YQ) eval -i 'select(documentIndex == 0).metadata.annotations["k0rdent.mirantis.com/kof-cert-email"] = "$(USER_EMAIL)"' dev/$(CLOUD_CLUSTER_TEMPLATE)-regional.yaml
 	@$(YQ) eval -i 'select(documentIndex == 1).spec.cluster_name = "$(REGIONAL_CLUSTER_NAME)"' dev/$(CLOUD_CLUSTER_TEMPLATE)-regional.yaml
-	@$(YQ) 'select(documentIndex == 0).spec.serviceSpec.services[] | select(.name == "kof-storage") | .values' dev/$(CLOUD_CLUSTER_TEMPLATE)-regional.yaml > dev/kof-storage-values.yaml
-	@$(YQ) eval -i '.["cert-manager"].email = "$(USER_EMAIL)"' dev/kof-storage-values.yaml
-	@$(YQ) eval -i '.victoriametrics.vmauth.ingress.host = "vmauth.$(REGIONAL_DOMAIN)"' dev/kof-storage-values.yaml
-	@$(YQ) eval -i '.grafana.ingress.host = "grafana.$(REGIONAL_DOMAIN)"' dev/kof-storage-values.yaml
-	@$(YQ) eval -i '.jaeger.ingress.enabled = true' dev/kof-storage-values.yaml
-	@$(YQ) eval -i '.jaeger.ingress.host = "jaeger.$(REGIONAL_DOMAIN)"' dev/kof-storage-values.yaml
-	@$(YQ) eval -i '.["external-dns"] = {"enabled": true, "env": [{"name": "AWS_SHARED_CREDENTIALS_FILE", "value": "/etc/aws/credentials/external-dns-aws-credentials"}, {"name": "AWS_DEFAULT_REGION", "value": "$(CLOUD_CLUSTER_REGION)"}]}' dev/kof-storage-values.yaml
-	@$(YQ) eval -i '(select(documentIndex == 0).spec.serviceSpec.services[] | select(.name == "kof-storage")).values |= load_str("dev/kof-storage-values.yaml")' dev/$(CLOUD_CLUSTER_TEMPLATE)-regional.yaml
 	@$(YQ) eval -i 'select(documentIndex == 1).spec.targets = ["vmauth.$(REGIONAL_DOMAIN):443"]' dev/$(CLOUD_CLUSTER_TEMPLATE)-regional.yaml
 	@$(YQ) eval -i 'select(documentIndex == 2).spec.datasource.name =  "$(REGIONAL_CLUSTER_NAME)"' dev/$(CLOUD_CLUSTER_TEMPLATE)-regional.yaml
 	@$(YQ) eval -i 'select(documentIndex == 2).spec.datasource.url = "https://vmauth.$(REGIONAL_DOMAIN)/vls"' dev/$(CLOUD_CLUSTER_TEMPLATE)-regional.yaml

--- a/charts/kof-mothership/templates/sveltos/kof-cluster-role-child.yaml
+++ b/charts/kof-mothership/templates/sveltos/kof-cluster-role-child.yaml
@@ -26,11 +26,12 @@ spec:
         namespace: kof
         template: kof-collectors-{{ .Values.kcm.kof.charts.collectors.version | replace "." "-" }}
         values: |
-          {{/*
+          {{- /*
             We read the label of the **child** cluster for now.
 
-            Upcoming `kof-operator` should read it from the **regional** cluster instead,
-            and create this `MultiClusterService` dynamically.
+            `kof-operator` should read it from the **regional** cluster instead,
+            and create this `MultiClusterService` dynamically from
+            `ClusterDeployment` having `k0rdent.mirantis.com/kof-cluster-role: child`.
           */}}
           global:
             clusterName: {{`{{ .Cluster.metadata.name }}`}}

--- a/charts/kof-mothership/templates/sveltos/kof-cluster-role-regional.yaml
+++ b/charts/kof-mothership/templates/sveltos/kof-cluster-role-regional.yaml
@@ -1,0 +1,68 @@
+apiVersion: k0rdent.mirantis.com/v1alpha1
+kind: MultiClusterService
+metadata:
+  name: kof-regional-cluster
+spec:
+  clusterSelector:
+    matchLabels:
+      k0rdent.mirantis.com/kof-cluster-role: regional
+  serviceSpec:
+    priority: 100
+    services:
+
+      - name: ingress-nginx
+        namespace: ingress-nginx
+        template: ingress-nginx-4-11-3
+
+      - name: cert-manager
+        namespace: cert-manager
+        template: cert-manager-1-16-2
+        values: |
+          cert-manager:
+            crds:
+              enabled: true
+
+      - name: kof-storage
+        namespace: kof
+        template: kof-storage-{{ .Values.kcm.kof.charts.storage.version | replace "." "-" }}
+        values: |
+          {{- /*
+            `kof-operator` should create this `MultiClusterService`
+            and also the `PromxyServerGroup` and `GrafanaDatasource` dynamically from
+            `ClusterDeployment` having `k0rdent.mirantis.com/kof-cluster-role: regional`.
+
+            It should also set `values.cert-manager.email` from the
+            `ClusterDeployment.metadata.annotations["k0rdent.mirantis.com/kof-cert-email"]`
+            to avoid `metadata.labels: Invalid value` because of `@` character in email.
+            Move similar values from `clusterLabels` to `annotations` too.
+          */}}
+          global:
+            storageClass: "{{`{{ default "" (index .Cluster.metadata.labels "k0rdent.mirantis.com/kof-storage-class") }}`}}"
+          victoria-logs-single:
+            server:
+              persistentVolume:
+                storageClassName: "{{`{{ default "" (index .Cluster.metadata.labels "k0rdent.mirantis.com/kof-storage-class") }}`}}"
+          victoriametrics:
+            vmauth:
+              ingress:
+                host: vmauth.{{`{{ index .Cluster.metadata.labels "k0rdent.mirantis.com/kof-regional-domain" }}`}}
+            security:
+              username_key: username
+              password_key: password
+              credentials_secret_name: storage-vmuser-credentials
+          jaeger:
+            ingress:
+              enabled: true
+              host: jaeger.{{`{{ index .Cluster.metadata.labels "k0rdent.mirantis.com/kof-regional-domain" }}`}}
+          grafana:
+            ingress:
+              host: grafana.{{`{{ index .Cluster.metadata.labels "k0rdent.mirantis.com/kof-regional-domain" }}`}}
+            security:
+              credentials_secret_name: grafana-admin-credentials
+          external-dns:
+            enabled: {{`{{ index .Cluster.metadata.labels "k0rdent.mirantis.com/kof-dns-enabled" }}`}}
+            env:
+              - name: AWS_SHARED_CREDENTIALS_FILE
+                value: /etc/aws/credentials/external-dns-aws-credentials
+              - name: AWS_DEFAULT_REGION
+                value: {{`{{ index .Cluster.metadata.labels "k0rdent.mirantis.com/kof-dns-region" }}`}}

--- a/charts/kof-storage/values.yaml
+++ b/charts/kof-storage/values.yaml
@@ -82,7 +82,7 @@ victoria-metrics-operator:
 victoria-logs-single:
   enabled: true
   server:
-    storage:
+    persistentVolume:
       enabled: true
       storageClassName: ""
   fluent-bit:

--- a/demo/cluster/aws-eks-regional.yaml
+++ b/demo/cluster/aws-eks-regional.yaml
@@ -3,6 +3,8 @@ kind: ClusterDeployment
 metadata:
   name: aws-eks-ue2
   namespace: kcm-system
+  annotations:
+    k0rdent.mirantis.com/kof-cert-email: mail@example.net
 spec:
   template: aws-eks-0-1-0
   credential: aws-cluster-identity-cred
@@ -17,48 +19,11 @@ spec:
     clusterLabels:
       k0rdent.mirantis.com/kof-storage-secrets: "true"
       k0rdent.mirantis.com/kof-aws-dns-secrets: "true"
-  serviceSpec:
-    priority: 100
-    services:
-      - name: ingress-nginx
-        namespace: ingress-nginx
-        template: ingress-nginx-4-11-3
-      - name: cert-manager
-        namespace: cert-manager
-        template: cert-manager-1-16-2
-        values: |
-          cert-manager:
-            crds:
-              enabled: true
-      - name: kof-storage
-        namespace: kof
-        template: kof-storage-0-1-1
-        values: |
-          global:
-            storageClass: gp2
-          victoriametrics:
-            vmauth:
-              ingress:
-                host: vmauth.storage0.example.net
-            security:
-              username_key: username
-              password_key: password
-              credentials_secret_name: storage-vmuser-credentials
-          victoria-logs-single:
-            server:
-              storage:
-                storageClassName: gp2
-          grafana:
-            ingress:
-              host: vmauth.storage0.example.net
-            security:
-              credentials_secret_name: grafana-admin-credentials
-          cert-manager:
-            email: mail@example.net
-          jaeger:
-            ingress:
-              enabled: false
-              host: jaeger.example.com
+      k0rdent.mirantis.com/kof-cluster-role: regional
+      k0rdent.mirantis.com/kof-regional-domain: aws-eks-ue2.kof.example.com
+      k0rdent.mirantis.com/kof-dns-enabled: "true"
+      k0rdent.mirantis.com/kof-dns-region: us-east-2
+      k0rdent.mirantis.com/kof-storage-class: gp2
 ---
 apiVersion: kof.k0rdent.mirantis.com/v1alpha1
 kind: PromxyServerGroup

--- a/demo/cluster/aws-standalone-regional.yaml
+++ b/demo/cluster/aws-standalone-regional.yaml
@@ -3,6 +3,8 @@ kind: ClusterDeployment
 metadata:
   name: aws-ue2
   namespace: kcm-system
+  annotations:
+    k0rdent.mirantis.com/kof-cert-email: mail@example.net
 spec:
   credential: aws-cluster-identity-cred
   template: aws-standalone-cp-0-1-2
@@ -21,42 +23,10 @@ spec:
     clusterLabels:
       k0rdent.mirantis.com/kof-storage-secrets: "true"
       k0rdent.mirantis.com/kof-aws-dns-secrets: "true"
-  serviceSpec:
-    priority: 100
-    services:
-      - name: ingress-nginx
-        namespace: ingress-nginx
-        template: ingress-nginx-4-11-3
-      - name: cert-manager
-        namespace: cert-manager
-        template: cert-manager-1-16-2
-        values: |
-          cert-manager:
-            crds:
-              enabled: true
-      - name: kof-storage
-        namespace: kof
-        template: kof-storage-0-1-1
-        values: |
-          jaeger:
-            ingress:
-              enabled: false
-              host: jaeger.example.com
-          victoriametrics:
-            vmauth:
-              ingress:
-                host: vmauth.storage0.example.net
-            security:
-              username_key: username
-              password_key: password
-              credentials_secret_name: storage-vmuser-credentials
-          grafana:
-            ingress:
-              host: vmauth.storage0.example.net
-            security:
-              credentials_secret_name: grafana-admin-credentials
-          cert-manager:
-            email: mail@example.net
+      k0rdent.mirantis.com/kof-cluster-role: regional
+      k0rdent.mirantis.com/kof-regional-domain: aws-ue2.kof.example.com
+      k0rdent.mirantis.com/kof-dns-enabled: "true"
+      k0rdent.mirantis.com/kof-dns-region: us-east-2
 ---
 apiVersion: kof.k0rdent.mirantis.com/v1alpha1
 kind: PromxyServerGroup

--- a/docs/DEV.md
+++ b/docs/DEV.md
@@ -61,16 +61,8 @@ This is a full-featured option.
 
 * Deploy `kof-mothership` chart to local management cluster:
   ```bash
-  make dev-ms-deploy-cloud
+  make dev-ms-deploy
   ```
-
-  * If it fails with `the template is not valid` and no more details,
-    ensure all templates became `VALID`:
-    ```bash
-    kubectl get clustertmpl -A
-    kubectl get svctmpl -A
-    ```
-    and then retry.
 
 * Wait for all pods to show that they're `Running`:
   ```bash
@@ -107,3 +99,23 @@ kubectl delete namespace kof --wait --cascade=foreground
 
 cd ../kcm && make dev-destroy
 ```
+
+## Adopted local cluster
+
+* For quick dev/test iterations, update the related `demo/cluster/` file to use:
+  ```
+    credential: adopted-cluster-cred
+    template: adopted-cluster-0-1-0
+  ```
+
+* Run this to create the `adopted-cluster-cred`
+  and to verify the version of the `template`:
+  ```bash
+  cd ../kcm
+  kind create cluster -n adopted
+  kubectl config use kind-kcm-dev
+  KUBECONFIG_DATA=$(kind get kubeconfig --internal -n adopted | base64) make dev-adopted-creds
+  kubectl get clustertemplate -n kcm-system | grep adopted
+  ```
+
+* Use `kubectl --context=kind-adopted` to inspect the cluster.


### PR DESCRIPTION
* Part of https://github.com/k0rdent/kof/issues/77
* Similar to https://github.com/k0rdent/kof/pull/101 but for regional clusters.
* Also fixes `storageClass` passed to `kof-storage` and `victoria-logs-single`.
* Also adds "Adopted local cluster for quick dev/test iterations" to `DEV.md`.
* Tested end-to-end. Proof of generated values:


```bash
KUBECONFIG=dev/regional-kubeconfig helm get values -n kof kof-storage
```

```yaml
USER-SUPPLIED VALUES:
external-dns:
  enabled: true
  env:
  - name: AWS_SHARED_CREDENTIALS_FILE
    value: /etc/aws/credentials/external-dns-aws-credentials
  - name: AWS_DEFAULT_REGION
    value: us-west-1
global:
  storageClass: ""
grafana:
  ingress:
    host: grafana.dryzhkov-aws-standalone-regional.REDACTED
  security:
    credentials_secret_name: grafana-admin-credentials
jaeger:
  ingress:
    enabled: true
    host: jaeger.dryzhkov-aws-standalone-regional.REDACTED
victoria-logs-single:
  server:
    persistentVolume:
      storageClassName: ""
victoriametrics:
  security:
    credentials_secret_name: storage-vmuser-credentials
    password_key: password
    username_key: username
  vmauth:
    ingress:
      host: vmauth.dryzhkov-aws-standalone-regional.REDACTED
```
