### PR TITLE
fix: Few fixes for kof v0.2.1

### DIFF
--- a/charts/kof-child/Chart.yaml
+++ b/charts/kof-child/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: kof-child
 description: A Helm chart that installs multi cluster service template for kof child clusters
-version: "0.2.0"
-appVersion: "0.2.0"
+version: "0.2.1"
+appVersion: "0.2.1"

--- a/charts/kof-child/templates/child-multi-cluster-service.yaml
+++ b/charts/kof-child/templates/child-multi-cluster-service.yaml
@@ -24,7 +24,7 @@ spec:
       {{- if (index .Values "cert-manager" "enabled") }}
       - name: cert-manager
         namespace: {{ .Release.Namespace }}
-        template: cert-manager-1-16-2
+        template: cert-manager-1-16-4
         values: |
           crds:
             enabled: true

--- a/charts/kof-collectors/Chart.yaml
+++ b/charts/kof-collectors/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: kof-collectors
 description: A Helm chart that deploys OpenTelemetryCollector resources
-version: "0.2.0"
-appVersion: "0.2.0"
+version: "0.2.1"
+appVersion: "0.2.1"
 dependencies:
   - name: prometheus-node-exporter
     version: "4.39.*"

--- a/charts/kof-istio/Chart.yaml
+++ b/charts/kof-istio/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: kof-istio
 description: A Helm chart that deploys Istio with multicluster multinetwork setup
-version: "0.2.0"
-appVersion: "0.2.0"
+version: "0.2.1"
+appVersion: "0.2.1"
 dependencies:
   - name: cert-manager-istio-csr
     version: "0.14.0"

--- a/charts/kof-istio/templates/child-cluster-profiles.yaml
+++ b/charts/kof-istio/templates/child-cluster-profiles.yaml
@@ -64,8 +64,8 @@ spec:
             enabled: true
 
     - repositoryName:   {{ .Values.kcm.kof.repo.name }}
-      repositoryURL:    {{ .Values.kcm.kof.repo.url }}
-      {{- include "repo_chart_name" (dict "name" "kof-istio" "type" .Values.kcm.kof.repo.type "repo" .Values.kcm.kof.repo.name) | nindent 6 }}
+      repositoryURL:    {{ .Values.kcm.kof.repo.spec.url }}
+      {{- include "repo_chart_name" (dict "name" "kof-istio" "type" .Values.kcm.kof.repo.spec.type "repo" .Values.kcm.kof.repo.name) | nindent 6 }}
       chartVersion:     {{ .Chart.Version }}
       releaseName:      kof-istio
       releaseNamespace: {{ .Release.Namespace }}

--- a/charts/kof-istio/templates/kof-child-cluster-profile.yaml
+++ b/charts/kof-istio/templates/kof-child-cluster-profile.yaml
@@ -25,16 +25,16 @@ spec:
   helmCharts:
 
     - repositoryName:   {{ .Values.kcm.kof.repo.name }}
-      repositoryURL:    {{ .Values.kcm.kof.repo.url }}
-      {{- include "repo_chart_name" (dict "name" "kof-operators" "type" .Values.kcm.kof.repo.type "repo" .Values.kcm.kof.repo.name) | nindent 6 }}
+      repositoryURL:    {{ .Values.kcm.kof.repo.spec.url }}
+      {{- include "repo_chart_name" (dict "name" "kof-operators" "type" .Values.kcm.kof.repo.spec.type "repo" .Values.kcm.kof.repo.name) | nindent 6 }}
       chartVersion:     {{ .Chart.Version }}
       releaseName:      kof-operators
       releaseNamespace: {{ .Values.kof.namespace }}
       helmChartAction:  Install
 
     - repositoryName:   {{ .Values.kcm.kof.repo.name }}
-      repositoryURL:    {{ .Values.kcm.kof.repo.url }}
-      {{- include "repo_chart_name" (dict "name" "kof-collectors" "type" .Values.kcm.kof.repo.type "repo" .Values.kcm.kof.repo.name) | nindent 6 }}
+      repositoryURL:    {{ .Values.kcm.kof.repo.spec.url }}
+      {{- include "repo_chart_name" (dict "name" "kof-collectors" "type" .Values.kcm.kof.repo.spec.type "repo" .Values.kcm.kof.repo.name) | nindent 6 }}
       chartVersion:     {{ .Chart.Version }}
       releaseName:      kof-collectors
       releaseNamespace: {{ .Values.kof.namespace }}

