### PR TITLE
Remove pre-upgrade hook from service templates

### DIFF
--- a/charts/kof-mothership/templates/k0rdent/catalog/_helpers.tpl
+++ b/charts/kof-mothership/templates/k0rdent/catalog/_helpers.tpl
@@ -12,7 +12,7 @@ metadata:
   annotations:
     helm.sh/resource-policy: keep
     # To avoid `ServiceTemplate not found` in `MultiClusterService/ClusterDeployment`:
-    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook: pre-install
 spec:
   helm:
     chartSpec:

--- a/charts/kof-mothership/templates/k0rdent/kof/svctmpl.yaml
+++ b/charts/kof-mothership/templates/k0rdent/kof/svctmpl.yaml
@@ -8,7 +8,7 @@ metadata:
   namespace: {{ $.Values.kcm.namespace }}
   annotations:
     # To avoid `ServiceTemplate not found` in `MultiClusterService/ClusterDeployment`:
-    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook: pre-install
     helm.sh/resource-policy: keep
 spec:
   helm:


### PR DESCRIPTION
pre-upgrade hook cannot be used for service templates as it will be deleted on next upgrade due to default
https://helm.sh/docs/topics/charts_hooks/#hook-deletion-policies annotation.

It causes
```
W0327 16:59:21.424244    8730 warnings.go:70] The kof-storage-0-2-0-rc2 ServiceTemplate object can't be removed if MultiClusterService objects [kof-regional-cluster] referencing it still exist
Error: UPGRADE FAILED: pre-upgrade hooks failed: admission webhook "validation.servicetemplate.k0rdent.mirantis.com" denied the request: template deletion is forbidden
```