### PR TITLE
Make `kof-mothership` to use correct version of `kof-operator`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,7 +101,9 @@ helm-push: helm-package
 .PHONY: kof-operator-docker-build
 kof-operator-docker-build: ## Build kof-operator controller docker image
 	cd kof-operator && make docker-build
-	$(KIND) load docker-image kof-operator-controller --name $(KIND_CLUSTER_NAME)
+	@kof_version=v$$(yq .version $(TEMPLATES_DIR)/kof-mothership/Chart.yaml); \
+	$(CONTAINER_TOOL) tag kof-operator-controller kof-operator-controller:$$kof_version; \
+	$(KIND) load docker-image kof-operator-controller:$$kof_version --name $(KIND_CLUSTER_NAME)
 
 .PHONY: dev-operators-deploy
 dev-operators-deploy: dev ## Deploy kof-operators helm chart to the K8s cluster specified in ~/.kube/config

--- a/charts/kof-mothership/README.md
+++ b/charts/kof-mothership/README.md
@@ -41,7 +41,7 @@ A Helm chart that deploys Grafana, Promxy, and VictoriaMetrics.
 | kcm<br>.installTemplates | bool | `false` | Auto-installs `ServiceTemplate`-s like `cert-manager` and `kof-storage` to reference them from Regional and Child `ClusterDeployment`-s. |
 | kcm<br>.kof<br>.clusterProfiles | object | `{"kof-storage-secrets":{"create_secrets":true,`<br>`"matchLabels":{"k0rdent.mirantis.com/kof-storage-secrets":"true"},`<br>`"secrets":["storage-vmuser-credentials"]}}` | Names of secrets auto-distributed to clusters with matching labels. |
 | kcm<br>.kof<br>.operator<br>.enabled | bool | `true` |  |
-| kcm<br>.kof<br>.operator<br>.image | object | `{"pullPolicy":"IfNotPresent",`<br>`"repository":"ghcr.io/k0rdent/kof/kof-operator-controller",`<br>`"tag":"latest"}` | Image of the kof operator. |
+| kcm<br>.kof<br>.operator<br>.image | object | `{"pullPolicy":"IfNotPresent",`<br>`"repository":"ghcr.io/k0rdent/kof/kof-operator-controller"}` | Image of the kof operator. |
 | kcm<br>.kof<br>.operator<br>.rbac<br>.create | bool | `true` | Creates the `kof-mothership-kof-operator` cluster role and binds it to the service account of operator. |
 | kcm<br>.kof<br>.operator<br>.replicaCount | int | `1` |  |
 | kcm<br>.kof<br>.operator<br>.resources<br>.limits | object | `{"cpu":"100m",`<br>`"memory":"128Mi"}` | Maximum resources available for operator. |

--- a/charts/kof-mothership/templates/kof-operator/operator-deployment.yaml
+++ b/charts/kof-mothership/templates/kof-operator/operator-deployment.yaml
@@ -58,7 +58,7 @@ spec:
             value: "http://{{ .Release.Name }}-promxy:{{ .Values.promxy.service.servicePort }}/-/reload"
           - name: "RELEASE_NAMESPACE"
             value: {{ .Release.Namespace }}
-        image: "{{ .Values.kcm.kof.operator.image.repository }}:{{ .Values.kcm.kof.operator.image.tag }}"
+        image: "{{ .Values.kcm.kof.operator.image.repository }}:v{{ .Chart.Version }}"
         imagePullPolicy: {{ .Values.kcm.kof.operator.image.pullPolicy }}
         livenessProbe:
           failureThreshold: 6

--- a/charts/kof-mothership/values.yaml
+++ b/charts/kof-mothership/values.yaml
@@ -68,7 +68,6 @@ kcm:
       # -- Image of the kof operator.
       image:
         repository: ghcr.io/k0rdent/kof/kof-operator-controller
-        tag: "latest"
         pullPolicy: IfNotPresent
 
       resources:

--- a/docs/DEV.md
+++ b/docs/DEV.md
@@ -180,12 +180,9 @@ This method does not help when you need a real cluster, but may help with other 
 * [x] Push, e.g: `git commit -am 'Release candidate: kof v0.2.0-rc1' && git push -u origin v0.2.0-rc1`
 * [x] Create a PR, selecting the base branch e.g: `release/v0.2.0`
 * [x] Get this PR approved and merged to e.g: `release/v0.2.0`
-* [x] Open https://github.com/k0rdent/kof/pulls and click:
-  * New pull request.
-  * base - `main`
-  * compare - e.g: `release/v0.2.0`
-  * Create pull request e.g: `Syncing changes from release/v0.2.0 to main`
-  * Get it approved and merged.
+* [x] If there are changes in the release branch,
+  then `git cherry-pick` them and create a PR to the `main` branch,
+  e.g: `Syncing changes from release/v0.2.0 to main`
 * [x] Open https://github.com/k0rdent/kof/releases and click:
   * Draft a new release.
   * Choose a tag - Find or create - e.g: `v0.2.0-rc1` - Create new tag.
@@ -194,7 +191,7 @@ This method does not help when you need a real cluster, but may help with other 
   * Generate release notes.
   * Set as a pre-release.
   * Publish release.
-* [ ] Open https://github.com/k0rdent/kof/actions and verify CI created the artifacts.
+* [x] Open https://github.com/k0rdent/kof/actions and verify CI created the artifacts.
 * [ ] Update the docs to use RC artifacts: https://docs.k0rdent.io/next/admin/kof/
 * [ ] Test end-to-end by the docs.
 * [ ] Add more release candidates using `git cherry-pick` of what blocks the release only.


### PR DESCRIPTION
* [.github/workflows/release_operator.yml](https://github.com/k0rdent/kof/blob/9a0fa75ec56aac4dd1fe902a9f2e007cbc69bd88/.github/workflows/release_operator.yml#L58) releases both:
  * `ghcr.io/k0rdent/kof/kof-operator-controller:v0.2.0-rc1` and
  * `ghcr.io/k0rdent/kof/kof-operator-controller:latest` [here](https://github.com/k0rdent/kof/actions/runs/14065208037/job/39385813230#step:8:447), and it is OK,
* but the [kof-operator/operator-deployment.yaml](https://github.com/k0rdent/kof/blob/9a0fa75ec56aac4dd1fe902a9f2e007cbc69bd88/charts/kof-mothership/templates/kof-operator/operator-deployment.yaml#L61) should not use [tag: "latest"](https://github.com/k0rdent/kof/blob/9a0fa75ec56aac4dd1fe902a9f2e007cbc69bd88/charts/kof-mothership/values.yaml#L71),
* because this will break installations of kof v0.2.0 when we release backward incompatible kof-operator, e.g. in v0.3.0.
* This PR makes `kof-mothership` to use correct version of `kof-operator` both in prod and for `make`-based local deployment:

```
kubectl get deploy -n kof kof-mothership-kof-operator -o yaml \
| yq .spec.template.spec.containers[].image

  kof-operator-controller:v0.2.0-rc1

kubectl logs -n kof deploy/kof-mothership-kof-operator

  2025-03-26T12:39:51Z	INFO	setup	starting manager...
```
