### PR TITLE
Add values to override for child and regional cluster profiles

### DIFF
--- a/charts/kof-child/templates/child-multi-cluster-service.yaml
+++ b/charts/kof-child/templates/child-multi-cluster-service.yaml
@@ -44,6 +44,9 @@ spec:
           {{`{{ $logsEndpoint := getField "ChildConfig" "data.write_logs_endpoint" }}`}}
           {{`{{ $tracesEndpoint := getField "ChildConfig" "data.write_traces_endpoint" }}`}}
           {{`{{ $patch := index .Cluster.metadata.annotations "k0rdent.mirantis.com/kof-collectors-values" | default "{}" | fromYaml }}`}}
+          {{`{{ $collectorsValues := `}}`
+          {{ .Values.collectors | toYaml }}
+          ` | fromYaml {{`}}`}}
           {{`{{ $values := printf `}}`{{`
           global:
             clusterName: %q
@@ -72,4 +75,4 @@ spec:
               exporter:
                 defaultClusterId: %q
           `}}`{{` $childClusterName $writeMetricsEndpoint $logsEndpoint $tracesEndpoint $readMetricsEndpoint $childClusterName | fromYaml }}`}}
-          {{`{{ mergeOverwrite $values $patch | toYaml | nindent 4 }}`}}
+          {{`{{ mergeOverwrite $values $collectorsValues $patch | toYaml | nindent 4 }}`}}

--- a/charts/kof-child/values.yaml
+++ b/charts/kof-child/values.yaml
@@ -3,3 +3,5 @@ cert-manager:
 
 kcm:
   namespace: kcm-system
+
+collectors: {}

--- a/charts/kof-istio/templates/kof-child-cluster-profile.yaml
+++ b/charts/kof-istio/templates/kof-child-cluster-profile.yaml
@@ -43,6 +43,9 @@ spec:
         {{`{{ $patch := index .Cluster.metadata.annotations "k0rdent.mirantis.com/kof-collectors-values" | default "{}" | fromYaml }}`}}
         {{`{{ $childClusterName := .Cluster.metadata.name }}`}}
         {{`{{ $regionalClusterName := getField "ChildConfig" "data.regional_cluster_name" }}`}}
+        {{`{{ $collectorsValues := `}}`
+        {{ .Values.collectors | toYaml }}
+        ` | fromYaml {{`}}`}}
         {{`{{ $values := printf `}}`{{`
         global:
           clusterName: %q
@@ -64,5 +67,5 @@ spec:
             exporter:
               defaultClusterId: %q
           `}}`{{` $childClusterName $regionalClusterName $regionalClusterName $regionalClusterName $regionalClusterName $childClusterName | fromYaml }}`}}
-        {{`{{ mergeOverwrite $values $patch | toYaml | nindent 4 }}`}}
+        {{`{{ mergeOverwrite $values $collectorsValues $patch | toYaml | nindent 4 }}`}}
 {{- end }}

--- a/charts/kof-istio/templates/kof-regional-cluster-profile.yaml
+++ b/charts/kof-istio/templates/kof-regional-cluster-profile.yaml
@@ -38,6 +38,9 @@ spec:
         {{`{{ $storageClass := index .Cluster.metadata.annotations "k0rdent.mirantis.com/kof-storage-class" | default "" }}`}}
         {{`{{ $clusterName := .Cluster.metadata.name }}`}}
         {{`{{ $patch := index .Cluster.metadata.annotations "k0rdent.mirantis.com/kof-storage-values" | default "{}" | fromYaml }}`}}
+        {{`{{ $storageValues := `}}`
+        {{ .Values.storage | toYaml }}
+        ` | fromYaml {{`}}`}}
         {{`{{ $values := printf `}}`{{`
         global:
           clusterName: %q
@@ -59,5 +62,5 @@ spec:
           dashboard:
             istio_dashboard_enabled: true
           `}}`{{` $clusterName $storageClass $storageClass | fromYaml }}`}}
-        {{`{{ mergeOverwrite $values $patch | toYaml | nindent 4 }}`}}
+        {{`{{ mergeOverwrite $values $storageValues $patch | toYaml | nindent 4 }}`}}
 {{- end }}

--- a/charts/kof-istio/values.yaml
+++ b/charts/kof-istio/values.yaml
@@ -75,4 +75,6 @@ istiod:
 gateway:
   enabled: false
   name: istio-eastwestgateway
-  
+storage: {}
+collectors: {}
+

--- a/charts/kof-regional/templates/regional-multi-cluster-service.yaml
+++ b/charts/kof-regional/templates/regional-multi-cluster-service.yaml
@@ -49,6 +49,9 @@ spec:
           {{`{{ $grafanaHost := printf "grafana.%s" $regionalDomain }}`}}
           {{`{{ $certEmail := index .Cluster.metadata.annotations "k0rdent.mirantis.com/kof-cert-email" }}`}}
           {{`{{ $patch := index .Cluster.metadata.annotations "k0rdent.mirantis.com/kof-storage-values" | default "{}" | fromYaml }}`}}
+          {{`{{ $storageValues := `}}`
+          {{ .Values.storage | toYaml }}
+          ` | fromYaml {{`}}`}}
           {{`{{ $values := printf `}}`{{`
           global:
             storageClass: %q
@@ -79,4 +82,4 @@ spec:
           cert-manager:
             email: %q
           `}}`{{` $storageClass $storageClass $tracesEnabled $tracesHost $metricsEnabled $metricsHost $grafanaHost $certEmail | fromYaml }}`}}
-          {{`{{ mergeOverwrite $values $patch | toYaml | nindent 4 }}`}}
+          {{`{{ mergeOverwrite $values $storageValues $patch | toYaml | nindent 4 }}`}}

--- a/charts/kof-regional/values.yaml
+++ b/charts/kof-regional/values.yaml
@@ -3,3 +3,5 @@ cert-manager:
 
 ingress-nginx:
   enabled: true
+
+storage: {}


### PR DESCRIPTION
Part of https://github.com/k0rdent/kof/issues/180

This allow to specify values for collector and storage helm charts that passed to ClusterProfiles (i.e. applied to all clusters)