### PR TITLE
fix: Protect Jaeger UI

### DIFF
--- a/charts/kof-storage/templates/jaeger/ingress.yaml
+++ b/charts/kof-storage/templates/jaeger/ingress.yaml
@@ -1,5 +1,4 @@
-{{- if .Values.jaeger.enabled }}
-{{- if .Values.jaeger.ingress.enabled}}
+{{- if and .Values.jaeger.enabled .Values.jaeger.ingress.enabled }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -8,6 +7,8 @@ metadata:
   annotations:
     cert-manager.io/cluster-issuer: {{ include "cert-manager.cluster-issuer.name" $ }}
     {{- include "cert-manager.acme-annotation" $ | nindent 4 }}
+    nginx.ingress.kubernetes.io/auth-type: basic
+    nginx.ingress.kubernetes.io/auth-secret: {{ .Values.jaeger.security.htpasswd_secret_name }}
     nginx.ingress.kubernetes.io/use-regex: "true"
     nginx.ingress.kubernetes.io/enable-rewrite-log: "true"
     nginx.ingress.kubernetes.io/rewrite-target: /$2
@@ -35,5 +36,4 @@ spec:
   - hosts:
     - {{ .Values.jaeger.ingress.host | quote }}
     secretName: jaeger-ingress-tls-secret
-{{- end }}
 {{- end }}

--- a/charts/kof-storage/templates/jaeger/secret.yaml
+++ b/charts/kof-storage/templates/jaeger/secret.yaml
@@ -1,0 +1,28 @@
+{{- if and .Values.jaeger.enabled .Values.jaeger.ingress.enabled }}
+  {{- $username := randAlpha (.Values.global.random_username_length | int) }}
+  {{- $password := randAlpha (.Values.global.random_password_length | int) }}
+  {{- $secret := lookup "v1" "Secret" .Release.Namespace .Values.jaeger.security.credentials_secret_name }}
+  {{- if $secret }}
+    {{- $username = $secret.data.username | b64dec }}
+    {{- $password = $secret.data.password | b64dec }}
+  {{- end }}
+---
+kind: Secret
+apiVersion: v1
+metadata:
+  name: {{ .Values.jaeger.security.credentials_secret_name }}
+  namespace: {{ .Release.Namespace }}
+stringData:
+  username: {{ $username | quote }}
+  password: {{ $password | quote }}
+type: Opaque
+---
+kind: Secret
+apiVersion: v1
+metadata:
+  name: {{ .Values.jaeger.security.htpasswd_secret_name }}
+  namespace: {{ .Release.Namespace }}
+data:
+  auth: {{ htpasswd $username $password | b64enc }}
+type: Opaque
+{{- end }}

--- a/charts/kof-storage/values.yaml
+++ b/charts/kof-storage/values.yaml
@@ -103,6 +103,9 @@ jaeger-operator:
   enabled: true
 jaeger:
   enabled: true
+  security:
+    credentials_secret_name: jaeger-credentials
+    htpasswd_secret_name: jaeger-htpasswd
   collector:
     replicaCount: 1
     podLabels:

--- a/docs/DEV.md
+++ b/docs/DEV.md
@@ -107,6 +107,16 @@ This is a full-featured option.
   wait for all `READY` to become `True` and then apply:
   * [Verification](https://docs.k0rdent.io/next/admin/kof/kof-verification/)
   * [Grafana](https://docs.k0rdent.io/next/admin/kof/kof-using/#access-to-grafana)
+  * Jaeger - will be moved to https://docs.k0rdent.io/next/admin/kof/kof-using/ soon:
+    * Get the regional Jaeger username and password:
+    ```bash
+    KUBECONFIG=dev/regional-kubeconfig kubectl get secret \
+      -n kof jaeger-credentials -o yaml | yq '{
+      "user": .data.username | @base64d,
+      "pass": .data.password | @base64d
+    }'
+    ```
+    * Login to `https://jaeger.$REGIONAL_CLUSTER_NAME.$KOF_DNS`
 
 ### Uninstall
 


### PR DESCRIPTION
* Closes https://github.com/k0rdent/kof/issues/212
* Tested:
  ```
  curl -v https://jaeger.dryzhkov-aws-standalone-regional.REDACTED/

    < HTTP/2 401
    ...
    <head><title>401 Authorization Required</title></head>
  ```
* Logged in. It shows data, OK.
