### PR TITLE
Auto-discover regional cluster using AWS region, Azure location, etc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -144,7 +144,7 @@ dev-regional-deploy-cloud: dev ## Deploy regional cluster using k0rdent
 	@$(YQ) eval -i '.metadata.name = "$(REGIONAL_CLUSTER_NAME)"' dev/$(CLOUD_CLUSTER_TEMPLATE)-regional.yaml # set the same name for all documents in yaml
 	@$(YQ) eval -i 'select(documentIndex == 0).spec.config.region = "$(CLOUD_CLUSTER_REGION)"' dev/$(CLOUD_CLUSTER_TEMPLATE)-regional.yaml
 	@$(YQ) eval -i 'select(documentIndex == 1).spec.cluster_name = "$(REGIONAL_CLUSTER_NAME)"' dev/$(CLOUD_CLUSTER_TEMPLATE)-regional.yaml
-	@$(YQ) eval -i 'select(documentIndex == 0).spec.config.clusterLabels["k0rdent.mirantis.com/kof-regional-domain"] = "$(REGIONAL_DOMAIN)"' dev/$(CLOUD_CLUSTER_TEMPLATE)-regional.yaml
+	@$(YQ) eval -i 'select(documentIndex == 0).metadata.labels["k0rdent.mirantis.com/kof-regional-domain"] = "$(REGIONAL_DOMAIN)"' dev/$(CLOUD_CLUSTER_TEMPLATE)-regional.yaml
 	@$(YQ) 'select(documentIndex == 0).spec.serviceSpec.services[] | select(.name == "kof-storage") | .values' dev/$(CLOUD_CLUSTER_TEMPLATE)-regional.yaml > dev/kof-storage-values.yaml
 	@$(YQ) eval -i '.["cert-manager"].email = "$(USER_EMAIL)"' dev/kof-storage-values.yaml
 	@$(YQ) eval -i '.["external-dns"] = {"enabled": true, "env": [{"name": "AWS_SHARED_CREDENTIALS_FILE", "value": "/etc/aws/credentials/external-dns-aws-credentials"}, {"name": "AWS_DEFAULT_REGION", "value": "$(CLOUD_CLUSTER_REGION)"}]}' dev/kof-storage-values.yaml
@@ -160,7 +160,7 @@ dev-child-deploy-cloud: dev ## Deploy child cluster using k0rdent
 	@$(YQ) eval -i 'select(documentIndex == 0).metadata.name = "$(CHILD_CLUSTER_NAME)"' dev/$(CLOUD_CLUSTER_TEMPLATE)-child.yaml
 	@$(YQ) eval -i 'select(documentIndex == 0).spec.config.region = "$(CLOUD_CLUSTER_REGION)"' dev/$(CLOUD_CLUSTER_TEMPLATE)-child.yaml
 	@# Optional, auto-detected by region:
-	@# $(YQ) eval -i 'select(documentIndex == 0).spec.config.clusterLabels["k0rdent.mirantis.com/kof-regional-cluster-name"] = "$(REGIONAL_CLUSTER_NAME)"' dev/$(CLOUD_CLUSTER_TEMPLATE)-child.yaml
+	@# $(YQ) eval -i 'select(documentIndex == 0).metadata.labels["k0rdent.mirantis.com/kof-regional-cluster-name"] = "$(REGIONAL_CLUSTER_NAME)"' dev/$(CLOUD_CLUSTER_TEMPLATE)-child.yaml
 	kubectl apply -f dev/$(CLOUD_CLUSTER_TEMPLATE)-child.yaml
 
 ## Tool Binaries

--- a/Makefile
+++ b/Makefile
@@ -135,7 +135,8 @@ dev-ms-deploy: dev kof-operator-docker-build ## Deploy `kof-mothership` helm cha
 
 	@$(YQ) eval -i '.kcm.kof.operator.image.repository = "kof-operator-controller"' dev/mothership-values.yaml
 	@$(call set_local_registry, "dev/mothership-values.yaml")