--- a/charts/kof-istio/templates/kof-regional-cluster-profile.yaml
+++ b/charts/kof-istio/templates/kof-regional-cluster-profile.yaml
@@ -28,8 +28,8 @@ spec:
           istio: eastwestgateway
 
     - repositoryName:   {{ .Values.kcm.kof.repo.name }}
-      repositoryURL:    {{ .Values.kcm.kof.repo.url }}
-      {{- include "repo_chart_name" (dict "name" "kof-storage" "type" .Values.kcm.kof.repo.type "repo" .Values.kcm.kof.repo.name) | nindent 6 }}
+      repositoryURL:    {{ .Values.kcm.kof.repo.spec.url }}
+      {{- include "repo_chart_name" (dict "name" "kof-storage" "type" .Values.kcm.kof.repo.spec.type "repo" .Values.kcm.kof.repo.name) | nindent 6 }}
       chartVersion:     {{ .Chart.Version }}
       releaseName:      kof-storage
       releaseNamespace: {{ .Values.kof.namespace }}

--- a/charts/kof-istio/values.yaml
+++ b/charts/kof-istio/values.yaml
@@ -4,8 +4,9 @@ kcm:
     # -- Repo of `kof-*` helm charts.
     repo:
       name: kof
-      type: oci
-      url: oci://ghcr.io/k0rdent/kof/charts
+      spec:
+        type: oci
+        url: oci://ghcr.io/k0rdent/kof/charts
 kof:
   namespace: kof
   traces_sampling_percentage: 100

--- a/charts/kof-mothership/Chart.yaml
+++ b/charts/kof-mothership/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: kof-mothership
 description: A Helm chart that deploys Grafana, Promxy, and VictoriaMetrics.
-version: "0.2.0"
-appVersion: "0.2.0"
+version: "0.2.1"
+appVersion: "0.2.1"
 dependencies:
   - name: grafana-operator
     version: v5.13.0

--- a/charts/kof-mothership/README.md
+++ b/charts/kof-mothership/README.md
@@ -1,6 +1,6 @@
 # kof-mothership
 
