### PR TITLE
fix: filter out projectsveltos_* metrics from kcm cm

### DIFF
--- a/charts/kof-collectors/templates/kcm/service-monitor/kcm-controller-manager.yaml
+++ b/charts/kof-collectors/templates/kcm/service-monitor/kcm-controller-manager.yaml
@@ -12,6 +12,11 @@ spec:
       port: http
       scheme: http
       interval: 30s
+      metricRelabelings:
+        - action: drop
+          regex: projectsveltos_(.+)
+          sourceLabels:
+            - __name__
   selector:
     matchLabels:
       control-plane: kcm-controller-manager


### PR DESCRIPTION
kcm produces some invalid projectsveltos_* metrics due to some import in golang,

this commit is a workaround for 
https://github.com/k0rdent/kcm/issues/1549