### PR TITLE
feat: Added ServiceMonitor for alertmanager

### DIFF
--- a/charts/kof-mothership/templates/victoria/service-monitors.yaml
+++ b/charts/kof-mothership/templates/victoria/service-monitors.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.victoriametrics.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ .Release.Name }}-alertmanager
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "promxy.labels" . | nindent 4 }}
+spec:
+  endpoints:
+  - path: /metrics
+    port: http
+    scheme: http
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: monitoring
+      app.kubernetes.io/instance: cluster
+      app.kubernetes.io/name: vmalertmanager
+      managed-by: vm-operator
+{{- end }}

--- a/docs/DEV.md
+++ b/docs/DEV.md
@@ -90,8 +90,8 @@ This is a full-featured option.
 * Change the cluster name and apply the istio clusterdeployments from demo
 
   ```bash
-  kubectl apply -f demo/aws-standalone-istio-regional.yaml
-  kubectl apply -f demo/aws-standalone-istio-child.yaml
+  kubectl apply -f demo/cluster/aws-standalone-istio-regional.yaml
+  kubectl apply -f demo/cluster/aws-standalone-istio-child.yaml
   ```
 
 ### Verification

--- a/kof-operator/go.mod
+++ b/kof-operator/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/grafana/grafana-operator/v5 v5.16.0
 	github.com/onsi/ginkgo/v2 v2.23.3
 	github.com/onsi/gomega v1.36.2
-	golang.org/x/net v0.37.0 // indirect; https://github.com/k0rdent/kof/security/dependabot/10
+	golang.org/x/net v0.38.0 // indirect; https://github.com/k0rdent/kof/security/dependabot/13
 	gopkg.in/yaml.v3 v3.0.1
 	helm.sh/helm/v3 v3.17.3 // indirect; https://github.com/k0rdent/kof/security/dependabot/11
 	k8s.io/api v0.32.2

--- a/kof-operator/go.sum
+++ b/kof-operator/go.sum
@@ -474,8 +474,8 @@ golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v
 golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
 golang.org/x/net v0.6.0/go.mod h1:2Tu9+aMcznHK/AK1HMvgo6xiTLG5rD5rZLDS+rp2Bjs=
 golang.org/x/net v0.10.0/go.mod h1:0qNGK6F8kojg2nk9dLZ2mShWaEBan6FAoqfSigmmuDg=
-golang.org/x/net v0.37.0 h1:1zLorHbz+LYj7MQlSf1+2tPIIgibq2eL5xkrGk6f+2c=
-golang.org/x/net v0.37.0/go.mod h1:ivrbrMbzFq5J41QOQh0siUuly180yBYtLp+CKbEaFx8=
+golang.org/x/net v0.38.0 h1:vRMAPTMaeGqVhG5QyLJHqNDwecKTomGeqbnfZyKlBI8=
+golang.org/x/net v0.38.0/go.mod h1:ivrbrMbzFq5J41QOQh0siUuly180yBYtLp+CKbEaFx8=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.27.0 h1:da9Vo7/tDv5RH/7nZDz1eMGS/q1Vv1N/7FCrBhI9I3M=
 golang.org/x/oauth2 v0.27.0/go.mod h1:onh5ek6nERTohokkhCD/y2cV4Do3fxFHFuAejCkRWT8=


### PR DESCRIPTION
* Part of https://github.com/k0rdent/kof/issues/232
* Added ServiceMonitor for alertmanager.
* Tested: "Grafana - Explore" started showing metrics like `alertmanager_alerts`
* Also fixed dev docs typo and https://github.com/k0rdent/kof/security/dependabot/13
