### PR TITLE
Fix yq usage in makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,7 +101,7 @@ helm-push: helm-package
 .PHONY: kof-operator-docker-build
 kof-operator-docker-build: ## Build kof-operator controller docker image
 	cd kof-operator && make docker-build
-	@kof_version=v$$(yq .version $(TEMPLATES_DIR)/kof-mothership/Chart.yaml); \
+	@kof_version=v$$($(YQ) .version $(TEMPLATES_DIR)/kof-mothership/Chart.yaml); \
 	$(CONTAINER_TOOL) tag kof-operator-controller kof-operator-controller:$$kof_version; \
 	$(KIND) load docker-image kof-operator-controller:$$kof_version --name $(KIND_CLUSTER_NAME)
 


### PR DESCRIPTION
YQ should be used from cli-install command, not assume it's globally available

```
/bin/sh: yq: command not found
Image: "kof-operator-controller:v" with ID "sha256:d1dd70dac2901d902c33f276315c51edb0395aa84f416bb9940145a545893cbe" not yet present on node "kcm-dev-control-plane", loading...
```