### PR TITLE
feat: Collect data from regional clusters too

### DIFF
--- a/charts/kof-child/templates/child-multi-cluster-service.yaml
+++ b/charts/kof-child/templates/child-multi-cluster-service.yaml
@@ -43,36 +43,26 @@ spec:
           {{`{{ $readMetricsEndpoint := getField "ChildConfig" "data.read_metrics_endpoint" }}`}}
           {{`{{ $logsEndpoint := getField "ChildConfig" "data.write_logs_endpoint" }}`}}
           {{`{{ $tracesEndpoint := getField "ChildConfig" "data.write_traces_endpoint" }}`}}
-          {{`{{ $patch := index .Cluster.metadata.annotations "k0rdent.mirantis.com/kof-collectors-values" | default "{}" | fromYaml }}`}}
-          {{`{{ $collectorsValues := `}}`
+          {{`{{ $collectorsValuesFromAnnotation := index .Cluster.metadata.annotations "k0rdent.mirantis.com/kof-collectors-values" | default "{}" | fromYaml }}`}}
+          {{`{{`}} $collectorsValuesFromHelm := `
           {{ .Values.collectors | toYaml }}
           ` | fromYaml {{`}}`}}
-          {{`{{ $values := printf `}}`{{`
+          {{`{{`}} $collectorsValuesHere := printf `
           global:
             clusterName: %q
           kof:
             metrics:
-              username_key: username
-              password_key: password
-              credentials_secret_name: storage-vmuser-credentials
               endpoint: %q
             logs:
-              username_key: username
-              password_key: password
-              credentials_secret_name: storage-vmuser-credentials
               endpoint: %q
             traces:
               endpoint: %q
           opencost:
-            enabled: true
             opencost:
               prometheus:
-                username_key: username
-                password_key: password
-                existingSecretName: storage-vmuser-credentials
                 external:
                   url: %q
               exporter:
                 defaultClusterId: %q
-          `}}`{{` $childClusterName $writeMetricsEndpoint $logsEndpoint $tracesEndpoint $readMetricsEndpoint $childClusterName | fromYaml }}`}}
-          {{`{{ mergeOverwrite $values $collectorsValues $patch | toYaml | nindent 4 }}`}}
+          ` $childClusterName $writeMetricsEndpoint $logsEndpoint $tracesEndpoint $readMetricsEndpoint $childClusterName | fromYaml {{`}}`}}
+          {{`{{ mergeOverwrite $collectorsValuesHere $collectorsValuesFromHelm $collectorsValuesFromAnnotation | toYaml | nindent 4 }}`}}

--- a/charts/kof-collectors/values.yaml
+++ b/charts/kof-collectors/values.yaml
@@ -4,7 +4,7 @@ global:
 kof:
   basic_auth: true
   logs:
-    endpoint: http://victoria-logs-single-server:9428/insert/opentelemetry/v1/logs
+    endpoint: http://kof-storage-victoria-logs-single-server:9428/insert/opentelemetry/v1/logs
     credentials_secret_name: storage-vmuser-credentials
     username_key: username
     password_key: password
@@ -339,7 +339,7 @@ opencost:
       password_key: password
       external:
         enabled: true
-        url: "https://vmauth.storage0.example.net/vm/select/0/prometheus"
+        url: https://vmselect-cluster:8481/select/0/prometheus
       internal:
         enabled: false
     metrics:

--- a/charts/kof-istio/templates/_helpers.tpl
+++ b/charts/kof-istio/templates/_helpers.tpl
@@ -5,3 +5,24 @@ chartName: {{ .name }}
 chartName: {{ .repo }}/{{ .name }}
 {{- end }}
 {{- end -}}
+
+{{- define "collectors_values_format" -}}
+        global:
+          clusterName: %s
+        kof:
+          logs:
+            endpoint: http://%s-logs:9428/insert/opentelemetry/v1/logs
+          metrics:
+            endpoint: http://%s-vminsert:8480/insert/0/prometheus/api/v1/write
+          traces:
+            endpoint: http://%s-jaeger-collector:4318
+          basic_auth: false
+        opencost:
+          opencost:
+            prometheus:
+              existingSecretName: ""
+              external:
+                url: http://%s-vmselect:8481/select/0/prometheus
+            exporter:
+              defaultClusterId: %s
+{{- end }}

--- a/charts/kof-istio/templates/kof-child-cluster-profile.yaml
+++ b/charts/kof-istio/templates/kof-child-cluster-profile.yaml
@@ -40,32 +40,14 @@ spec:
       releaseNamespace: {{ .Values.kof.namespace }}
       helmChartAction:  Install
       values: |
-        {{`{{ $patch := index .Cluster.metadata.annotations "k0rdent.mirantis.com/kof-collectors-values" | default "{}" | fromYaml }}`}}
         {{`{{ $childClusterName := .Cluster.metadata.name }}`}}
         {{`{{ $regionalClusterName := getField "ChildConfig" "data.regional_cluster_name" }}`}}
-        {{`{{ $collectorsValues := `}}`
+        {{`{{ $collectorsValuesFromAnnotation := index .Cluster.metadata.annotations "k0rdent.mirantis.com/kof-collectors-values" | default "{}" | fromYaml }}`}}
+        {{`{{`}} $collectorsValuesFromHelm := `
         {{ .Values.collectors | toYaml }}
         ` | fromYaml {{`}}`}}
-        {{`{{ $values := printf `}}`{{`
-        global:
-          clusterName: %q
-        kof:
-          logs:
-            endpoint: http://%s-logs:9428/insert/opentelemetry/v1/logs
-          metrics:
-            endpoint: http://%s-vminsert:8480/insert/0/prometheus/api/v1/write
-          traces:
-            endpoint: http://%s-jaeger-collector:4318
-          basic_auth: false
-        opencost:
-          enabled: true
-          opencost:
-            prometheus:
-              existingSecretName: ""
-              external:
-                url: http://%s-vmselect:8481/select/0/prometheus
-            exporter:
-              defaultClusterId: %q
-          `}}`{{` $childClusterName $regionalClusterName $regionalClusterName $regionalClusterName $regionalClusterName $childClusterName | fromYaml }}`}}
-        {{`{{ mergeOverwrite $values $collectorsValues $patch | toYaml | nindent 4 }}`}}
+        {{`{{`}} $collectorsValuesHere := printf `
+        {{ include "collectors_values_format" dict }}
+        ` $childClusterName $regionalClusterName $regionalClusterName $regionalClusterName $regionalClusterName $childClusterName | fromYaml {{`}}`}}
+        {{`{{ mergeOverwrite $collectorsValuesHere $collectorsValuesFromHelm $collectorsValuesFromAnnotation | toYaml | nindent 4 }}`}}
 {{- end }}

--- a/charts/kof-istio/templates/kof-regional-cluster-profile.yaml
+++ b/charts/kof-istio/templates/kof-regional-cluster-profile.yaml
@@ -37,11 +37,11 @@ spec:
       values: |
         {{`{{ $storageClass := index .Cluster.metadata.annotations "k0rdent.mirantis.com/kof-storage-class" | default "" }}`}}
         {{`{{ $clusterName := .Cluster.metadata.name }}`}}
-        {{`{{ $patch := index .Cluster.metadata.annotations "k0rdent.mirantis.com/kof-storage-values" | default "{}" | fromYaml }}`}}
-        {{`{{ $storageValues := `}}`
+        {{`{{ $storageValuesFromAnnotation := index .Cluster.metadata.annotations "k0rdent.mirantis.com/kof-storage-values" | default "{}" | fromYaml }}`}}
+        {{`{{`}} $storageValuesFromHelm := `
         {{ .Values.storage | toYaml }}
         ` | fromYaml {{`}}`}}
-        {{`{{ $values := printf `}}`{{`
+        {{`{{`}} $storageValuesHere := printf `
         global:
           clusterName: %q
           storageClass: %q
@@ -61,6 +61,31 @@ spec:
             enabled: false
           dashboard:
             istio_dashboard_enabled: true
-          `}}`{{` $clusterName $storageClass $storageClass | fromYaml }}`}}
-        {{`{{ mergeOverwrite $values $storageValues $patch | toYaml | nindent 4 }}`}}
+        ` $clusterName $storageClass $storageClass | fromYaml {{`}}`}}
+        {{`{{ mergeOverwrite $storageValuesHere $storageValuesFromHelm $storageValuesFromAnnotation | toYaml | nindent 4 }}`}}
+
+    - repositoryName:   {{ .Values.kcm.kof.repo.name }}
+      repositoryURL:    {{ .Values.kcm.kof.repo.spec.url }}
+      {{- include "repo_chart_name" (dict "name" "kof-operators" "type" .Values.kcm.kof.repo.spec.type "repo" .Values.kcm.kof.repo.name) | nindent 6 }}
+      chartVersion:     {{ .Chart.Version }}
+      releaseName:      kof-operators
+      releaseNamespace: {{ .Values.kof.namespace }}
+      helmChartAction:  Install
+
+    - repositoryName:   {{ .Values.kcm.kof.repo.name }}
+      repositoryURL:    {{ .Values.kcm.kof.repo.spec.url }}
+      {{- include "repo_chart_name" (dict "name" "kof-collectors" "type" .Values.kcm.kof.repo.spec.type "repo" .Values.kcm.kof.repo.name) | nindent 6 }}
+      chartVersion:     {{ .Chart.Version }}
+      releaseName:      kof-collectors
+      releaseNamespace: {{ .Values.kof.namespace }}
+      helmChartAction:  Install
+      values: |
+        {{`{{ $collectorsValuesFromAnnotation := index .Cluster.metadata.annotations "k0rdent.mirantis.com/kof-collectors-values" | default "{}" | fromYaml }}`}}
+        {{`{{`}} $collectorsValuesFromHelm := `
+        {{ .Values.collectors | toYaml }}
+        ` | fromYaml {{`}}`}}
+        {{`{{`}} $collectorsValuesHere := `
+        {{ include "collectors_values_format" dict }}
+        ` | replace "%s" .Cluster.metadata.name | fromYaml {{`}}`}}
+        {{`{{ mergeOverwrite $collectorsValuesHere $collectorsValuesFromHelm $collectorsValuesFromAnnotation | toYaml | nindent 4 }}`}}
 {{- end }}

--- a/charts/kof-regional/templates/regional-multi-cluster-service.yaml
+++ b/charts/kof-regional/templates/regional-multi-cluster-service.yaml
@@ -48,11 +48,11 @@ spec:
           {{`{{ $metricsHost := $metricsEnabled | ternary (printf "vmauth.%s" $regionalDomain) "" }}`}}
           {{`{{ $grafanaHost := printf "grafana.%s" $regionalDomain }}`}}
           {{`{{ $certEmail := index .Cluster.metadata.annotations "k0rdent.mirantis.com/kof-cert-email" }}`}}
-          {{`{{ $patch := index .Cluster.metadata.annotations "k0rdent.mirantis.com/kof-storage-values" | default "{}" | fromYaml }}`}}
-          {{`{{ $storageValues := `}}`
+          {{`{{ $storageValuesFromAnnotation := index .Cluster.metadata.annotations "k0rdent.mirantis.com/kof-storage-values" | default "{}" | fromYaml }}`}}
+          {{`{{`}} $storageValuesFromHelm := `
           {{ .Values.storage | toYaml }}
           ` | fromYaml {{`}}`}}
-          {{`{{ $values := printf `}}`{{`
+          {{`{{`}} $storageValuesHere := printf `
           global:
             storageClass: %q
           victoria-logs-single:
@@ -70,16 +70,32 @@ spec:
               ingress:
                 enabled: %t
                 host: %q
-            security:
-              username_key: username
-              password_key: password
-              credentials_secret_name: storage-vmuser-credentials
           grafana:
             ingress:
               host: %q
-            security:
-              credentials_secret_name: grafana-admin-credentials
           cert-manager:
             email: %q
-          `}}`{{` $storageClass $storageClass $tracesEnabled $tracesHost $metricsEnabled $metricsHost $grafanaHost $certEmail | fromYaml }}`}}
-          {{`{{ mergeOverwrite $values $storageValues $patch | toYaml | nindent 4 }}`}}
+          ` $storageClass $storageClass $tracesEnabled $tracesHost $metricsEnabled $metricsHost $grafanaHost $certEmail | fromYaml {{`}}`}}
+          {{`{{ mergeOverwrite $storageValuesHere $storageValuesFromHelm $storageValuesFromAnnotation | toYaml | nindent 4 }}`}}
+
+      - name: kof-operators
+        namespace: {{ .Release.Namespace }}
+        template: kof-operators-{{ .Chart.Version | replace "." "-" }}
+
+      - name: kof-collectors
+        namespace: {{ .Release.Namespace }}
+        template: kof-collectors-{{ .Chart.Version | replace "." "-" }}
+        values: |
+          {{`{{ $collectorsValuesFromAnnotation := index .Cluster.metadata.annotations "k0rdent.mirantis.com/kof-collectors-values" | default "{}" | fromYaml }}`}}
+          {{`{{`}} $collectorsValuesFromHelm := `
+          {{ .Values.collectors | toYaml }}
+          ` | fromYaml {{`}}`}}
+          {{`{{`}} $collectorsValuesHere := printf `
+          global:
+            clusterName: %q
+          opencost:
+            opencost:
+              exporter:
+                defaultClusterId: %q
+          ` .Cluster.metadata.name .Cluster.metadata.name | fromYaml {{`}}`}}
+          {{`{{ mergeOverwrite $collectorsValuesHere $collectorsValuesFromHelm $collectorsValuesFromAnnotation | toYaml | nindent 4 }}`}}

--- a/charts/kof-regional/values.yaml
+++ b/charts/kof-regional/values.yaml
@@ -4,4 +4,5 @@ cert-manager:
 ingress-nginx:
   enabled: true
 
+collectors: {}
 storage: {}


### PR DESCRIPTION
* Part of https://github.com/k0rdent/kof/issues/112
* Added `kof-operators` and `kof-collectors` to `kof-regional` MCS
  and to `kof-istio` regional ClusterProfile.
* Deleted redundant values (equal to default `values.yaml`) from all MCS.
* Fixed two default values in `kof-collectors`:
  `.kof.logs.endpoint` and `.opencost.opencost.prometheus.external.url`.
* Simplified Sveltos-in-Helm multiline templates with unified open/close tags:
  ```
  {{`{{`}}
  ...
  {{`}}`}}
  ```
* Renamed `$values $collectorsValues $patch`
  to `$collectorsValuesHere $collectorsValuesFromHelm $collectorsValuesFromAnnotation`
  and `$storageValuesHere $storageValuesFromHelm $storageValuesFromAnnotation`,
  to avoid confusion.
* DRY-ed collectors values in both istio ClusterProfiles, checked result, OK:
  ```
  kubectl get clusterprofile kof-istio-regional -o yaml

  ...
  - chartName: kof/kof-storage
    ...
    values: |
      {{ $storageClass := index .Cluster.metadata.annotations "k0rdent.mirantis.com/kof-storage-class" | default "" }}
      {{ $clusterName := .Cluster.metadata.name }}
      {{ $storageValuesFromAnnotation := index .Cluster.metadata.annotations "k0rdent.mirantis.com/kof-storage-values" | default "{}" | fromYaml }}
      {{ $storageValuesFromHelm := `
      {}
      ` | fromYaml }}
      {{ $storageValuesHere := printf `
      global:
        clusterName: %q
        storageClass: %q
      victoria-logs-single:
        server:
          persistentVolume:
            storageClassName: %q
      istio_endpoints: true
      jaeger:
        ingress:
          enabled: false
      victoriametrics:
        vmauth:
          enabled: false
      grafana:
        ingress:
          enabled: false
        dashboard:
          istio_dashboard_enabled: true
      ` $clusterName $storageClass $storageClass | fromYaml }}
      {{ mergeOverwrite $storageValuesHere $storageValuesFromHelm $storageValuesFromAnnotation | toYaml | nindent 4 }}
  - chartName: kof/kof-operators
    ...
  - chartName: kof/kof-collectors
    ...
    values: |
      {{ $collectorsValuesFromAnnotation := index .Cluster.metadata.annotations "k0rdent.mirantis.com/kof-collectors-values" | default "{}" | fromYaml }}
      {{ $collectorsValuesFromHelm := `
      {}
      ` | fromYaml }}
      {{ $collectorsValuesHere := `
      global:
        clusterName: %s
      kof:
        logs:
          endpoint: http://%s-logs:9428/insert/opentelemetry/v1/logs
        metrics:
          endpoint: http://%s-vminsert:8480/insert/0/prometheus/api/v1/write
        traces:
          endpoint: http://%s-jaeger-collector:4318
        basic_auth: false
      opencost:
        opencost:
          prometheus:
            existingSecretName: ""
            external:
              url: http://%s-vmselect:8481/select/0/prometheus
          exporter:
            defaultClusterId: %s
      ` | replace "%s" .Cluster.metadata.name | fromYaml }}
      {{ mergeOverwrite $collectorsValuesHere $collectorsValuesFromHelm $collectorsValuesFromAnnotation | toYaml | nindent 4 }}
      ```
* Tested both classic and istio options, Grafana shows metrics and logs, OK.
