### PR TITLE
fix: "Insufficient cpu" for istio-regional

### DIFF
--- a/demo/cluster/aws-standalone-istio-regional.yaml
+++ b/demo/cluster/aws-standalone-istio-regional.yaml
@@ -25,4 +25,4 @@ spec:
 
     workersNumber: 3
     worker:
-      instanceType: t3.large
+      instanceType: t3.xlarge


### PR DESCRIPTION
* Part of https://github.com/k0rdent/kof/issues/229
* Updated istio-child workers to use `t3.medium` instead `t3.small` in https://github.com/k0rdent/docs/pull/224 - this fixed the issue for the **child** cluster.
* Updated istio-**regional** workers to use `t3.xlarge` as even `t3.large` was not enough, leading to:
```
vminsert-cluster,
kof-collectors-node-exporter-targetallocator:

1 node(s) had untolerated taint {node-role.kubernetes.io/master: },
3 Insufficient cpu.
preemption: 0/4 nodes are available
```
* This fix resolved the issue.