### PR TITLE
Fix upgrade of kof-child-cluster

### DIFF
--- a/charts/kof-mothership/templates/sveltos/child-cluster-profile.yaml
+++ b/charts/kof-mothership/templates/sveltos/child-cluster-profile.yaml
@@ -2,6 +2,11 @@ apiVersion: config.projectsveltos.io/v1beta1
 kind: ClusterProfile
 metadata:
   name: kof-child-cluster
+  labels:
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    meta.helm.sh/release-name: {{ .Release.Name }}
+    meta.helm.sh/release-namespace: {{ .Release.Namespace }}
 spec:
   clusterSelector:
     matchLabels:


### PR DESCRIPTION
Bug report by @aglarendil:
> I tried upgrading kof-mothership charts and bumped into
```
Pulled: 10.244.0.1:30500/charts/kof-mothership:0.2.0-rc1
Digest: sha256:46c473871afabdb54034e1e05b6c4ae1433e6b75905af388f325fe64fbc55be8
Error: UPGRADE FAILED: Unable to continue with update:
ClusterProfile "kof-child-cluster" in namespace "" exists
and cannot be imported into the current release: invalid ownership metadata;

label validation error: missing key "app.kubernetes.io/managed-by": must be set to "Helm";
annotation validation error: missing key "meta.helm.sh/release-name": must be set to "kof-mothership";
annotation validation error: missing key "meta.helm.sh/release-namespace": must be set to "kof"
```
> so the MCS => ClusterProfile and back change breaks upgrades

Checking:
* Initially the `kof-child-cluster` was created as a `ClusterProfile` in https://github.com/k0rdent/kof/pull/101
* Then https://github.com/k0rdent/kof/pull/109
* Then reverted it in https://github.com/k0rdent/kof/pull/130
* Looks like Helm gets confused on upgrade,
  so we'd better add the labels and annotations mentioned above.
* Smoke-testing the changes:

```
kubectl get clusterprofile -n kof kof-child-cluster -o yaml | yq .metadata

  annotations:
    meta.helm.sh/release-name: kof-mothership
    meta.helm.sh/release-namespace: kof
  creationTimestamp: "2025-03-27T11:42:31Z"
  finalizers:
    - clusterprofilefinalizer.projectsveltos.io
  generation: 1
  labels:
    app.kubernetes.io/managed-by: Helm
  name: kof-child-cluster
  resourceVersion: "516169"
  uid: cd4cb667-9e8b-424a-910d-d04ede094587
```