-	$(HELM) upgrade -i kof-mothership ./charts/kof-mothership -n kof --create-namespace -f dev/mothership-values.yaml
+	$(HELM) upgrade -i --wait --create-namespace -n kof kof-mothership ./charts/kof-mothership -f dev/mothership-values.yaml
+	kubectl rollout restart -n kof deployment/kof-mothership-kof-operator
 
 .PHONY: dev-regional-deploy-cloud
 dev-regional-deploy-cloud: dev ## Deploy regional cluster using k0rdent
@@ -158,7 +159,8 @@ dev-child-deploy-cloud: dev ## Deploy child cluster using k0rdent
 	cp -f demo/cluster/$(CLOUD_CLUSTER_TEMPLATE)-child.yaml dev/$(CLOUD_CLUSTER_TEMPLATE)-child.yaml
 	@$(YQ) eval -i 'select(documentIndex == 0).metadata.name = "$(CHILD_CLUSTER_NAME)"' dev/$(CLOUD_CLUSTER_TEMPLATE)-child.yaml
 	@$(YQ) eval -i 'select(documentIndex == 0).spec.config.region = "$(CLOUD_CLUSTER_REGION)"' dev/$(CLOUD_CLUSTER_TEMPLATE)-child.yaml
-	@$(YQ) eval -i 'select(documentIndex == 0).spec.config.clusterLabels["k0rdent.mirantis.com/kof-regional-cluster-name"] = "$(REGIONAL_CLUSTER_NAME)"' dev/$(CLOUD_CLUSTER_TEMPLATE)-child.yaml
+	@# Optional, auto-detected by region:
+	@# $(YQ) eval -i 'select(documentIndex == 0).spec.config.clusterLabels["k0rdent.mirantis.com/kof-regional-cluster-name"] = "$(REGIONAL_CLUSTER_NAME)"' dev/$(CLOUD_CLUSTER_TEMPLATE)-child.yaml
 	kubectl apply -f dev/$(CLOUD_CLUSTER_TEMPLATE)-child.yaml
 
 ## Tool Binaries

--- a/demo/cluster/aws-eks-child.yaml
+++ b/demo/cluster/aws-eks-child.yaml
@@ -3,6 +3,11 @@ kind: ClusterDeployment
 metadata:
   name: aws-eks-ue2-child1
   namespace: kcm-system
+  labels:
+    k0rdent.mirantis.com/kof-storage-secrets: "true"
+    k0rdent.mirantis.com/kof-cluster-role: child
+    # Optional, auto-detected by region:
+    # k0rdent.mirantis.com/kof-regional-cluster-name: aws-eks-ue2
 spec:
   template: aws-eks-0-1-0
   credential: aws-cluster-identity-cred
@@ -14,8 +19,3 @@ spec:
     worker:
       instanceType: t3.small
     workersNumber: 3
-    clusterLabels:
-      k0rdent.mirantis.com/kof-storage-secrets: "true"
-      k0rdent.mirantis.com/kof-cluster-role: child
-      # Optional, auto-detected by region:
-      # k0rdent.mirantis.com/kof-regional-cluster-name: aws-eks-ue2

--- a/demo/cluster/aws-eks-child.yaml
+++ b/demo/cluster/aws-eks-child.yaml
@@ -17,4 +17,5 @@ spec:
     clusterLabels:
       k0rdent.mirantis.com/kof-storage-secrets: "true"
       k0rdent.mirantis.com/kof-cluster-role: child
-      k0rdent.mirantis.com/kof-regional-cluster-name: aws-eks-ue2
+      # Optional, auto-detected by region:
+      # k0rdent.mirantis.com/kof-regional-cluster-name: aws-eks-ue2

