### PR TITLE
Patch of values via annotation

### DIFF
--- a/charts/kof-mothership/templates/grafana/grafana.yaml
+++ b/charts/kof-mothership/templates/grafana/grafana.yaml
@@ -49,7 +49,7 @@ spec:
     metadata:
       annotations:
         cert-manager.io/cluster-issuer: {{ include "cert-manager.cluster-issuer.name" $ }}
-{{- include "cert-manager.acme-annotation" $ | indent 8 }}
+        {{- include "cert-manager.acme-annotation" $ | nindent 8 }}
     spec:
       ingressClassName: nginx
       rules:

--- a/charts/kof-mothership/templates/sveltos/regional-multi-cluster-service.yaml
+++ b/charts/kof-mothership/templates/sveltos/regional-multi-cluster-service.yaml
@@ -39,7 +39,7 @@ spec:
             {{`{{ $metricsHost := $metricsEnabled | ternary (printf "vmauth.%s" $regionalDomain) "" }}`}}
             {{`{{ $grafanaHost := printf "grafana.%s" $regionalDomain }}`}}
             {{`{{ $certEmail := index .Cluster.metadata.annotations "k0rdent.mirantis.com/kof-cert-email" }}`}}
-            {{`{{ $patch := index .Cluster.metadata.annotations "k0rdent.mirantis.com/kof-storage-values" | default "{}" | mustFromJson }}`}}
+            {{`{{ $patch := index .Cluster.metadata.annotations "k0rdent.mirantis.com/kof-storage-values" | default "{}" | fromYaml }}`}}
             {{`{{ $values := printf `}}`{{`
           global:
             storageClass: %q

--- a/charts/kof-mothership/templates/sveltos/regional-multi-cluster-service.yaml
+++ b/charts/kof-mothership/templates/sveltos/regional-multi-cluster-service.yaml
@@ -31,35 +31,43 @@ spec:
         template: kof-storage-{{ .Chart.Version | replace "." "-" }}
         values: |
           tmp: |
-            {{`{{ $metricsAreCustom := index .Cluster.metadata.annotations "k0rdent.mirantis.com/kof-write-metrics-endpoint" }}`}}
-            {{`{{ $tracesAreCustom := index .Cluster.metadata.annotations "k0rdent.mirantis.com/kof-write-traces-endpoint" }}`}}
-            {{`{{ $regionalDomain := index .Cluster.metadata.annotations "k0rdent.mirantis.com/kof-regional-domain" }}`}}
             {{`{{ $storageClass := index .Cluster.metadata.annotations "k0rdent.mirantis.com/kof-storage-class" | default "" }}`}}
+            {{`{{ $regionalDomain := index .Cluster.metadata.annotations "k0rdent.mirantis.com/kof-regional-domain" }}`}}
+            {{`{{ $tracesEnabled := not (index .Cluster.metadata.annotations "k0rdent.mirantis.com/kof-write-traces-endpoint") }}`}}
+            {{`{{ $tracesHost := $tracesEnabled | ternary (printf "jaeger.%s" $regionalDomain) "" }}`}}
+            {{`{{ $metricsEnabled := not (index .Cluster.metadata.annotations "k0rdent.mirantis.com/kof-write-metrics-endpoint") }}`}}
+            {{`{{ $metricsHost := $metricsEnabled | ternary (printf "vmauth.%s" $regionalDomain) "" }}`}}
+            {{`{{ $grafanaHost := printf "grafana.%s" $regionalDomain }}`}}
+            {{`{{ $certEmail := index .Cluster.metadata.annotations "k0rdent.mirantis.com/kof-cert-email" }}`}}
+            {{`{{ $patch := index .Cluster.metadata.annotations "k0rdent.mirantis.com/kof-storage-values" | default "{}" | mustFromJson }}`}}
+            {{`{{ $values := printf `}}`{{`
           global:
-            storageClass: "{{`{{ $storageClass }}`}}"
+            storageClass: %q
           victoria-logs-single:
             server:
               persistentVolume:
-                storageClassName: "{{`{{ $storageClass }}`}}"
+                storageClassName: %q
           external-dns:
             enabled: true
           jaeger:
             ingress:
-              enabled: {{`{{ not $tracesAreCustom }}`}}
-              host: {{`{{ if $tracesAreCustom }}""{{ else }}jaeger.{{ $regionalDomain }}{{ end }}`}}
+              enabled: %t
+              host: %q
           victoriametrics:
             vmauth:
               ingress:
-                enabled: {{`{{ not $metricsAreCustom }}`}}
-                host: {{`{{ if $metricsAreCustom }}""{{ else }}vmauth.{{ $regionalDomain }}{{ end }}`}}
+                enabled: %t
+                host: %q
             security:
               username_key: username
               password_key: password
               credentials_secret_name: storage-vmuser-credentials
           grafana:
             ingress:
-              host: grafana.{{`{{ $regionalDomain }}`}}
+              host: %q
             security:
               credentials_secret_name: grafana-admin-credentials
           cert-manager:
-            email: {{`{{ index .Cluster.metadata.annotations "k0rdent.mirantis.com/kof-cert-email" }}`}}
+            email: %q
+            `}}`{{` $storageClass $storageClass $tracesEnabled $tracesHost $metricsEnabled $metricsHost $grafanaHost $certEmail | fromYaml }}`}}
+          {{`{{ mergeOverwrite $values $patch | toYaml | nindent 4 }}`}}

--- a/charts/kof-storage/templates/grafana/grafana.yaml
+++ b/charts/kof-storage/templates/grafana/grafana.yaml
@@ -55,7 +55,7 @@ spec:
     metadata:
       annotations:
         cert-manager.io/cluster-issuer: {{ include "cert-manager.cluster-issuer.name" $ }}
-{{- include "cert-manager.acme-annotation" $ | indent 8 }}
+        {{- include "cert-manager.acme-annotation" $ | nindent 8 }}
     spec:
       ingressClassName: nginx
       rules:

--- a/charts/kof-storage/templates/jaeger/ingress.yaml
+++ b/charts/kof-storage/templates/jaeger/ingress.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   annotations:
     cert-manager.io/cluster-issuer: {{ include "cert-manager.cluster-issuer.name" $ }}
-{{- include "cert-manager.acme-annotation" $ | indent 4 }}
+    {{- include "cert-manager.acme-annotation" $ | nindent 4 }}
     nginx.ingress.kubernetes.io/use-regex: "true"
     nginx.ingress.kubernetes.io/enable-rewrite-log: "true"
     nginx.ingress.kubernetes.io/rewrite-target: /$2

--- a/charts/kof-storage/templates/victoria/vmauth.yaml
+++ b/charts/kof-storage/templates/victoria/vmauth.yaml
@@ -9,7 +9,7 @@ spec:
   ingress:
     annotations:
       cert-manager.io/cluster-issuer: {{ include "cert-manager.cluster-issuer.name" $ }}
-{{- include "cert-manager.acme-annotation" $ | indent 6 }}
+      {{- include "cert-manager.acme-annotation" $ | nindent 6 }}
     class_name: nginx
     tlsHosts:
     - {{ .Values.victoriametrics.vmauth.ingress.host | quote }}

--- a/demo/cluster/aws-standalone-child.yaml
+++ b/demo/cluster/aws-standalone-child.yaml
@@ -9,7 +9,7 @@ metadata:
     # Optional, auto-detected by region:
     # k0rdent.mirantis.com/kof-regional-cluster-name: aws-ue2
 spec:
-  template: aws-standalone-cp-0-1-5
+  template: aws-standalone-cp-0-1-6
   credential: aws-cluster-identity-cred
   config:
     clusterIdentity:

--- a/demo/cluster/aws-standalone-istio-child.yaml
+++ b/demo/cluster/aws-standalone-istio-child.yaml
@@ -7,7 +7,7 @@ metadata:
     k0rdent.mirantis.com/istio-role: child
     k0rdent.mirantis.com/kof-cluster-role: child
 spec:
-  template: aws-standalone-cp-0-1-5
+  template: aws-standalone-cp-0-1-6
   credential: aws-cluster-identity-cred
   config:
     clusterIdentity:

--- a/demo/cluster/aws-standalone-istio-regional.yaml
+++ b/demo/cluster/aws-standalone-istio-regional.yaml
@@ -8,8 +8,11 @@ metadata:
     k0rdent.mirantis.com/kof-cluster-role: regional
 spec:
   credential: aws-cluster-identity-cred
-  template: aws-standalone-cp-0-1-2
+  template: aws-standalone-cp-0-1-6
   config:
+    clusterAnnotations:
+      # `template: aws-standalone-cp` provides a default storage class:
+      # k0rdent.mirantis.com/kof-storage-class: ebs-csi-default-sc
     clusterIdentity:
       name: aws-cluster-identity
       namespace: kcm-system

--- a/demo/cluster/aws-standalone-regional.yaml
+++ b/demo/cluster/aws-standalone-regional.yaml
@@ -9,11 +9,14 @@ metadata:
     k0rdent.mirantis.com/kof-cluster-role: regional
 spec:
   credential: aws-cluster-identity-cred
-  template: aws-standalone-cp-0-1-5
+  template: aws-standalone-cp-0-1-6
   config:
     clusterAnnotations:
       k0rdent.mirantis.com/kof-regional-domain: aws-ue2.kof.example.com
       k0rdent.mirantis.com/kof-cert-email: mail@example.com
+
+      # Any custom values, e.g. https://docs.victoriametrics.com/helm/victorialogs-single/index.html#parameters
+      k0rdent.mirantis.com/kof-storage-values: '{"victoria-logs-single": {"server": {"replicaCount": 2}}}'
 
       # `template: aws-standalone-cp` provides a default storage class:
       # k0rdent.mirantis.com/kof-storage-class: ebs-csi-default-sc

--- a/demo/cluster/aws-standalone-regional.yaml
+++ b/demo/cluster/aws-standalone-regional.yaml
@@ -16,7 +16,10 @@ spec:
       k0rdent.mirantis.com/kof-cert-email: mail@example.com
 
       # Any custom values, e.g. https://docs.victoriametrics.com/helm/victorialogs-single/index.html#parameters
-      k0rdent.mirantis.com/kof-storage-values: '{"victoria-logs-single": {"server": {"replicaCount": 2}}}'
+      k0rdent.mirantis.com/kof-storage-values: |
+        victoria-logs-single:
+          server:
+            replicaCount: 2
 
       # `template: aws-standalone-cp` provides a default storage class:
       # k0rdent.mirantis.com/kof-storage-class: ebs-csi-default-sc


### PR DESCRIPTION
* Part of https://github.com/k0rdent/docs/issues/148
* Creating a new annotation for every possible custom value is not a scalable option,
  so we decided to create generic patch annotations. The first one:
  ```
  k0rdent.mirantis.com/kof-storage-values: |
    victoria-logs-single:
      server:
        replicaCount: 2
  ```
* Tested:
  ```
  KUBECONFIG=dev/regional-kubeconfig helm get values -n kof kof-storage

    USER-SUPPLIED VALUES:
    cert-manager:
      email: denisr@denisr.com
    external-dns:
      enabled: true
    global:
      storageClass: ""
    grafana:
      ingress:
        host: grafana.dryzhkov-aws-standalone-regional.REDACTED
      security:
        credentials_secret_name: grafana-admin-credentials
    jaeger:
      ingress:
        enabled: true
        host: jaeger.dryzhkov-aws-standalone-regional.REDACTED
    tmp: ""
    victoria-logs-single:
      server:
        persistentVolume:
          storageClassName: ""
        replicaCount: 2
    victoriametrics:
      security:
        credentials_secret_name: storage-vmuser-credentials
        password_key: password
        username_key: username
      vmauth:
        ingress:
          enabled: true
          host: vmauth.dryzhkov-aws-standalone-regional.REDACTED

  KUBECONFIG=dev/regional-kubeconfig kubectl get pod -n kof | grep victoria-logs-single

    kof-storage-victoria-logs-single-server-0                1/1     Running   0          22m
    kof-storage-victoria-logs-single-server-1                1/1     Running   0          21m
  ```
* This PR should be replicated to `charts/kof-istio/templates/kof-regional-cluster-profile.yaml` too - after the release deadline.
