### PR TITLE
feat: add nvidia gpu monitoring dashboard to grafana

### DIFF
--- a/charts/kof-mothership/files/dashboards/nvidia-dcgm-exporter.yaml
+++ b/charts/kof-mothership/files/dashboards/nvidia-dcgm-exporter.yaml
@@ -1,0 +1,1067 @@
+{{- $Values := (.helm).Values | default .Values }}
+{{- $defaultDatasource := "prometheus" -}}
+annotations:
+  list:
+    - builtIn: 1
+      datasource:
+        type: datasource
+        uid: grafana
+      enable: true
+      hide: true
+      iconColor: rgba(0, 211, 255, 1)
+      name: Annotations & Alerts
+      target:
+        limit: 100
+        matchAny: false
+        tags: []
+        type: dashboard
+      type: dashboard
+description: 'Dashboard providing comprehensive NVIDIA GPU metrics collected via DCGM exporter. GitHub repository: https://github.com/NVIDIA/dcgm-exporter/blob/main/grafana/dcgm-exporter-dashboard.json'
+editable: true
+fiscalYearStartMonth: 0
+graphTooltip: 0
+id: 13
+links: []
+liveNow: false
+panels:
+  - datasource:
+      type: prometheus
+      uid: $datasource
+    fieldConfig:
+      defaults:
+        color:
+          mode: palette-classic
+        custom:
+          axisBorderShow: false
+          axisCenteredZero: false
+          axisColorMode: text
+          axisLabel: ""
+          axisPlacement: auto
+          barAlignment: 0
+          drawStyle: line
+          fillOpacity: 10
+          gradientMode: none
+          hideFrom:
+            legend: false
+            tooltip: false
+            viz: false
+          insertNulls: false
+          lineInterpolation: linear
+          lineWidth: 2
+          pointSize: 5
+          scaleDistribution:
+            type: linear
+          showPoints: never
+          spanNulls: 60000
+          stacking:
+            group: A
+            mode: none
+          thresholdsStyle:
+            mode: off
+        mappings: []
+        thresholds:
+          mode: absolute
+          steps:
+            - color: green
+              value: null
+            - color: red
+              value: 80
+        unit: celsius
+      overrides: []
+    gridPos:
+      h: 8
+      w: 12
+      x: 0
+      y: 0
+    id: 12
+    options:
+      legend:
+        calcs:
+          - mean
+          - max
+        displayMode: table
+        placement: right
+        showLegend: true
+      tooltip:
+        mode: multi
+        sort: none
+    targets:
+      - expr: DCGM_FI_DEV_GPU_TEMP{clusterName=~"$cluster", instance=~"$node", gpu=~"$gpu"}
+        interval: ""
+        legendFormat: "GPU {{`{{gpu}}`}}"
+        refId: A
+    title: GPU Temperature
+    type: timeseries
+  - datasource:
+      type: prometheus
+      uid: $datasource
+    fieldConfig:
+      defaults:
+        color:
+          mode: palette-classic
+        custom:
+          axisBorderShow: false
+          axisCenteredZero: false
+          axisColorMode: text
+          axisLabel: ""
+          axisPlacement: auto
+          barAlignment: 0
+          drawStyle: line
+          fillOpacity: 10
+          gradientMode: none
+          hideFrom:
+            legend: false
+            tooltip: false
+            viz: false
+          insertNulls: false
+          lineInterpolation: linear
+          lineWidth: 2
+          pointSize: 5
+          scaleDistribution:
+            type: linear
+          showPoints: never
+          spanNulls: 60000
+          stacking:
+            group: A
+            mode: none
+          thresholdsStyle:
+            mode: off
+        mappings: []
+        thresholds:
+          mode: absolute
+          steps:
+            - color: green
+              value: null
+            - color: red
+              value: 80
+        unit: celsius
+      overrides: []
+    gridPos:
+      h: 8
+      w: 12
+      x: 12
+      y: 0
+    id: 19
+    options:
+      legend:
+        calcs:
+          - mean
+          - max
+        displayMode: table
+        placement: right
+        showLegend: true
+      tooltip:
+        mode: multi
+        sort: none
+    targets:
+      - expr: DCGM_FI_DEV_MEMORY_TEMP{clusterName=~"$cluster", instance=~"$node", gpu=~"$gpu"}
+        legendFormat: "GPU {{`{{gpu}}`}}"
+        refId: A
+    title: GPU Memory Temperature
+    type: timeseries
+  - datasource:
+      type: prometheus
+      uid: $datasource
+    fieldConfig:
+      defaults:
+        color:
+          mode: palette-classic
+        custom:
+          axisBorderShow: false
+          axisCenteredZero: false
+          axisColorMode: text
+          axisLabel: ""
+          axisPlacement: auto
+          barAlignment: 0
+          drawStyle: line
+          fillOpacity: 10
+          gradientMode: none
+          hideFrom:
+            legend: false
+            tooltip: false
+            viz: false
+          insertNulls: false
+          lineInterpolation: linear
+          lineWidth: 2
+          pointSize: 5
+          scaleDistribution:
+            type: linear
+          showPoints: never
+          spanNulls: 60000
+          stacking:
+            group: A
+            mode: none
+          thresholdsStyle:
+            mode: off
+        mappings: []
+        max: 100
+        min: 0
+        thresholds:
+          mode: absolute
+          steps:
+            - color: green
+              value: null
+        unit: percent
+      overrides: []
+    gridPos:
+      h: 8
+      w: 12
+      x: 0
+      y: 8
+    id: 6
+    options:
+      legend:
+        calcs:
+          - mean
+          - max
+        displayMode: table
+        placement: right
+        showLegend: true
+      tooltip:
+        mode: multi
+        sort: none
+    targets:
+      - expr: DCGM_FI_DEV_GPU_UTIL{clusterName=~"$cluster", instance=~"$node", gpu=~"$gpu"}
+        legendFormat: "GPU {{`{{gpu}}`}}"
+
+        refId: A
+    title: GPU Utilization
+    type: timeseries
+  - datasource:
+      type: prometheus
+      uid: $datasource
+    fieldConfig:
+      defaults:
+        color:
+          mode: palette-classic
+        custom:
+          axisBorderShow: false
+          axisCenteredZero: false
+          axisColorMode: text
+          axisLabel: ""
+          axisPlacement: auto
+          barAlignment: 0
+          drawStyle: line
+          fillOpacity: 10
+          gradientMode: none
+          hideFrom:
+            legend: false
+            tooltip: false
+            viz: false
+          insertNulls: false
+          lineInterpolation: linear
+          lineWidth: 2
+          pointSize: 5
+          scaleDistribution:
+            type: linear
+          showPoints: never
+          spanNulls: 60000
+          stacking:
+            group: A
+            mode: none
+          thresholdsStyle:
+            mode: off
+        mappings: []
+        max: 100
+        min: 0
+        thresholds:
+          mode: absolute
+          steps:
+            - color: green
+              value: null
+        unit: percent
+      overrides: []
+    gridPos:
+      h: 8
+      w: 12
+      x: 12
+      y: 8
+    id: 21
+    options:
+      legend:
+        calcs:
+          - mean
+          - max
+        displayMode: table
+        placement: right
+        showLegend: true
+      tooltip:
+        mode: multi
+        sort: none
+    targets:
+      - expr: DCGM_FI_DEV_MEM_COPY_UTIL{clusterName=~"$cluster", instance=~"$node", gpu=~"$gpu"}
+        legendFormat: "GPU {{`{{gpu}}`}}"
+
+        refId: A
+    title: GPU Memory Bandwidth Utilization
+    type: timeseries
+  - datasource:
+      type: prometheus
+      uid: $datasource
+    fieldConfig:
+      defaults:
+        color:
+          mode: palette-classic
+        custom:
+          axisBorderShow: false
+          axisCenteredZero: false
+          axisColorMode: text
+          axisLabel: ""
+          axisPlacement: auto
+          barAlignment: 0
+          drawStyle: line
+          fillOpacity: 10
+          gradientMode: none
+          hideFrom:
+            legend: false
+            tooltip: false
+            viz: false
+          insertNulls: false
+          lineInterpolation: linear
+          lineWidth: 2
+          pointSize: 5
+          scaleDistribution:
+            type: linear
+          showPoints: never
+          spanNulls: 60000
+          stacking:
+            group: A
+            mode: none
+          thresholdsStyle:
+            mode: off
+        mappings: []
+        thresholds:
+          mode: absolute
+          steps:
+            - color: green
+              value: null
+        unit: watt
+      overrides: []
+    gridPos:
+      h: 8
+      w: 12
+      x: 0
+      y: 16
+    id: 10
+    options:
+      legend:
+        calcs:
+          - mean
+          - max
+        displayMode: table
+        placement: right
+        showLegend: true
+      tooltip:
+        mode: multi
+        sort: none
+    targets:
+      - expr: DCGM_FI_DEV_POWER_USAGE{clusterName=~"$cluster", instance=~"$node", gpu=~"$gpu"}
+        legendFormat: "GPU {{`{{gpu}}`}}"
+
+        refId: A
+    title: GPU Power Usage
+    type: timeseries
+  - datasource:
+      type: prometheus
+      uid: $datasource
+    fieldConfig:
+      defaults:
+        color:
+          mode: palette-classic
+        custom:
+          axisBorderShow: false
+          axisCenteredZero: false
+          axisColorMode: text
+          axisLabel: ""
+          axisPlacement: auto
+          barAlignment: 0
+          drawStyle: line
+          fillOpacity: 10
+          gradientMode: none
+          hideFrom:
+            legend: false
+            tooltip: false
+            viz: false
+          insertNulls: false
+          lineInterpolation: linear
+          lineWidth: 2
+          pointSize: 5
+          scaleDistribution:
+            type: linear
+          showPoints: never
+          spanNulls: 60000
+          stacking:
+            group: A
+            mode: none
+          thresholdsStyle:
+            mode: off
+        mappings: []
+        thresholds:
+          mode: absolute
+          steps:
+            - color: green
+              value: null
+        unit: mbytes
+      overrides: []
+    gridPos:
+      h: 8
+      w: 12
+      x: 12
+      y: 16
+    id: 18
+    options:
+      legend:
+        calcs:
+          - mean
+          - max
+        displayMode: table
+        placement: right
+        showLegend: true
+      tooltip:
+        mode: multi
+        sort: none
+    targets:
+      - expr: DCGM_FI_DEV_FB_USED{clusterName=~"$cluster", instance=~"$node", gpu=~"$gpu"}
+        legendFormat: "GPU {{`{{gpu}}`}}"
+
+        refId: A
+    title: GPU Framebuffer Memory Used
+    type: timeseries
+  - datasource:
+      type: prometheus
+      uid: $datasource
+    fieldConfig:
+      defaults:
+        color:
+          mode: palette-classic
+        custom:
+          axisBorderShow: false
+          axisCenteredZero: false
+          axisColorMode: text
+          axisLabel: ""
+          axisPlacement: auto
+          barAlignment: 0
+          drawStyle: line
+          fillOpacity: 10
+          gradientMode: none
+          hideFrom:
+            legend: false
+            tooltip: false
+            viz: false
+          insertNulls: false
+          lineInterpolation: linear
+          lineWidth: 2
+          pointSize: 5
+          scaleDistribution:
+            type: linear
+          showPoints: auto
+          spanNulls: 60000
+          stacking:
+            group: A
+            mode: none
+          thresholdsStyle:
+            mode: off
+        mappings: []
+        max: 1
+        min: 0
+        thresholds:
+          mode: absolute
+          steps:
+            - color: green
+              value: null
+        unit: percentunit
+      overrides: []
+    gridPos:
+      h: 8
+      w: 12
+      x: 0
+      y: 24
+    id: 4
+    options:
+      legend:
+        calcs:
+          - mean
+          - max
+        displayMode: table
+        placement: right
+        showLegend: true
+      tooltip:
+        mode: multi
+        sort: none
+    targets:
+      - expr: DCGM_FI_PROF_GR_ENGINE_ACTIVE{clusterName=~"$cluster", instance=~"$node", gpu=~"$gpu"}
+        legendFormat: "GPU {{`{{gpu}}`}}"
+
+        refId: A
+    title: GPU Graphics Engine Utilization
+    type: timeseries
+  - datasource:
+      type: prometheus
+      uid: $datasource
+    fieldConfig:
+      defaults:
+        color:
+          mode: palette-classic
+        custom:
+          axisBorderShow: false
+          axisCenteredZero: false
+          axisColorMode: text
+          axisLabel: ""
+          axisPlacement: auto
+          barAlignment: 0
+          drawStyle: line
+          fillOpacity: 10
+          gradientMode: none
+          hideFrom:
+            legend: false
+            tooltip: false
+            viz: false
+          insertNulls: false
+          lineInterpolation: linear
+          lineWidth: 2
+          pointSize: 5
+          scaleDistribution:
+            type: linear
+          showPoints: auto
+          spanNulls: 60000
+          stacking:
+            group: A
+            mode: none
+          thresholdsStyle:
+            mode: off
+        mappings: []
+        max: 1
+        min: 0
+        thresholds:
+          mode: absolute
+          steps:
+            - color: green
+              value: null
+        unit: percentunit
+      overrides: []
+    gridPos:
+      h: 8
+      w: 12
+      x: 12
+      y: 24
+    id: 23
+    options:
+      legend:
+        calcs:
+          - mean
+          - max
+        displayMode: table
+        placement: right
+        showLegend: true
+      tooltip:
+        mode: multi
+        sort: none
+    targets:
+      - expr: DCGM_FI_PROF_PIPE_TENSOR_ACTIVE{clusterName=~"$cluster", instance=~"$node", gpu=~"$gpu"}
+        legendFormat: "GPU {{`{{gpu}}`}}"
+
+        refId: A
+    title: GPU Tensor Core Utilization
+    type: timeseries
+  - datasource:
+      type: prometheus
+      uid: $datasource
+    fieldConfig:
+      defaults:
+        color:
+          mode: palette-classic
+        custom:
+          axisBorderShow: false
+          axisCenteredZero: false
+          axisColorMode: text
+          axisLabel: ""
+          axisPlacement: auto
+          barAlignment: 0
+          drawStyle: line
+          fillOpacity: 10
+          gradientMode: none
+          hideFrom:
+            legend: false
+            tooltip: false
+            viz: false
+          insertNulls: false
+          lineInterpolation: linear
+          lineWidth: 2
+          pointSize: 5
+          scaleDistribution:
+            type: linear
+          showPoints: auto
+          spanNulls: 60000
+          stacking:
+            group: A
+            mode: none
+          thresholdsStyle:
+            mode: off
+        max: 1
+        min: 0
+        thresholds:
+          mode: absolute
+          steps:
+            - color: green
+        unit: percentunit
+      overrides: []
+    gridPos:
+      h: 8
+      w: 12
+      x: 0
+      y: 32
+    id: 24
+    options:
+      legend:
+        calcs:
+          - mean
+          - max
+        displayMode: table
+        placement: right
+        showLegend: true
+      tooltip:
+        mode: multi
+        sort: none
+    targets:
+      - expr: DCGM_FI_PROF_DRAM_ACTIVE{clusterName=~"$cluster", instance=~"$node", gpu=~"$gpu"}
+        legendFormat: "GPU {{`{{gpu}}`}}"
+
+        refId: A
+    title: GPU Memory Interface Utilization
+    type: timeseries
+  - datasource:
+      type: prometheus
+      uid: $datasource
+    fieldConfig:
+      defaults:
+        color:
+          mode: palette-classic
+        custom:
+          axisBorderShow: false
+          axisCenteredZero: false
+          axisColorMode: text
+          axisLabel: ""
+          axisPlacement: auto
+          barAlignment: 0
+          drawStyle: line
+          fillOpacity: 10
+          gradientMode: none
+          hideFrom:
+            legend: false
+            tooltip: false
+            viz: false
+          insertNulls: false
+          lineInterpolation: linear
+          lineStyle:
+            fill: solid
+          lineWidth: 2
+          pointSize: 4
+          scaleDistribution:
+            type: linear
+          showPoints: auto
+          spanNulls: 60000
+          stacking:
+            group: A
+            mode: none
+          thresholdsStyle:
+            mode: off
+        thresholds:
+          mode: absolute
+          steps:
+            - color: green
+        unit: cps
+      overrides: []
+    gridPos:
+      h: 8
+      w: 12
+      x: 12
+      y: 32
+    id: 22
+    options:
+      legend:
+        calcs:
+          - mean
+          - max
+        displayMode: table
+        placement: right
+        showLegend: true
+      tooltip:
+        mode: multi
+        sort: none
+    targets:
+      - expr: DCGM_FI_DEV_NVLINK_BANDWIDTH_TOTAL{clusterName=~"$cluster", instance=~"$node", gpu=~"$gpu"}
+        legendFormat: "GPU {{`{{gpu}}`}}"
+
+        refId: A
+    title: GPU NVLink Bandwidth
+    type: timeseries
+  - datasource:
+      type: prometheus
+      uid: $datasource
+    fieldConfig:
+      defaults:
+        color:
+          mode: palette-classic
+        custom:
+          axisBorderShow: false
+          axisCenteredZero: false
+          axisColorMode: text
+          axisLabel: ""
+          axisPlacement: auto
+          barAlignment: 0
+          drawStyle: line
+          fillOpacity: 10
+          gradientMode: none
+          hideFrom:
+            legend: false
+            tooltip: false
+            viz: false
+          insertNulls: false
+          lineInterpolation: linear
+          lineStyle:
+            fill: solid
+          lineWidth: 2
+          pointSize: 4
+          scaleDistribution:
+            type: linear
+          showPoints: auto
+          spanNulls: 60000
+          stacking:
+            group: A
+            mode: none
+          thresholdsStyle:
+            mode: off
+        thresholds:
+          mode: absolute
+          steps:
+            - color: green
+        unit: binBps
+      overrides: []
+    gridPos:
+      h: 8
+      w: 12
+      x: 0
+      y: 40
+    id: 25
+    options:
+      legend:
+        calcs:
+          - mean
+          - max
+        displayMode: table
+        placement: right
+        showLegend: true
+      tooltip:
+        mode: multi
+        sort: none
+    targets:
+      - expr: DCGM_FI_PROF_PCIE_TX_BYTES{clusterName=~"$cluster", instance=~"$node", gpu=~"$gpu"}
+        legendFormat: "GPU {{`{{gpu}}`}}"
+
+        refId: A
+    title: GPU PCIe Transmit
+    type: timeseries
+  - datasource:
+      type: prometheus
+      uid: $datasource
+    fieldConfig:
+      defaults:
+        color:
+          mode: palette-classic
+        custom:
+          axisBorderShow: false
+          axisCenteredZero: false
+          axisColorMode: text
+          axisLabel: ""
+          axisPlacement: auto
+          barAlignment: 0
+          drawStyle: line
+          fillOpacity: 10
+          gradientMode: none
+          hideFrom:
+            legend: false
+            tooltip: false
+            viz: false
+          insertNulls: false
+          lineInterpolation: linear
+          lineStyle:
+            fill: solid
+          lineWidth: 2
+          pointSize: 4
+          scaleDistribution:
+            type: linear
+          showPoints: auto
+          spanNulls: 60000
+          stacking:
+            group: A
+            mode: none
+          thresholdsStyle:
+            mode: off
+        thresholds:
+          mode: absolute
+          steps:
+            - color: green
+        unit: binBps
+      overrides: []
+    gridPos:
+      h: 8
+      w: 12
+      x: 12
+      y: 40
+    id: 26
+    options:
+      legend:
+        calcs:
+          - mean
+          - max
+        displayMode: table
+        placement: right
+        showLegend: true
+      tooltip:
+        mode: multi
+        sort: none
+    targets:
+      - expr: DCGM_FI_PROF_PCIE_RX_BYTES{clusterName=~"$cluster", instance=~"$node", gpu=~"$gpu"}
+        legendFormat: "GPU {{`{{gpu}}`}}"
+
+        refId: A
+    title: GPU PCIe Receive
+    type: timeseries
+  - datasource:
+      type: prometheus
+      uid: $datasource
+    fieldConfig:
+      defaults:
+        color:
+          mode: palette-classic
+        custom:
+          axisBorderShow: false
+          axisCenteredZero: false
+          axisColorMode: text
+          axisLabel: ""
+          axisPlacement: auto
+          barAlignment: 0
+          drawStyle: line
+          fillOpacity: 10
+          gradientMode: none
+          hideFrom:
+            legend: false
+            tooltip: false
+            viz: false
+          insertNulls: false
+          lineInterpolation: linear
+          lineWidth: 2
+          pointSize: 5
+          scaleDistribution:
+            type: linear
+          showPoints: never
+          spanNulls: 60000
+          stacking:
+            group: A
+            mode: none
+          thresholdsStyle:
+            mode: off
+        thresholds:
+          mode: absolute
+          steps:
+            - color: green
+        unit: rothz
+      overrides: []
+    gridPos:
+      h: 8
+      w: 12
+      x: 0
+      y: 48
+    id: 2
+    options:
+      legend:
+        calcs:
+          - mean
+          - max
+        displayMode: table
+        placement: right
+        showLegend: true
+      tooltip:
+        mode: multi
+        sort: none
+    targets:
+      - expr: DCGM_FI_DEV_SM_CLOCK{clusterName=~"$cluster", instance=~"$node", gpu=~"$gpu"} * 1000000
+        legendFormat: "GPU {{`{{gpu}}`}}"
+
+        refId: A
+    title: GPU SM Clock
+    type: timeseries
+  - datasource:
+      type: prometheus
+      uid: $datasource
+    fieldConfig:
+      defaults:
+        color:
+          mode: palette-classic
+        custom:
+          axisBorderShow: false
+          axisCenteredZero: false
+          axisColorMode: text
+          axisLabel: ""
+          axisPlacement: auto
+          barAlignment: 0
+          drawStyle: line
+          fillOpacity: 10
+          gradientMode: none
+          hideFrom:
+            legend: false
+            tooltip: false
+            viz: false
+          insertNulls: false
+          lineInterpolation: linear
+          lineStyle:
+            fill: solid
+          lineWidth: 2
+          pointSize: 5
+          scaleDistribution:
+            type: linear
+          showPoints: never
+          spanNulls: 60000
+          stacking:
+            group: A
+            mode: none
+          thresholdsStyle:
+            mode: off
+        thresholds:
+          mode: absolute
+          steps:
+            - color: green
+        unit: rothz
+      overrides: []
+    gridPos:
+      h: 8
+      w: 12
+      x: 12
+      y: 48
+    id: 20
+    options:
+      legend:
+        calcs:
+          - mean
+          - max
+        displayMode: table
+        placement: right
+        showLegend: true
+      tooltip:
+        mode: multi
+        sort: none
+    targets:
+      - expr: DCGM_FI_DEV_MEM_CLOCK{clusterName=~"$cluster", instance=~"$node", gpu=~"$gpu"} * 1000000
+        legendFormat: "GPU {{`{{gpu}}`}}"
+
+        refId: A
+    title: GPU Memory Clock
+    type: timeseries
+refresh: false
+schemaVersion: 39
+tags: []
+templating:
+  list:
+    - current:
+        selected: false
+        text: promxy
+        value: 905f228f-2da6-4807-9521-3b71186a0f45
+      hide: 0
+      includeAll: false
+      label: Datasource
+      multi: false
+      name: datasource
+      options: []
+      query: prometheus
+      refresh: 1
+      regex: ""
+      skipUrlSync: false
+      type: datasource
+    - current:
+        selected: false
+        text: ozymandias-azure-standalone-child-0
+        value: ozymandias-azure-standalone-child-0
+      datasource:
+        type: prometheus
+        uid: $datasource
+      definition: ""
+      hide: 0
+      includeAll: false
+      label: Cluster
+      multi: false
+      name: cluster
+      options: []
+      query:
+        query: label_values(DCGM_FI_DEV_GPU_TEMP, clusterName)
+        refId: ClusterVariable
+      refresh: 1
+      regex: ""
+      skipUrlSync: false
+      sort: 1
+      type: query
+    - current:
+        selected: false
+        text: 10.244.42.82:9400
+        value: 10.244.42.82:9400
+      datasource:
+        type: prometheus
+        uid: $datasource
+      definition: ""
+      hide: 0
+      includeAll: false
+      label: Node
+      multi: false
+      name: node
+      options: []
+      query:
+        query: label_values(DCGM_FI_DEV_GPU_TEMP{clusterName=~"$cluster"}, instance)
+        refId: NodeVariable
+      refresh: 1
+      regex: ""
+      skipUrlSync: false
+      sort: 1
+      type: query
+    - current:
+        selected: false
+        text:
+          - All
+        value:
+          - $__all
+      datasource:
+        type: prometheus
+        uid: $datasource
+      definition: ""
+      hide: 0
+      includeAll: true
+      label: GPU
+      multi: true
+      name: gpu
+      options: []
+      query:
+        query: label_values(DCGM_FI_DEV_GPU_TEMP{clusterName=~"$cluster", instance=~"$node"}, gpu)
+        refId: GpuVariable
+      refresh: 1
+      regex: ""
+      skipUrlSync: false
+      sort: 1
+      type: query
+time:
+  from: now-24h
+  to: now
+timepicker:
+  refresh_intervals:
+    - 5s
+    - 10s
+    - 30s
+    - 1m
+    - 5m
+    - 15m
+    - 30m
+    - 1h
+    - 2h
+    - 1d
+timezone: ""
+title: DCGM GPU Monitoring
+uid: DCGM
+version: 1
+weekStart: ""


### PR DESCRIPTION
## What

This PR introduces a Grafana dashboard for monitoring NVIDIA GPU metrics via the DCGM Exporter. 

![image](https://github.com/user-attachments/assets/d2b49794-699d-4c35-9e93-d3e8c2873d8d)

## How

The dashboard is based on the official [NVIDIA dcgm-exporter](https://github.com/NVIDIA/dcgm-exporter/blob/main/grafana/dcgm-exporter-dashboard.json) with few additional template key inherited from other existing dashboards in the repo.
The dashboard assumes that the DCGM Exporter metrics are being scraped. This requires a ServiceMonitor resource to be present, which directs to the DCGM Exporter's metrics endpoint.

Note - While the NVIDIA GPU Operator deploys the DCGM Exporter, it does not, by default, create a ServiceMonitor resource for it. 

  