### PR TITLE
feat: Documented 4 options to collect data from DEV management cluster

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -141,6 +141,8 @@ dev-storage-deploy: dev ## Deploy kof-storage helm chart to the K8s cluster spec
 	@$(YQ) eval -i '.victoria-metrics-operator.enabled = false' dev/storage-values.yaml
 	@$(YQ) eval -i '.victoriametrics.enabled = false' dev/storage-values.yaml
 	@$(YQ) eval -i '.promxy.enabled = true' dev/storage-values.yaml
+	@# TODO: Delete the next redundant line right before release, to minimize "Test Release Upgrade" CI failures:
+	@$(YQ) eval -i '.["victoria-logs-single"].server.persistentVolume.storageClassName = "standard"' dev/storage-values.yaml
 	$(HELM) upgrade -i --wait -n kof kof-storage ./charts/kof-storage -f dev/storage-values.yaml
 
 .PHONY: dev-ms-deploy

--- a/Makefile
+++ b/Makefile
@@ -30,8 +30,6 @@ CLOUD_CLUSTER_REGION ?= us-east-2
 CHILD_CLUSTER_NAME = $(USER)-$(CLOUD_CLUSTER_TEMPLATE)-child
 REGIONAL_CLUSTER_NAME = $(USER)-$(CLOUD_CLUSTER_TEMPLATE)-regional
 REGIONAL_DOMAIN = $(REGIONAL_CLUSTER_NAME).$(KOF_DNS)
-KOF_STORAGE_NAME = kof-storage
-KOF_STORAGE_NG = kof
 
 KIND_CLUSTER_NAME ?= kcm-dev
 
@@ -123,22 +121,17 @@ kof-operator-docker-build: ## Build kof-operator controller docker image
 
 .PHONY: dev-operators-deploy
 dev-operators-deploy: dev ## Deploy kof-operators helm chart to the K8s cluster specified in ~/.kube/config
-	cp -f $(TEMPLATES_DIR)/kof-operators/values.yaml dev/operators-values.yaml
-	$(HELM) upgrade -i --wait kof-operators ./charts/kof-operators --create-namespace -n kof -f dev/operators-values.yaml
+	$(HELM) upgrade -i --wait --create-namespace -n kof kof-operators ./charts/kof-operators
 
 .PHONY: dev-collectors-deploy
 dev-collectors-deploy: dev ## Deploy kof-collector helm chart to the K8s cluster specified in ~/.kube/config
-	cp -f $(TEMPLATES_DIR)/kof-collectors/values.yaml dev/collectors-values.yaml
-	@$(YQ) eval -i '.kof.logs.endpoint = "http://$(KOF_STORAGE_NAME)-victoria-logs-single-server.$(KOF_STORAGE_NG):9428/insert/opentelemetry/v1/logs"' dev/collectors-values.yaml
-	@$(YQ) eval -i '.kof.metrics.endpoint = "http://vminsert-cluster.$(KOF_STORAGE_NG):8480/insert/0/prometheus/api/v1/write"' dev/collectors-values.yaml
-	@$(YQ) eval -i '.opencost.opencost.prometheus.external.url = "http://vmselect-cluster.$(KOF_STORAGE_NG):8481/select/0/prometheus"' dev/collectors-values.yaml
-	$(HELM) upgrade -i --wait kof-collectors ./charts/kof-collectors --create-namespace -n kof -f dev/collectors-values.yaml
+	$(HELM) upgrade -i --wait -n kof kof-collectors ./charts/kof-collectors
 
 .PHONY: dev-istio-deploy
 dev-istio-deploy: dev ## Deploy kof-istio helm chart to the K8s cluster specified in ~/.kube/config
 	cp -f $(TEMPLATES_DIR)/kof-istio/values.yaml dev/istio-values.yaml
 	@$(call set_local_registry, "dev/istio-values.yaml")
-	$(HELM) upgrade -i --wait kof-istio ./charts/kof-istio --create-namespace -n istio-system -f dev/istio-values.yaml
+	$(HELM) upgrade -i --wait -n istio-system kof-istio ./charts/kof-istio -f dev/istio-values.yaml
 
 .PHONY: dev-storage-deploy
 dev-storage-deploy: dev ## Deploy kof-storage helm chart to the K8s cluster specified in ~/.kube/config
