### PR TITLE
feat: add cluster annotation to customize promxy and datasource http config

### DIFF
--- a/demo/cluster/aws-standalone-regional.yaml
+++ b/demo/cluster/aws-standalone-regional.yaml
@@ -7,6 +7,10 @@ metadata:
     k0rdent.mirantis.com/kof-storage-secrets: "true"
     k0rdent.mirantis.com/kof-aws-dns-secrets: "true"
     k0rdent.mirantis.com/kof-cluster-role: regional
+  annotations:
+    {}
+    # Custom promxy and grafana datasource http client config
+    # k0rdent.mirantis.com/kof-http-config: '{"dial_timeout": "10s", "tls_config": {"insecure_skip_verify": true}}'
 spec:
   template: aws-standalone-cp-0-1-6
   credential: aws-cluster-identity-cred

--- a/kof-operator/api/v1beta1/groupversion_info.go
+++ b/kof-operator/api/v1beta1/groupversion_info.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package v1alpha1 contains API Schema definitions for the kof v1alpha1 API group
+// Package v1beta1 contains API Schema definitions for the kof v1beta1 API group
 // +kubebuilder:object:generate=true
 // +groupName=kof.k0rdent.mirantis.com
 package v1beta1

--- a/kof-operator/internal/controller/promxyservergroup_controller_test.go
+++ b/kof-operator/internal/controller/promxyservergroup_controller_test.go
@@ -171,7 +171,7 @@ var _ = Describe("PromxyServerGroup Controller", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			promxyConfig := string(secret.Data["config.yaml"])
-			promxyConfigYaml := make(map[string]interface{})
+			promxyConfigYaml := make(map[string]any)
 			Expect(promxyConfig).ToNot(BeNil())
 			Expect(yaml.Unmarshal([]byte(promxyConfig), promxyConfigYaml)).ToNot(HaveOccurred())
 			Expect("\n" + promxyConfig).To(Equal(`


### PR DESCRIPTION
Closes https://github.com/k0rdent/kof/issues/258

Added  clusterDeployment annotation to customize promxy and grafana datasource http config params
```yaml
k0rdent.mirantis.com/kof-http-config: '{"dial_timeout": "10s", "tls_config": {"insecure_skip_verify": true}}'
```