-![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![AppVersion: 0.2.0](https://img.shields.io/badge/AppVersion-0.2.0-informational?style=flat-square)
+![Version: 0.2.1](https://img.shields.io/badge/Version-0.2.1-informational?style=flat-square) ![AppVersion: 0.2.1](https://img.shields.io/badge/AppVersion-0.2.1-informational?style=flat-square)
 
 A Helm chart that deploys Grafana, Promxy, and VictoriaMetrics.
 
@@ -19,7 +19,7 @@ A Helm chart that deploys Grafana, Promxy, and VictoriaMetrics.
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| cert-manager-service-template | object | `{"helm":{"charts":[{"name":"cert-manager",`<br>`"version":"1.16.2"}],`<br>`"repository":{"name":"cert-manager",`<br>`"url":"https://charts.jetstack.io"}},`<br>`"namespace":"kcm-system"}` | Config of `ServiceTemplate` to use `cert-manager` in `MultiClusterService`. |
+| cert-manager-service-template | object | `{"helm":{"charts":[{"name":"cert-manager",`<br>`"version":"1.16.4"}],`<br>`"repository":{"name":"cert-manager",`<br>`"url":"https://charts.jetstack.io"}},`<br>`"namespace":"kcm-system"}` | Config of `ServiceTemplate` to use `cert-manager` in `MultiClusterService`. |
 | cert-manager<br>.cluster-issuer<br>.create | bool | `false` | Whether to create a default clusterissuer |
 | cert-manager<br>.cluster-issuer<br>.provider | string | `"letsencrypt"` | Default clusterissuer provider |
 | cert-manager<br>.email | string | `"mail@example.net"` | If we use letsencrypt (or similar) which email to use |

--- a/charts/kof-mothership/values.yaml
+++ b/charts/kof-mothership/values.yaml
@@ -36,7 +36,7 @@ cert-manager-service-template:
       url: https://charts.jetstack.io
     charts:
       - name: cert-manager
-        version: 1.16.2
+        version: 1.16.4
   namespace: kcm-system
 
 # -- Config of `ServiceTemplate` to use `ingress-nginx` in `MultiClusterService`.

--- a/charts/kof-operators/Chart.yaml
+++ b/charts/kof-operators/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: kof-operators
 description: A Helm chart that deploys opentelemetry-operator and prometheus CRDs
-version: "0.2.0"
-appVersion: "0.2.0"
+version: "0.2.1"
+appVersion: "0.2.1"
 dependencies:
   - name: opentelemetry-operator
     version: "0.75.*"

--- a/charts/kof-regional/Chart.yaml
+++ b/charts/kof-regional/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: kof-regional
 description: A Helm chart that installs multi cluster service template for kof regional clusters
-version: "0.2.0"
-appVersion: "0.2.0"
+version: "0.2.1"
+appVersion: "0.2.1"

--- a/charts/kof-regional/templates/regional-multi-cluster-service.yaml
+++ b/charts/kof-regional/templates/regional-multi-cluster-service.yaml
@@ -16,7 +16,7 @@ spec:
       {{- if (index .Values "cert-manager" "enabled") }}
       - name: cert-manager
         namespace: {{ .Release.Namespace }}
-        template: cert-manager-1-16-2
+        template: cert-manager-1-16-4
         values: |
           crds:
             enabled: true

--- a/charts/kof-storage/Chart.yaml
+++ b/charts/kof-storage/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: kof-storage
 description: A Helm chart that deploys Grafana, and VictoriaMetrics.
-version: "0.2.0"
-appVersion: "0.2.0"
+version: "0.2.1"
+appVersion: "0.2.1"
 dependencies:
   - name: grafana-operator
     version: v5.15.1

--- a/docs/DEV.md
+++ b/docs/DEV.md
@@ -2,76 +2,62 @@
 
 ## kcm
 
-[Apply kcm dev docs](https://github.com/k0rdent/kcm/blob/main/docs/dev.md) or just run:
-
-```bash
-git clone https://github.com/k0rdent/kcm.git
-cd kcm
-make cli-install
-make dev-apply
-```
+* [Apply kcm dev docs](https://github.com/k0rdent/kcm/blob/main/docs/dev.md)
+  or just run:
+  ```bash
+  git clone https://github.com/k0rdent/kcm.git
+  cd kcm
+  make cli-install
+  make dev-apply
+  ```
 
 ## kof
 
-Fork https://github.com/k0rdent/kof to `https://github.com/YOUR_USERNAME/kof` and run:
+* Fork https://github.com/k0rdent/kof to `https://github.com/YOUR_USERNAME/kof`
+* Run:
+  ```bash
+  cd ..
+  git clone git@github.com:YOUR_USERNAME/kof.git
+  cd kof
 
-```bash
-cd ..
-git clone git@github.com:YOUR_USERNAME/kof.git
-cd kof
+  make cli-install
+  make registry-deploy
+  make helm-push
+  ```
 
-make cli-install
-make registry-deploy
-make helm-push
-```
+* To use [Istio servicemesh](./istio.md):
+  ```bash
+  kubectl create namespace kof
+  kubectl label namespace kof istio-injection=enabled
+  make dev-istio-deploy
+  ```
 
-To use [Istio servicemesh](./istio.md):
-
-```bash
-kubectl create namespace kof
-kubectl label namespace kof istio-injection=enabled
-```
-
-```bash
-make dev-operators-deploy
-```
+* Deploy CRDs required for `kof-mothership`:
+  ```bash
+  make dev-operators-deploy
+  ```
 
 * Deploy `kof-mothership` chart to local management cluster:
-```bash
-make dev-ms-deploy
-```
-
-* If it fails with `the template is not valid` and no more details,
-  ensure all templates became `VALID`:
   ```bash
-  kubectl get clustertmpl -A
-  kubectl get svctmpl -A
+  make dev-ms-deploy
   ```
-  and then retry.
 
-
-To use Istio servicemesh install helm chart and re-start all pods in kof namespace
-```bash
-make dev-istio-deploy
-kubectl delete pod --all -n kof
-```
-
-* Wait for all pods to show that they're `Running`:
-```bash
-kubectl get pod -n kof
-```
+* Wait for all pods to became `Running`:
+  ```bash
+  kubectl get pod -n kof
+  ```
 
 ## Local deployment
 
 Quick option without regional/child clusters.
 
+* Run:
+  ```bash
+  make dev-storage-deploy
+  make dev-collectors-deploy
+  ```
 
-```bash
-make dev-storage-deploy
-make dev-collectors-deploy
-```
-
-Apply [Grafana](https://docs.k0rdent.io/next/admin/kof/kof-using/#access-to-grafana) section.
+* Apply [Grafana](https://docs.k0rdent.io/next/admin/kof/kof-using/#access-to-grafana) section.
 
 ## Deployment to AWS
 


### PR DESCRIPTION
* Installing `kof-istio` before `kof-mothership` - no need to delete all kof pods now.
* Adapted repo-related values of `kof-istio` to recent `repo.spec` change.
* Fixed waiting for `VALID` status in `make dev-ms-deploy`.
* Fixed `Spec is immutable` on upgrade due to migration to `kgst` by creating ServiceTemplate `cert-manager-1-16-4`.
* Tested on AWS and Azure with and without `kof-istio`.