@@ -148,9 +141,7 @@ dev-storage-deploy: dev ## Deploy kof-storage helm chart to the K8s cluster spec
 	@$(YQ) eval -i '.victoria-metrics-operator.enabled = false' dev/storage-values.yaml
 	@$(YQ) eval -i '.victoriametrics.enabled = false' dev/storage-values.yaml
 	@$(YQ) eval -i '.promxy.enabled = true' dev/storage-values.yaml
-	@$(YQ) eval -i '.global.storageClass = "standard"' dev/storage-values.yaml
-	@$(YQ) eval -i '.["victoria-logs-single"].server.persistentVolume.storageClassName = "standard"' dev/storage-values.yaml
-	$(HELM) upgrade -i --wait $(KOF_STORAGE_NAME) ./charts/kof-storage --create-namespace -n $(KOF_STORAGE_NG) -f dev/storage-values.yaml
+	$(HELM) upgrade -i --wait -n kof kof-storage ./charts/kof-storage -f dev/storage-values.yaml
 
 .PHONY: dev-ms-deploy
 dev-ms-deploy: dev kof-operator-docker-build ## Deploy `kof-mothership` helm chart to the management cluster
@@ -159,7 +150,7 @@ dev-ms-deploy: dev kof-operator-docker-build ## Deploy `kof-mothership` helm cha
 	@$(YQ) eval -i '.kcm.kof.clusterProfiles.kof-aws-dns-secrets = {"matchLabels": {"k0rdent.mirantis.com/kof-aws-dns-secrets": "true"}, "secrets": ["external-dns-aws-credentials"]}' dev/mothership-values.yaml
 	@$(YQ) eval -i '.kcm.kof.operator.image.repository = "kof-operator-controller"' dev/mothership-values.yaml
 	@$(call set_local_registry, "dev/mothership-values.yaml")
-	$(HELM) upgrade -i --wait --create-namespace -n kof kof-mothership ./charts/kof-mothership -f dev/mothership-values.yaml
+	$(HELM) upgrade -i --wait -n kof kof-mothership ./charts/kof-mothership -f dev/mothership-values.yaml
 	$(KUBECTL) rollout restart -n kof deployment/kof-mothership-kof-operator
 	@get_svctmpl() { $(KUBECTL) get svctmpl -A | grep -E 'cert-manager|ingress-nginx|kof-storage|kof-operators|kof-collectors';	}; \
 	for attempt in $$(seq 1 10); do \

--- a/Makefile
+++ b/Makefile
@@ -154,12 +154,12 @@ dev-ms-deploy: dev kof-operator-docker-build ## Deploy `kof-mothership` helm cha
 	@$(call set_local_registry, "dev/mothership-values.yaml")
 	$(HELM) upgrade -i --wait -n kof kof-mothership ./charts/kof-mothership -f dev/mothership-values.yaml
 	$(KUBECTL) rollout restart -n kof deployment/kof-mothership-kof-operator
-	@get_svctmpl() { $(KUBECTL) get svctmpl -A | grep -E 'cert-manager|ingress-nginx|kof-storage|kof-operators|kof-collectors';	}; \
+	@svctmpls='cert-manager-1-16-4|ingress-nginx-4-12-1|kof-collectors-0-2-1|kof-operators-0-2-1|kof-storage-0-2-1'; \
 	for attempt in $$(seq 1 10); do \
-		if [ $$(get_svctmpl | grep -c true) -eq 5 ]; then break; fi; \
-	  echo "Waiting for all service templates to become valid:"; \
-	  get_svctmpl; \
-	  sleep 5; \
+		if [ $$($(KUBECTL) get svctmpl -A | grep -E "$$svctmpls" | grep -c true) -eq 5 ]; then break; fi; \
+		echo "|Waiting for the next service templates to become VALID:|$$svctmpls|Found:" | tr "|" "\n"; \
+		$(KUBECTL) get svctmpl -A | grep -E "$$svctmpls"; \
+		sleep 5; \
 	done
 	$(HELM) upgrade -i --wait -n kof kof-regional ./charts/kof-regional
 	$(HELM) upgrade -i --wait -n kof kof-child ./charts/kof-child

--- a/charts/kof-collectors/templates/_helpers.tpl
+++ b/charts/kof-collectors/templates/_helpers.tpl
@@ -1,4 +1,5 @@
 {{- define "cluster_exporters" }}
