### PR TITLE
chore: bump go version to upcomming upgrade

### DIFF
--- a/.github/workflows/release_operator.yml
+++ b/.github/workflows/release_operator.yml
@@ -5,7 +5,7 @@ on:
       - "*"
 
 env:
-  GO_VERSION: "1.23"
+  GO_VERSION: "1.24"
   IMAGE_REPO: "ghcr.io/k0rdent/kof/kof-operator-controller"
 
 jobs:


### PR DESCRIPTION
Bump go version to prevent CI falure due outdated version