### PR TITLE
Use pullPolicy Always for the Operator for Dev Scenarios

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -134,6 +134,7 @@ dev-ms-deploy: dev kof-operator-docker-build ## Deploy `kof-mothership` helm cha
 	@$(YQ) eval -i '.kcm.kof.clusterProfiles.kof-aws-dns-secrets = {"matchLabels": {"k0rdent.mirantis.com/kof-aws-dns-secrets": "true"}, "secrets": ["external-dns-aws-credentials"]}' dev/mothership-values.yaml
 
 	@$(YQ) eval -i '.kcm.kof.operator.image.repository = "kof-operator-controller"' dev/mothership-values.yaml
+	@$(YQ) eval -i '.kcm.kof.operator.image.pullPolicy = "Always"' dev/mothership-values.yaml
 	@$(call set_local_registry, "dev/mothership-values.yaml")
 	$(HELM) upgrade -i kof-mothership ./charts/kof-mothership -n kof --create-namespace -f dev/mothership-values.yaml
 


### PR DESCRIPTION
For dev scenarios it is better to use pullPolicy "Always" as the latest tag will be overwritten and not pulled on container recreation while the new image is available.