+{{- if .kof.metrics.endpoint }}
 prometheusremotewrite:
   endpoint: {{ .kof.metrics.endpoint }}
   {{- include "kof-collectors.helper.tls_options" .kof.metrics | indent 2 }}
@@ -6,6 +7,8 @@ prometheusremotewrite:
   auth:
     authenticator: basicauth/metrics
   {{- end }}
+{{- end }}
+{{- if .kof.logs.endpoint }}
 otlphttp:
   {{- if .kof.basic_auth }}
   auth:
@@ -13,6 +16,7 @@ otlphttp:
   {{- end }}
   {{- include "kof-collectors.helper.tls_options" .kof.logs | indent 2 }}
   logs_endpoint: {{ .kof.logs.endpoint }}
+{{- end }}
 {{- end }}
 
 {{- define "node_receivers" }}
@@ -26,9 +30,12 @@ prometheus:
 {{- end }}
 
 {{- define "node_exporters" }}
+{{- if .kof.traces.endpoint }}
 otlphttp/traces:
   endpoint: {{ .kof.traces.endpoint }}
   {{- include "kof-collectors.helper.tls_options" .kof.traces | indent 2 }}
+{{- end }}
+{{- if .kof.metrics.endpoint }}
 prometheusremotewrite:
   endpoint: {{ .kof.metrics.endpoint }}
   {{- include "kof-collectors.helper.tls_options" .kof.metrics | indent 2 }}
@@ -36,6 +43,8 @@ prometheusremotewrite:
   auth:
     authenticator: basicauth/metrics
   {{- end }}
+{{- end }}
+{{- if .kof.logs.endpoint }}
 otlphttp/logs:
   {{- if .kof.basic_auth }}
   auth:
@@ -43,6 +52,7 @@ otlphttp/logs:
   {{- end }}
   logs_endpoint: {{ .kof.logs.endpoint }}
   {{- include "kof-collectors.helper.tls_options" .kof.logs | indent 2 }}
+{{- end }}
 {{- end }}
 
 {{- define "service" }}

--- a/docs/DEV.md
+++ b/docs/DEV.md
@@ -172,6 +172,7 @@ This method does not help when you need a real cluster, but may help with other 
 
 * Use `kubectl --context=kind-adopted` to inspect the cluster.
 
-## Helm docs
+## See also
 
-* Apply the steps in [.pre-commit-config.yaml](../.pre-commit-config.yaml) file.
+* [Options to collect data from DEV management cluster](collect-from-management.md).
+* Helm docs: apply the steps in [.pre-commit-config.yaml](../.pre-commit-config.yaml) file.

