### PR TITLE
Support plain-text local BYOT OCI Repo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,9 +75,10 @@ helm-push: helm-package
 	@if [ ! $(REGISTRY_IS_OCI) ]; then \
 	    repo_flag="--repo"; \
 	fi; \
-        if [ $(REGISTRY_PLAIN_HTTP) = "true" ];   then \
-            plain_http_flag="--plain-http"; \
-        fi; \
+	if [ $(REGISTRY_PLAIN_HTTP) = "true" ]; \
+	then plain_http_flag="--plain-http"; \
+	else plain_http_flag=""; \
+	fi; \
 	for chart in $(CHARTS_PACKAGE_DIR)/*.tgz; do \
 		base=$$(basename $$chart .tgz); \
 		chart_version=$$(echo $$base | grep -o "v\{0,1\}[0-9]\+\.[0-9]\+\.[0-9].*"); \

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ REGISTRY_NAME ?= kof
 REGISTRY_PORT ?= 8080
 REGISTRY_REPO ?= http://127.0.0.1:$(REGISTRY_PORT)
 REGISTRY_IS_OCI = $(shell echo $(REGISTRY_REPO) | grep -q oci && echo true || echo false)
+REGISTRY_PLAIN_HTTP ?= false
 
 TEMPLATE_FOLDERS = $(patsubst $(TEMPLATES_DIR)/%,%,$(wildcard $(TEMPLATES_DIR)/*))
 
@@ -42,7 +43,6 @@ endef
 
 dev:
 	mkdir -p dev
-
 lint-chart-%:
 	$(HELM) dependency update $(TEMPLATES_DIR)/$*
 	$(HELM) lint --strict $(TEMPLATES_DIR)/$* --set global.lint=true
@@ -75,6 +75,9 @@ helm-push: helm-package
 	@if [ ! $(REGISTRY_IS_OCI) ]; then \
 	    repo_flag="--repo"; \
 	fi; \
+        if [ $(REGISTRY_PLAIN_HTTP) = "true" ];   then \
+            plain_http_flag="--plain-http"; \
+        fi; \
 	for chart in $(CHARTS_PACKAGE_DIR)/*.tgz; do \
 		base=$$(basename $$chart .tgz); \
 		chart_version=$$(echo $$base | grep -o "v\{0,1\}[0-9]\+\.[0-9]\+\.[0-9].*"); \
@@ -90,7 +93,7 @@ helm-push: helm-package
 		fi; \
 		if $(REGISTRY_IS_OCI); then \
 			echo "Pushing $$chart to $(REGISTRY_REPO)"; \
-			$(HELM) push "$$chart" $(REGISTRY_REPO); \
+			$(HELM) push $${plain_http_flag} "$$chart" $(REGISTRY_REPO); \
 		else \
 			$(HELM) repo add kcm $(REGISTRY_REPO); \
 			echo "Pushing $$chart to $(REGISTRY_REPO)"; \


### PR DESCRIPTION
Sometimes it is handy to have a local repo for local sandboxes. It will be plain-text by default, so let's keep it like that and allow a user to specify it.