### PR TITLE
fix: Return ServiceTemplate `kof-istio-0-2-1` - it is used in ClusterProfile

### DIFF
--- a/charts/kof-mothership/templates/k0rdent/kof/svctmpl.yaml
+++ b/charts/kof-mothership/templates/k0rdent/kof/svctmpl.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.kcm.installTemplates }}
-  {{- range $name := list "operators" "collectors" "storage" }}
+  {{- range $name := list "operators" "collectors" "istio" "storage" }}
 ---
 apiVersion: k0rdent.mirantis.com/v1alpha1
 kind: ServiceTemplate


### PR DESCRIPTION
* https://github.com/k0rdent/kof/pull/234 had a wrong assumption, this PR fixes it.