--- a/docs/collect-from-management.md
+++ b/docs/collect-from-management.md
@@ -89,7 +89,7 @@
   ```bash
   REGIONAL_CLUSTER_NAME=$USER-aws-standalone-regional
 
-  cat >dev/collector-config <<EOF
+  COLLECTOR_CONFIG="
       env:
         - name: AWS_ACCESS_KEY_ID
           valueFrom:
@@ -105,9 +105,7 @@
         awscloudwatchlogs:
           region: us-east-2
           log_group_name: $REGIONAL_CLUSTER_NAME
-          log_stream_name: logs
-  EOF
-  COLLECTOR_CONFIG=$(cat dev/collector-config)
+          log_stream_name: logs"
 
   cat >dev/collectors-values.yaml <<EOF
   kof:
@@ -118,8 +116,7 @@
     traces:
       endpoint: ""
   collectors:
-    k8scluster:
-  $COLLECTOR_CONFIG
+    k8scluster:$COLLECTOR_CONFIG
       service:
         pipelines:
           logs:
@@ -129,8 +126,7 @@
           metrics:
             exporters:
               - debug
-    node:
-  $COLLECTOR_CONFIG
+    node:$COLLECTOR_CONFIG
       service:
         pipelines:
           logs:

--- a/docs/collect-from-management.md
+++ b/docs/collect-from-management.md
@@ -1,0 +1,166 @@
+# Options to collect data from DEV management cluster
+
+* Non-dev version will be added to https://docs.k0rdent.io/next/admin/kof/kof-install/
+
+## Export to the same management cluster
+
+* This option uses:
+  * Grafana and VictoriaMetrics provided by `kof-mothership`, disabled in `kof-storage`.
+  * VictoriaLogs and Jaeger provided by `kof-storage`.
+* Run:
+  ```bash
+  make dev-storage-deploy
+  make dev-collectors-deploy
+  ```
+
+## Export to a regional cluster
+
+* This option assumes you did not enable Istio,
+  and you have a regional cluster with the name and domain below.
+* Run:
+  ```bash
+  REGIONAL_CLUSTER_NAME=$USER-aws-standalone-regional
+  REGIONAL_DOMAIN=$REGIONAL_CLUSTER_NAME.$KOF_DNS
+
+  cat >dev/collectors-values.yaml <<EOF
+  kof:
+    logs:
+      endpoint: https://vmauth.$REGIONAL_DOMAIN/vls/insert/opentelemetry/v1/logs
+    metrics:
+      endpoint: https://vmauth.$REGIONAL_DOMAIN/vm/insert/0/prometheus/api/v1/write
+    traces:
+      endpoint: https://jaeger.$REGIONAL_DOMAIN/collector
+  opencost:
+    opencost:
+      prometheus:
+        external:
+          url: https://vmauth.$REGIONAL_DOMAIN/vm/select/0/prometheus
+  EOF
+
+  helm upgrade -i --wait -n kof kof-collectors ./charts/kof-collectors -f dev/collectors-values.yaml
+  ```
+
+## Export to a regional cluster with Istio
+
+* This option assumes you have Istio enabled,
+  and you have a regional cluster with the name below.
+* Run:
+  ```bash
+  REGIONAL_CLUSTER_NAME=$USER-aws-standalone-regional
+
+  cat >dev/collectors-values.yaml <<EOF
+  kof:
+    basic_auth: false
+    logs:
+      endpoint: http://$REGIONAL_CLUSTER_NAME-logs:9428/insert/opentelemetry/v1/logs
+    metrics:
+      endpoint: http://$REGIONAL_CLUSTER_NAME-vminsert:8480/insert/0/prometheus/api/v1/write
+    traces:
+      endpoint: http://$REGIONAL_CLUSTER_NAME-jaeger-collector:4318
+  opencost:
+    opencost:
+      prometheus:
+        existingSecretName: ""
+        external:
+          url: http://$REGIONAL_CLUSTER_NAME-vmselect:8481/select/0/prometheus
+  EOF
+
+  helm upgrade -i --wait -n kof kof-collectors ./charts/kof-collectors -f dev/collectors-values.yaml
+  ```
+
+## Export to a third-party storage like CloudWatch
+
+* This option uses the [AWS CloudWatch Logs Exporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/awscloudwatchlogsexporter) as an example of a third-party storage.
+* You should use the most secure option to [specify AWS credentials](https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials),
+  but to keep this demo simple we will use environment variables stored in a k8s secret.
+* Create AWS IAM user with access to CloudWatch Logs,
+  e.g. by allowing `"Action": "logs:*"` in the inline policy.
+* Create access key and save it to the `dev/cloudwatch-credentials` file:
+  ```
+  AWS_ACCESS_KEY_ID=REDACTED
+  AWS_SECRET_ACCESS_KEY=REDACTED
+  ```
+* Create the `cloudwatch-credentials` secret:
+  ```bash
+  kubectl create secret generic -n kof cloudwatch-credentials \
+    --from-env-file=dev/cloudwatch-credentials
+  ```
+* Run:
+  ```bash
+  REGIONAL_CLUSTER_NAME=$USER-aws-standalone-regional
+
+  cat >dev/collector-config <<EOF
+      env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: cloudwatch-credentials
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: cloudwatch-credentials
+              key: AWS_SECRET_ACCESS_KEY
+      exporters:
+        awscloudwatchlogs:
+          region: us-east-2
+          log_group_name: $REGIONAL_CLUSTER_NAME
+          log_stream_name: logs
+  EOF
+  COLLECTOR_CONFIG=$(cat dev/collector-config)
+
+  cat >dev/collectors-values.yaml <<EOF
+  kof:
+    logs:
+      endpoint: ""
+    metrics:
+      endpoint: ""
+    traces:
+      endpoint: ""
+  collectors:
+    k8scluster:
+  $COLLECTOR_CONFIG
+      service:
+        pipelines:
+          logs:
+            exporters:
+              - awscloudwatchlogs
+              - debug
+          metrics:
+            exporters:
+              - debug
+    node:
+  $COLLECTOR_CONFIG
+      service:
+        pipelines:
+          logs:
+            exporters:
+              - awscloudwatchlogs
+              - debug
+          metrics:
+            exporters:
+              - debug
+          traces:
+            exporters:
+              - debug
+  EOF
+
+  helm upgrade -i --wait -n kof kof-collectors ./charts/kof-collectors -f dev/collectors-values.yaml
+  ```
+* Verify:
+  ```bash
+  aws configure
+    # Use the same access key
+
+  aws logs get-log-events \
+    --region us-east-2 \
+    --log-group-name $REGIONAL_CLUSTER_NAME \
+    --log-stream-name logs \
+    --limit 1
+  ```
+* Example of the output:
+  ```
+  {"events": [{
+    "timestamp": 1744305535107,
+    "message": "{\"body\":\"10.244.0.1 - - [10/Apr/2025 17:18:55] \\\"GET /-/ready HTTP/1.1 200 ...
+  ```

--- a/docs/release.md
+++ b/docs/release.md
@@ -4,8 +4,8 @@
   * New branch - name e.g: `release/v0.2.0`
   * Source: `main`
   * Create new branch.
-* Create a Release Candidate branch in your forked repo,
-  based on upstream Release branch, e.g:
+* Create an RC (Release Candidate) branch in your forked repo,
+  based on upstream release branch, e.g:
   ```bash
   git remote add upstream git@github.com:k0rdent/kof.git
   git fetch upstream
@@ -15,9 +15,8 @@
   * `charts/*/Chart.yaml` - to e.g: `0.2.0-rc1`
   * `kof-operator/go.mod` for https://github.com/k0rdent/kcm - to e.g: `v0.2.0-rc1`
   * `cd kof-operator && go mod tidy && make test`
-* Push, e.g: `git commit -am 'Release candidate: kof v0.2.0-rc1' && git push -u origin v0.2.0-rc1`
-* Create a PR, selecting the base branch e.g: `release/v0.2.0`
-* Get this PR approved and merged to e.g: `release/v0.2.0`
+* Push, e.g: `git commit -am 'chore: kof v0.2.0-rc1' && git push -u origin v0.2.0-rc1`
+* Create a PR, selecting the base branch e.g: `release/v0.2.0`, get it approved and merged.
 * Open https://github.com/k0rdent/kof/releases and click:
   * Draft a new release.
   * Choose a tag - Find or create - e.g: `v0.2.0-rc1` - Create new tag.
@@ -27,7 +26,7 @@
   * Generate release notes.
   * Set as a pre-release.
   * Publish release.
-* Open https://github.com/k0rdent/kof/actions and verify CI created the artifacts.
+* Open https://github.com/k0rdent/kof/actions and verify that CI created the artifacts.
 * Update the docs: https://docs.k0rdent.io/next/admin/kof/
 * Test end-to-end by the docs.
 * To fix something do e.g:
@@ -35,9 +34,10 @@
   git fetch upstream
   git checkout -b fix-something upstream/release/v0.2.0
   ```
-  * Commit and push the fix, create a PR selecting the base branch e.g: `release/v0.2.0`
-  * Merge it, and create one more PR via https://github.com/k0rdent/kof/compare
+  * Commit and push the fix, create a PR selecting the base branch e.g. `release/v0.2.0`, merge it.
+  * Create one more PR via https://github.com/k0rdent/kof/compare
     e.g: `Syncing changes from release/v0.2.0 to main`
+    using a regular merge commit (no squash) to keep the metadata of the original commits.
 * Once there are enough fixes, create the next release candidate.
 * Check the team agrees that `kof` release is ready.
 * Bump to the final versions without `-rc`.


### PR DESCRIPTION
* Part of https://github.com/k0rdent/kof/issues/112
* Documented 4 options to collect data from DEV management cluster.
* Deleted redundant custom values from `make dev-collectors-deploy` and similar.
* Fixed "Waiting for service templates to become VALID" on upgrade when old versions are still there.
* Allowed to disable default exporters by specifying empty endpoints.
* Tested each option, OK.