--- a/demo/cluster/aws-eks-regional.yaml
+++ b/demo/cluster/aws-eks-regional.yaml
@@ -3,6 +3,11 @@ kind: ClusterDeployment
 metadata:
   name: aws-eks-ue2
   namespace: kcm-system
+  labels:
+    k0rdent.mirantis.com/kof-storage-secrets: "true"
+    k0rdent.mirantis.com/kof-aws-dns-secrets: "true"
+    k0rdent.mirantis.com/kof-cluster-role: regional
+    k0rdent.mirantis.com/kof-regional-domain: "aws-eks-ue2.kof.example.com"
 spec:
   template: aws-eks-0-1-0
   credential: aws-cluster-identity-cred
@@ -14,11 +19,6 @@ spec:
     worker:
       instanceType: t3.medium
     workersNumber: 3
-    clusterLabels:
-      k0rdent.mirantis.com/kof-storage-secrets: "true"
-      k0rdent.mirantis.com/kof-aws-dns-secrets: "true"
-      k0rdent.mirantis.com/kof-cluster-role: regional
-      k0rdent.mirantis.com/kof-regional-domain: "aws-eks-ue2.kof.example.com"
   serviceSpec:
     priority: 100
     services:

--- a/demo/cluster/aws-eks-regional.yaml
+++ b/demo/cluster/aws-eks-regional.yaml
@@ -17,6 +17,7 @@ spec:
     clusterLabels:
       k0rdent.mirantis.com/kof-storage-secrets: "true"
       k0rdent.mirantis.com/kof-aws-dns-secrets: "true"
+      k0rdent.mirantis.com/kof-cluster-role: regional
       k0rdent.mirantis.com/kof-regional-domain: "aws-eks-ue2.kof.example.com"
   serviceSpec:
     priority: 100

--- a/demo/cluster/aws-standalone-child.yaml
+++ b/demo/cluster/aws-standalone-child.yaml
@@ -3,6 +3,11 @@ kind: ClusterDeployment
 metadata:
   name: aws-ue2-child1
   namespace: kcm-system
+  labels:
+    k0rdent.mirantis.com/kof-storage-secrets: "true"
+    k0rdent.mirantis.com/kof-cluster-role: child
+    # Optional, auto-detected by region:
+    # k0rdent.mirantis.com/kof-regional-cluster-name: aws-ue2
 spec:
   template: aws-standalone-cp-0-1-2
   credential: aws-cluster-identity-cred
@@ -18,8 +23,3 @@ spec:
     worker:
       instanceType: t3.small
     workersNumber: 3
-    clusterLabels:
-      k0rdent.mirantis.com/kof-storage-secrets: "true"
-      k0rdent.mirantis.com/kof-cluster-role: child
-      # Optional, auto-detected by region:
-      # k0rdent.mirantis.com/kof-regional-cluster-name: aws-ue2

--- a/demo/cluster/aws-standalone-child.yaml
+++ b/demo/cluster/aws-standalone-child.yaml
@@ -21,4 +21,5 @@ spec:
     clusterLabels:
       k0rdent.mirantis.com/kof-storage-secrets: "true"
       k0rdent.mirantis.com/kof-cluster-role: child
-      k0rdent.mirantis.com/kof-regional-cluster-name: aws-ue2
+      # Optional, auto-detected by region:
+      # k0rdent.mirantis.com/kof-regional-cluster-name: aws-ue2

--- a/demo/cluster/aws-standalone-istio-child.yaml
+++ b/demo/cluster/aws-standalone-istio-child.yaml
@@ -3,6 +3,8 @@ kind: ClusterDeployment
 metadata:
   name: aws-ue2-istio-child
   namespace: kcm-system
+  labels:
+    k0rdent.mirantis.com/istio-role: child
 spec:
   template: aws-standalone-cp-0-1-2
   credential: aws-cluster-identity-cred
@@ -18,5 +20,3 @@ spec:
     worker:
       instanceType: t3.medium
     workersNumber: 3
