### PR TITLE
Bump kind version for compatibility with kcm

### DIFF
--- a/.github/workflows/pr_test_helm_chart.yml
+++ b/.github/workflows/pr_test_helm_chart.yml
@@ -9,7 +9,7 @@ on:
       - reopened
     branches:
       - main
-      - release-*
+      - release/*
     paths:
       - "kof-operator/**"
       - "charts/**"

--- a/Makefile
+++ b/Makefile
@@ -177,7 +177,7 @@ export YQ
 ## Tool Versions
 HELM_VERSION ?= v3.15.1
 YQ_VERSION ?= v4.44.2
-KIND_VERSION ?= v0.23.0
+KIND_VERSION ?= v0.27.0
 
 .PHONY: yq
 yq: $(YQ) ## Download yq locally if necessary.


### PR DESCRIPTION
* Part of https://github.com/k0rdent/docs/issues/148

* Error after bump of `KIND_VERSION` in https://github.com/k0rdent/kcm/pull/1272 is:
  ```
  make dev-ms-deploy

    ...
    bin/kind-v0.23.0 load docker-image kof-operator-controller --name kcm-dev
    Image: "kof-operator-controller" with ID "sha256:REDACTED"
    not yet present on node "kcm-dev-control-plane", loading...
    ERROR: failed to detect containerd snapshotter
  ```

* Apply this PR and then update your existing kof repo:
  ```
  rm bin/kind*
  make kind

    Downloading sigs.k8s.io/kind@v0.27.0

  make dev-ms-deploy

    ...
    bin/kind-v0.27.0 load docker-image kof-operator-controller --name kcm-dev
    Image: "kof-operator-controller" with ID "sha256:REDACTED"
    not yet present on node "kcm-dev-control-plane", loading...
    cp -f charts/kof-mothership/values.yaml dev/mothership-values.yaml
    ...
  ```

* Also enables CI tests for `release/v1.2.3` branches.
