### PR TITLE
fix: `Label does not exist` on `removeLabel` when multiple triage CI jobs are triggered

### DIFF
--- a/.github/workflows/triage.yaml
+++ b/.github/workflows/triage.yaml
@@ -31,12 +31,16 @@ jobs:
         with:
           retries: 3
           script: |
-            github.rest.issues.removeLabel({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              name: 'needs-triage'
-            })
+            try {
+              await github.rest.issues.removeLabel({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name: 'needs-triage'
+              });
+            } catch (error) {
+              if (error.status !== 404) throw error;
+            }
 
       - name: Remove needs-triage if closed
         uses: actions/github-script@v7
@@ -44,12 +48,16 @@ jobs:
         with:
           retries: 3
           script: |
-            github.rest.issues.removeLabel({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              name: 'needs-triage'
-            })
+            try {
+              await github.rest.issues.removeLabel({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name: 'needs-triage'
+              });
+            } catch (error) {
+              if (error.status !== 404) throw error;
+            }
 
       - name: Remove triage-ok if closed
         uses: actions/github-script@v7
@@ -57,9 +65,13 @@ jobs:
         with:
           retries: 3
           script: |
-            github.rest.issues.removeLabel({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              name: 'triage-ok'
-            })
+            try {
+              await github.rest.issues.removeLabel({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name: 'triage-ok'
+              });
+            } catch (error) {
+              if (error.status !== 404) throw error;
+            }


### PR DESCRIPTION
* When we add `triage-ok` and `enhancement` labels, two `triage` CI jobs are started.
* Both jobs see `needs-triage` label exists, so both jobs start the `actions/github-script`.
* First job deletes `needs-triage` successfully: https://github.com/k0rdent/kof/actions/runs/14638817106/job/41076130740
* Second job may fail with `Label does not exist`: https://github.com/k0rdent/kof/actions/runs/14638817112/job/41076130747
* As a result maintainers of the repo receive emails with errors that are not errors actually.
* This PR silences the case when `Label does not exist` already.
