### PR TITLE
fix: `"helm repo add" requires 2 arguments` in `workflows/release_charts` exposed by fix in yq v4.45.4

### DIFF
--- a/.github/workflows/release_charts.yml
+++ b/.github/workflows/release_charts.yml
@@ -31,7 +31,7 @@ jobs:
           mkdir build
           for dir in charts/*
           do
-            yq '.dependencies[] | select(.repository | test("^https?://"))
+            yq '.dependencies | filter(.repository | test("^https?://"))
               | map("helm repo add " + .name + " " + .repository)[]' "$dir/Chart.yaml" | sh
             helm dependency update "$dir"
 

--- a/.github/workflows/release_charts.yml
+++ b/.github/workflows/release_charts.yml
@@ -32,7 +32,7 @@ jobs:
           for dir in charts/*
           do
             yq '.dependencies[] | select(.repository | test("^https?://"))
-              | "helm repo add " + .name + " " + .repository' "$dir/Chart.yaml" | sh -x
+              | map("helm repo add " + .name + " " + .repository)[]' "$dir/Chart.yaml" | sh
             helm dependency update "$dir"
 
             tag="${{ github.ref_name }}"  # git tag like "v0.2.0"

--- a/.github/workflows/release_charts.yml
+++ b/.github/workflows/release_charts.yml
@@ -24,7 +24,7 @@ jobs:
         uses: azure/setup-helm@v4
 
       - name: Install YQ
-        uses: mikefarah/yq@v4
+        uses: mikefarah/yq@v4.45.4
 
       - name: Build charts
         run: |

--- a/.github/workflows/release_charts.yml
+++ b/.github/workflows/release_charts.yml
@@ -24,7 +24,7 @@ jobs:
         uses: azure/setup-helm@v4
 
       - name: Install YQ
-        uses: mikefarah/yq@v4.45.4
+        uses: mikefarah/yq@v4
 
       - name: Build charts
         run: |


### PR DESCRIPTION
* https://github.com/k0rdent/kof/pull/280
* https://github.com/k0rdent/kof/pull/281
* Found yq version has changed and now behaves differently:
```
yq --version
yq (https://github.com/mikefarah/yq/) version v4.45.4

echo '{"a": ["c", "d"]}' | yq '.a[] | "b" + .' 
bc
bd

echo '{"a": ["c"]}' | yq '.a[] | "b" + .' 
bc

echo '{"a": []}' | yq '.a[] | "b" + .' 
b
# o_O

echo '{"a": []}' | yq '.a | map("b" + .)[]'
# No output, OK!

echo '{"a": ["c", "d"]}' | yq '.a | map("b" + .)[]'
bc
bd
```
* Found yq has fixed the [issue](https://github.com/mikefarah/yq/issues/) 2359 (not referencing it directly to avoid spam) which exposed a bug in our yq query.
* Fixed, Tested with local yq v4.45.4 and in fork, OK: https://github.com/denis-ryzhkov/kof/actions/runs/15069511632/job/42362050446#step:6:21