### PR TITLE
support passing and detecting tls options for collectors

### DIFF
--- a/charts/kof-collectors/templates/_helpers.tpl
+++ b/charts/kof-collectors/templates/_helpers.tpl
@@ -11,3 +11,15 @@ basicauth/{{ . }}:
 {{- end }}
 {{- end }}
 
+
+{{- define "kof-collectors.helper.tls_options" -}}
+{{- $parsedEndpoint := urlParse .endpoint }} 
+{{- if eq $parsedEndpoint.scheme "http" }}
+tls:
+  insecure: true
+{{- else if eq $parsedEndpoint.scheme "https" }}
+  {{- with .tls_options }}
+tls: {{ . | toYaml | nindent 2 }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/kof-collectors/templates/opentelemetry/collector.yaml
+++ b/charts/kof-collectors/templates/opentelemetry/collector.yaml
@@ -37,18 +37,17 @@ spec:
 
     processors:
       batch: {}
-
     exporters:
       debug: {}
       prometheusremotewrite:
         endpoint: {{ .Values.kof.metrics.endpoint }}
-        tls:
-          insecure: true
+        {{- include "kof-collectors.helper.tls_options" .Values.kof.metrics | indent 8 }}
         auth:
           authenticator: basicauth/metrics
       otlphttp:
         auth:
           authenticator: basicauth/logs
+          {{- include "kof-collectors.helper.tls_options" .Values.kof.logs | indent 8 }}
         logs_endpoint: {{ .Values.kof.logs.endpoint }}
 
     {{- if .Values.kof.basic_auth }}

--- a/charts/kof-collectors/templates/opentelemetry/node-collector.yaml
+++ b/charts/kof-collectors/templates/opentelemetry/node-collector.yaml
@@ -200,16 +200,17 @@ spec:
     exporters:
       otlphttp/traces:
         endpoint: {{ .Values.kof.traces.endpoint }}
+        {{- include "kof-collectors.helper.tls_options" .Values.kof.traces | indent 8 }}
       prometheusremotewrite:
         endpoint: {{ .Values.kof.metrics.endpoint }}
-        tls:
-          insecure: true
+        {{- include "kof-collectors.helper.tls_options" .Values.kof.metrics | indent 8 }}
         auth:
           authenticator: basicauth/metrics
       otlphttp/logs:
         auth:
           authenticator: basicauth/logs
         logs_endpoint: {{ .Values.kof.logs.endpoint }}
+        {{- include "kof-collectors.helper.tls_options" .Values.kof.logs | indent 8 }}
       debug:
         verbosity: basic
 


### PR DESCRIPTION
1. add a helper
2. if an endpoint scheme is http: add tls.insecure = true
3. otherwise add tls_options if any