### PR TITLE
feat: add collectors env variables values

### DIFF
--- a/charts/kof-collectors/templates/opentelemetry/collector.yaml
+++ b/charts/kof-collectors/templates/opentelemetry/collector.yaml
@@ -7,6 +7,9 @@ metadata:
 spec:
   mode: deployment
   serviceAccount: "{{ .Release.Name }}-k8s-cluster-collector"
+  {{- with .Values.collectors.k8scluster.env }}
+  env: {{ toYaml . | nindent 4 }}
+  {{- end }}
   config:
     receivers: {{ .Values.collectors.k8scluster.receivers | toYaml | nindent 6 }}
     processors: {{ .Values.collectors.k8scluster.processors | toYaml | nindent 6 }}

--- a/charts/kof-collectors/templates/opentelemetry/node-collector.yaml
+++ b/charts/kof-collectors/templates/opentelemetry/node-collector.yaml
@@ -33,6 +33,9 @@ spec:
       podMonitorSelector: {}
       scrapeInterval: 10s
       serviceMonitorSelector: {}
+  {{- with .Values.collectors.node.env }}
+  env: {{ toYaml . | nindent 4 }}
+  {{- end }}
   config:
 
     {{- $receivers := include "node_receivers" (dict "Values" .Values) | fromYaml }}


### PR DESCRIPTION
Example of passing env variables via kof-collectors values:
```
collectors:
  node:
    env:
      - name: AWS_ACCESS_KEY_ID
        valueFrom:
          secretKeyRef:
            name: aws-credentials
            key: AWS_ACCESS_KEY_ID
```