### PR TITLE
Protecting from CVE-2019-11248 in VMAuth which exposes `/debug/pprof` and other endpoints

### DIFF
--- a/charts/kof-storage/templates/victoria/vmauth.yaml
+++ b/charts/kof-storage/templates/victoria/vmauth.yaml
@@ -21,7 +21,6 @@ spec:
 
   # Protecting from CVE-2019-11248 in VMAuth which exposes `/debug/pprof`
   # and a lot of other endpoints listed in https://docs.victoriametrics.com/#security
-  {{- if not .Values.global.lint }}
   extraArgs:
     envflag.enable: "true"
     envflag.prefix: "vm_"
@@ -36,7 +35,6 @@ spec:
         secretKeyRef:
           name: {{ .Values.victoriametrics.vmauth.credentials.credentials_secret_name }}
           key: {{ .Values.victoriametrics.vmauth.credentials.password_key }}
-  {{- end }}
 {{- end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
* Protecting from CVE-2019-11248 in VMAuth which exposes `/debug/pprof`
* and a lot of other endpoints listed in https://docs.victoriametrics.com/#security
* Tested after the fix:
```
curl -v https://vmauth.dryzhkov-aws-standalone-regional.REDACTED/health

  HTTP/2 200

curl -v https://vmauth.dryzhkov-aws-standalone-regional.REDACTED/debug/pprof

  HTTP/2 401

```
* Grafana shows data from the child cluster, OK.
