### PR TITLE
fix: add RegionalClusterDiscoveryFailed event

### DIFF
--- a/charts/kof-mothership/templates/kof-operator/role.yaml
+++ b/charts/kof-mothership/templates/kof-operator/role.yaml
@@ -17,6 +17,7 @@ rules:
   - get
   - list
   - update
+  - patch
   - watch
 - apiGroups:
   - grafana.integreatly.org

--- a/kof-operator/internal/controller/clusterdeployment_controller.go
+++ b/kof-operator/internal/controller/clusterdeployment_controller.go
@@ -19,7 +19,6 @@ package controller
 import (
 	"context"
 	"fmt"
-	"time"
 
 	kcmv1alpha1 "github.com/K0rdent/kcm/api/v1alpha1"
 	"github.com/k0rdent/kof/kof-operator/internal/controller/istio/cert"
@@ -34,8 +33,6 @@ import (
 )
 
 const IstioRoleLabel = "k0rdent.mirantis.com/istio-role"
-
-const RequeueInterval = time.Second * 5
 
 // ClusterDeploymentReconciler reconciles a ClusterDeployment object
 type ClusterDeploymentReconciler struct {
@@ -74,7 +71,7 @@ func (r *ClusterDeploymentReconciler) Reconcile(ctx context.Context, req ctrl.Re
 					clusterDeployment,
 					err,
 				)
-				return ctrl.Result{RequeueAfter: RequeueInterval}, err
+				return ctrl.Result{}, err
 			}
 
 			if err := r.IstioCertManager.TryDelete(ctx, req); err != nil {
@@ -85,7 +82,7 @@ func (r *ClusterDeploymentReconciler) Reconcile(ctx context.Context, req ctrl.Re
 					clusterDeployment,
 					err,
 				)
-				return ctrl.Result{RequeueAfter: RequeueInterval}, err
+				return ctrl.Result{}, err
 			}
 
 			return ctrl.Result{}, nil
@@ -95,7 +92,7 @@ func (r *ClusterDeploymentReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	}
 
 	if err := r.ReconcileKofClusterRole(ctx, clusterDeployment); err != nil {
-		return ctrl.Result{RequeueAfter: RequeueInterval}, err
+		return ctrl.Result{}, err
 	}
 
 	if istioRole, ok := clusterDeployment.Labels[IstioRoleLabel]; ok {
@@ -111,7 +108,7 @@ func (r *ClusterDeploymentReconciler) Reconcile(ctx context.Context, req ctrl.Re
 				clusterDeployment,
 				err,
 			)
-			return ctrl.Result{RequeueAfter: RequeueInterval}, err
+			return ctrl.Result{}, err
 		}
 
 		if err := r.IstioCertManager.TryCreate(ctx, clusterDeployment); err != nil {
@@ -122,7 +119,7 @@ func (r *ClusterDeploymentReconciler) Reconcile(ctx context.Context, req ctrl.Re
 				clusterDeployment,
 				err,
 			)
-			return ctrl.Result{RequeueAfter: RequeueInterval}, err
+			return ctrl.Result{}, err
 		}
 	}
 

--- a/kof-operator/internal/controller/clusterdeployment_kof_cluster_role.go
+++ b/kof-operator/internal/controller/clusterdeployment_kof_cluster_role.go
@@ -359,11 +359,19 @@ func (r *ClusterDeploymentReconciler) discoverRegionalClusterDeploymentByLocatio
 		}
 	}
 
-	return nil, fmt.Errorf(
+	err = fmt.Errorf(
 		"regional ClusterDeployment with matching location is not found, "+
 			`please set .metadata.labels["%s"] explicitly`,
 		KofRegionalClusterNameLabel,
 	)
+	record.Warnf(
+		childClusterDeployment,
+		utils.GetEventsAnnotations(childClusterDeployment),
+		"RegionalClusterDiscoveryFailed",
+		"Failed to discover regional cluster': %v",
+		err,
+	)
+	return nil, err
 }
 
 func locationIsTheSame(cloud string, c1, c2 *ClusterDeploymentConfig) bool {

--- a/kof-operator/internal/controller/promxyservergroup_controller.go
+++ b/kof-operator/internal/controller/promxyservergroup_controller.go
@@ -144,18 +144,18 @@ func (r *PromxyServerGroupReconciler) Reconcile(ctx context.Context, req ctrl.Re
 			log.Info("Creating promxy config secret", "secretName", name)
 			if err := r.Create(ctx, secret); err != nil {
 				utils.HandleError(ctx, "PromxySecretCreationFailed", "Cannot create promxy secret", secret, err, "promxySecretName", secret.Name)
-				return ctrl.Result{RequeueAfter: RequeueInterval}, err
+				return ctrl.Result{}, err
 			}
 			log.Info("Reloading promxy config")
 			if err := r.PromxyConfigReload(); err != nil {
 				utils.HandleError(ctx, "PromxyConfigReloadingFailed", "Cannot reload promxy config", secret, err, "promxySecretName", secret.Name)
-				return ctrl.Result{RequeueAfter: RequeueInterval}, err
+				return ctrl.Result{}, err
 			}
 			continue
 		}
 		if err != nil {
 			utils.HandleError(ctx, "PromxySecretNotFound", "Cannot get promxy secret", secret, err, "promxySecretName", secret.Name)
-			return ctrl.Result{RequeueAfter: RequeueInterval}, err
+			return ctrl.Result{}, err
 		}
 		setSecretOperatorLabels(secret)
 		secret.StringData = map[string]string{
@@ -164,12 +164,12 @@ func (r *PromxyServerGroupReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		log.Info("Updating promxy config secret", "secretName", name)
 		if err := r.Update(ctx, secret); err != nil {
 			utils.HandleError(ctx, "PromxySecretUpdateFailed", "Cannot update promxy secret", secret, err, "promxySecretName", secret.Name)
-			return ctrl.Result{RequeueAfter: RequeueInterval}, err
+			return ctrl.Result{}, err
 		}
 		log.Info("Reloading promxy config")
 		if err := r.PromxyConfigReload(); err != nil {
 			utils.HandleError(ctx, "PromxySecretReloadFailed", "Cannot reload promxy config", secret, err, "promxySecretName", secret.Name)
-			return ctrl.Result{RequeueAfter: RequeueInterval}, err
+			return ctrl.Result{}, err
 		}
 	}
 


### PR DESCRIPTION
- Add patch events permission to kof-operator
- Add RegionalClusterDiscoveryFailed event
- Removed RequeueInterval due to warning below
```
INFO    Warning: Reconciler returned both a non-zero result and a non-nil error. The result will always be ignored if the error is non-nil and the non-nil error causes requeuing with exponential backoff. For more details, see: https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/reconcile#Reconciler
```