-    clusterLabels:
-      k0rdent.mirantis.com/istio-role: child

--- a/demo/cluster/aws-standalone-regional.yaml
+++ b/demo/cluster/aws-standalone-regional.yaml
@@ -3,6 +3,11 @@ kind: ClusterDeployment
 metadata:
   name: aws-ue2
   namespace: kcm-system
+  labels:
+    k0rdent.mirantis.com/kof-storage-secrets: "true"
+    k0rdent.mirantis.com/kof-aws-dns-secrets: "true"
+    k0rdent.mirantis.com/kof-cluster-role: regional
+    k0rdent.mirantis.com/kof-regional-domain: "aws-ue2.kof.example.com"
 spec:
   credential: aws-cluster-identity-cred
   template: aws-standalone-cp-0-1-2
@@ -18,11 +23,6 @@ spec:
     worker:
       instanceType: t3.medium
     workersNumber: 3
-    clusterLabels:
-      k0rdent.mirantis.com/kof-storage-secrets: "true"
-      k0rdent.mirantis.com/kof-aws-dns-secrets: "true"
-      k0rdent.mirantis.com/kof-cluster-role: regional
-      k0rdent.mirantis.com/kof-regional-domain: "aws-ue2.kof.example.com"
   serviceSpec:
     priority: 100
     services:

--- a/demo/cluster/aws-standalone-regional.yaml
+++ b/demo/cluster/aws-standalone-regional.yaml
@@ -21,6 +21,7 @@ spec:
     clusterLabels:
       k0rdent.mirantis.com/kof-storage-secrets: "true"
       k0rdent.mirantis.com/kof-aws-dns-secrets: "true"
+      k0rdent.mirantis.com/kof-cluster-role: regional
       k0rdent.mirantis.com/kof-regional-domain: "aws-ue2.kof.example.com"
   serviceSpec:
     priority: 100

