### PR TITLE
feat: Adding ability to configure custom externalURL in alerts

### DIFF
--- a/charts/kof-mothership/templates/victoria/vmalert.yaml
+++ b/charts/kof-mothership/templates/victoria/vmalert.yaml
@@ -9,6 +9,12 @@ spec:
     url: http://vmselect-cluster:8481/select/0/prometheus
   evaluationInterval: 15s
   extraArgs:
+    {{- if .Values.victoriametrics.vmalert.extraArgs.externalURL }}
+    external.url: {{ .Values.victoriametrics.vmalert.extraArgs.externalURL }}
+    {{- end }}
+    {{- if .Values.victoriametrics.vmalert.extraArgs.externalAlertSource }}
+    external.alert.source: {{ .Values.victoriametrics.vmalert.extraArgs.externalAlertSource }}
+    {{- end }}
     http.pathPrefix: /
     remoteWrite.disablePathAppend: "true"
     "notifier.blackhole": "true"

--- a/charts/kof-mothership/templates/victoria/vmalert.yaml
+++ b/charts/kof-mothership/templates/victoria/vmalert.yaml
@@ -9,11 +9,11 @@ spec:
     url: http://vmselect-cluster:8481/select/0/prometheus
   evaluationInterval: 15s
   extraArgs:
-    {{- if .Values.victoriametrics.vmalert.extraArgs.externalURL }}
-    external.url: {{ .Values.victoriametrics.vmalert.extraArgs.externalURL }}
+    {{- with .Values.victoriametrics.vmalert.extraArgs.externalURL }}
+    external.url: {{ . }}
     {{- end }}
-    {{- if .Values.victoriametrics.vmalert.extraArgs.externalAlertSource }}
-    external.alert.source: {{ .Values.victoriametrics.vmalert.extraArgs.externalAlertSource }}
+    {{- with .Values.victoriametrics.vmalert.extraArgs.externalAlertSource }}
+    external.alert.source: {{ . }}
     {{- end }}
     http.pathPrefix: /
     remoteWrite.disablePathAppend: "true"

--- a/charts/kof-mothership/templates/victoria/vmalertmanager.yaml
+++ b/charts/kof-mothership/templates/victoria/vmalertmanager.yaml
@@ -12,8 +12,8 @@ spec:
     repository: prom/alertmanager
     tag: v0.27.0
   port: "9093"
-  {{- if .Values.victoriametrics.vmalert.vmalertmanager.externalURL }}
-  externalURL: {{ .Values.victoriametrics.vmalert.vmalertmanager.externalURL }}
+  {{- with .Values.victoriametrics.vmalert.vmalertmanager.externalURL }}
+  externalURL: {{ . }}
   {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/kof-mothership/templates/victoria/vmalertmanager.yaml
+++ b/charts/kof-mothership/templates/victoria/vmalertmanager.yaml
@@ -12,5 +12,8 @@ spec:
     repository: prom/alertmanager
     tag: v0.27.0
   port: "9093"
+  {{- if .Values.victoriametrics.vmalert.vmalertmanager.externalURL }}
+  externalURL: {{ .Values.victoriametrics.vmalert.vmalertmanager.externalURL }}
+  {{- end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
Closes #297

Values.victoriametrics.vmalert.vmalertmanager.externalURL will allow to configure "externalURL" field in alert

Based on
Values.victoriametrics.vmalert.extraArgs.externalURL 
and
Values.victoriametrics.vmalert.extraArgs.externalAlertSource 

"GeneratorURL" field will be constructed in following way:

GeneratorURL=externalURLexternalAlertSource