### PR TITLE
Added `regional_cluster_name` to child cluster `ConfigMap` to support istio

### DIFF
--- a/kof-operator/internal/controller/clusterdeployment_controller_test.go
+++ b/kof-operator/internal/controller/clusterdeployment_controller_test.go
@@ -412,7 +412,7 @@ var _ = Describe("ClusterDeployment Controller", func() {
 			configMap := &corev1.ConfigMap{}
 			err = k8sClient.Get(ctx, childClusterConfigMapNamespacedName, configMap)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(configMap.Data).To(HaveKey("regional_domain"))
+			Expect(configMap.Data["regional_cluster_name"]).To(Equal("test-regional"))
 			Expect(configMap.Data["regional_domain"]).To(Equal("test-aws-ue2.kof.example.com"))
 			configMapCDGeneration, err := strconv.Atoi(configMap.Data["cluster_deployment_generation"])
 			Expect(err).NotTo(HaveOccurred())

--- a/kof-operator/internal/controller/clusterdeployment_kof_cluster_role.go
+++ b/kof-operator/internal/controller/clusterdeployment_kof_cluster_role.go
@@ -13,6 +13,7 @@ import (
 )
 
 const CLUSTER_DEPLOYMENT_GENERATION_KEY = "cluster_deployment_generation"
+const REGIONAL_CLUSTER_NAME_KEY = "regional_cluster_name"
 const REGIONAL_DOMAIN_KEY = "regional_domain"
 
 func getConfigMapName(clusterDeploymentName string) string {
@@ -130,6 +131,7 @@ func (r *ClusterDeploymentReconciler) reconcileChildClusterRole(
 		},
 		Data: map[string]string{
 			CLUSTER_DEPLOYMENT_GENERATION_KEY: fmt.Sprintf("%d", childClusterDeployment.Generation),
+			REGIONAL_CLUSTER_NAME_KEY:         regionalClusterName,
 			REGIONAL_DOMAIN_KEY:               regionalDomain,
 		},
 	}
@@ -154,6 +156,7 @@ func (r *ClusterDeploymentReconciler) reconcileChildClusterRole(
 		log.Info(
 			"Updated child cluster ConfigMap",
 			"name", configMap.Name,
+			REGIONAL_CLUSTER_NAME_KEY, regionalClusterName,
 			REGIONAL_DOMAIN_KEY, regionalDomain,
 		)
 		return nil
@@ -162,6 +165,7 @@ func (r *ClusterDeploymentReconciler) reconcileChildClusterRole(
 	log.Info(
 		"Created child cluster ConfigMap",
 		"name", configMap.Name,
+		REGIONAL_CLUSTER_NAME_KEY, regionalClusterName,
 		REGIONAL_DOMAIN_KEY, regionalDomain,
 	)
 	return nil


### PR DESCRIPTION
* Part of istio: https://github.com/k0rdent/kof/issues/94