--- a/kof-operator/internal/controller/clusterdeployment_config.go
+++ b/kof-operator/internal/controller/clusterdeployment_config.go
@@ -3,14 +3,14 @@ package controller
 import "gopkg.in/yaml.v3"
 
 type ClusterDeploymentConfig struct {
-	Region      string
-	Location    string
+	Region      string `yaml:"region"`
+	Location    string `yaml:"location"`
 	IdentityRef struct {
-		Region string
+		Region string `yaml:"region"`
 	} `yaml:"identityRef"`
 	VSphere struct {
-		Datacenter string
-	}
+		Datacenter string `yaml:"datacenter"`
+	} `yaml:"vsphere"`
 }
 
 func ReadClusterDeploymentConfig(configYaml []byte) (*ClusterDeploymentConfig, error) {

--- a/kof-operator/internal/controller/clusterdeployment_config.go
+++ b/kof-operator/internal/controller/clusterdeployment_config.go
@@ -4,6 +4,14 @@ import "gopkg.in/yaml.v3"
 
 type ClusterDeploymentConfig struct {
 	ClusterLabels map[string]string `yaml:"clusterLabels"`
+	Region        string
+	Location      string
+	IdentityRef   struct {
+		Region string
+	} `yaml:"identityRef"`
+	VSphere struct {
+		Datacenter string
+	}
 }
 
 func ReadClusterDeploymentConfig(configYaml []byte) (*ClusterDeploymentConfig, error) {

--- a/kof-operator/internal/controller/clusterdeployment_config.go
+++ b/kof-operator/internal/controller/clusterdeployment_config.go
@@ -3,10 +3,9 @@ package controller
 import "gopkg.in/yaml.v3"
 
 type ClusterDeploymentConfig struct {
-	ClusterLabels map[string]string `yaml:"clusterLabels"`
-	Region        string
-	Location      string
-	IdentityRef   struct {
+	Region      string
+	Location    string
+	IdentityRef struct {
 		Region string
 	} `yaml:"identityRef"`
 	VSphere struct {

--- a/kof-operator/internal/controller/clusterdeployment_controller.go
+++ b/kof-operator/internal/controller/clusterdeployment_controller.go
@@ -35,6 +35,7 @@ import (
 )
 
 const istioReleaseName = "kof-istio"
+const IstioRoleLabel = "k0rdent.mirantis.com/istio-role"
 
 // ClusterDeploymentReconciler reconciles a ClusterDeployment object
 type ClusterDeploymentReconciler struct {
@@ -89,22 +90,12 @@ func (r *ClusterDeploymentReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		return ctrl.Result{}, err
 	}
 
-	if clusterDeployment.Spec.Config == nil {
-		return ctrl.Result{}, nil
-	}
-
-	config, err := ReadClusterDeploymentConfig(clusterDeployment.Spec.Config.Raw)
-	if err != nil {
-		log.Error(err, "cannot read cluster config labels")
-		return ctrl.Result{}, err
-	}
-
-	if err := r.ReconcileKofClusterRole(ctx, clusterDeployment, config); err != nil {
+	if err := r.ReconcileKofClusterRole(ctx, clusterDeployment); err != nil {
 		log.Error(err, "cannot reconcile kof-cluster-role label")
 		return ctrl.Result{}, err
 	}
 
-	if istioRole, ok := config.ClusterLabels["k0rdent.mirantis.com/istio-role"]; ok {
+	if istioRole, ok := clusterDeployment.Labels[IstioRoleLabel]; ok {
 		if istioRole != "child" {
 			return ctrl.Result{}, nil
 		}


### PR DESCRIPTION
* Part of https://github.com/k0rdent/kof/issues/70
* Improvement of https://github.com/k0rdent/kof/pull/130
* Auto-discover regional cluster using AWS region, Azure location, etc - when child `ClusterDeployment` has no `kof-regional-cluster-name` label.
* Note this label may still be useful e.g. when there are multiple isolated apps in the same region and the same management cluster.
* Tested end-to-end.
* Proofs:
```
kubectl get clusterdeployment -n kcm-system dryzhkov-aws-standalone-child -o yaml | yq .metadata.labels

  k0rdent.mirantis.com/component: kcm
  k0rdent.mirantis.com/kof-cluster-role: child
  k0rdent.mirantis.com/kof-storage-secrets: "true"

  # NOTICE: There is no `kof-regional-cluster-name` here! It is auto-discovered.

kubectl get clusterdeployment -n kcm-system dryzhkov-aws-standalone-child -o yaml | yq .spec.config.region

  us-west-1

kubectl get clusterdeployment -n kcm-system dryzhkov-aws-standalone-regional -o yaml | yq .spec.config.region

  us-west-1

kubectl logs -n kof kof-mothership-kof-operator-6f7fc67447-vf82r

  INFO	Created child cluster ConfigMap	{...
  "ClusterDeployment": {"name":"dryzhkov-aws-standalone-child","namespace":"kcm-system"},
  "regional_cluster_name": "dryzhkov-aws-standalone-regional",
  "regional_domain": "dryzhkov-aws-standalone-regional.REDACTED"}

KUBECONFIG=dev/child-kubeconfig helm get values -n kof kof-collectors | grep aws

  clusterName: dryzhkov-aws-standalone-child
    endpoint: https://vmauth.dryzhkov-aws-standalone-regional.REDACTED/vls/insert/opentelemetry/v1/logs
    endpoint: https://vmauth.dryzhkov-aws-standalone-regional.REDACTED/vm/insert/0/prometheus/api/v1/write
    endpoint: https://jaeger.dryzhkov-aws-standalone-regional.REDACTED/collector
      defaultClusterId: dryzhkov-aws-standalone-child
        url: https://vmauth.dryzhkov-aws-standalone-regional.REDACTED/vm/select/0/prometheus
```
