### PR TITLE
test: Debug `"helm repo add" requires 2 arguments` in `workflows/release_charts`

### DIFF
--- a/.github/workflows/release_charts.yml
+++ b/.github/workflows/release_charts.yml
@@ -32,7 +32,7 @@ jobs:
           for dir in charts/*
           do
             yq '.dependencies[] | select(.repository | test("^https?://"))
-              | "helm repo add " + .name + " " + .repository' "$dir/Chart.yaml" | sh
+              | "helm repo add " + .name + " " + .repository' "$dir/Chart.yaml" | sh -x
             helm dependency update "$dir"
 
             tag="${{ github.ref_name }}"  # git tag like "v0.2.0"


### PR DESCRIPTION
* Debugging https://github.com/k0rdent/kof/actions/runs/15063991323/job/42344618175
* The `-x` will show where exactly the error happens, because locally it looks good:
```
+ helm repo add prometheus-node-exporter https://prometheus-community.github.io/helm-charts
"prometheus-node-exporter" already exists with the same configuration, skipping
+ helm repo add kube-state-metrics https://prometheus-community.github.io/helm-charts
"kube-state-metrics" already exists with the same configuration, skipping
+ helm repo add opencost https://opencost.github.io/opencost-helm-chart
"opencost" already exists with the same configuration, skipping
+ helm repo add cert-manager-istio-csr https://charts.jetstack.io
"cert-manager-istio-csr" already exists with the same configuration, skipping
+ helm repo add base https://istio-release.storage.googleapis.com/charts
"base" already exists with the same configuration, skipping
+ helm repo add istiod https://istio-release.storage.googleapis.com/charts
"istiod" already exists with the same configuration, skipping
+ helm repo add victoria-metrics-operator https://victoriametrics.github.io/helm-charts/
"victoria-metrics-operator" already exists with the same configuration, skipping
+ helm repo add sveltos-dashboard https://projectsveltos.github.io/dashboard-helm-chart
"sveltos-dashboard" already exists with the same configuration, skipping
+ helm repo add opentelemetry-operator https://open-telemetry.github.io/opentelemetry-helm-charts
"opentelemetry-operator" already exists with the same configuration, skipping
+ helm repo add prometheus-operator-crds https://prometheus-community.github.io/helm-charts
"prometheus-operator-crds" already exists with the same configuration, skipping
+ helm repo add victoria-metrics-operator https://victoriametrics.github.io/helm-charts/
"victoria-metrics-operator" already exists with the same configuration, skipping
+ helm repo add victoria-logs-cluster https://victoriametrics.github.io/helm-charts/
"victoria-logs-cluster" already exists with the same configuration, skipping
+ helm repo add external-dns https://kubernetes-sigs.github.io/external-dns/
"external-dns" already exists with the same configuration, skipping
+ helm repo add jaeger-operator https://jaegertracing.github.io/helm-charts
"jaeger-operator" already exists with the same configuration, skipping
```