### PR TITLE
test: Test CI of upgrade with `--reset-values`

### DIFF
--- a/charts/kof-regional/values.yaml
+++ b/charts/kof-regional/values.yaml
@@ -5,4 +5,5 @@ ingress-nginx:
   enabled: true
 
 collectors: {}
+
 storage: {}


### PR DESCRIPTION
* I've found https://github.com/k0rdent/kof/pull/230 did not test the upgrade CI.
* Tested, [OK](https://github.com/k0rdent/kof/actions/runs/14450996571/job/40523408274?pr=231#step:27:126).
* Closing this test PR.