### PR TITLE
fix: Temporary adaptation of new alerts to current metrics

### DIFF
--- a/charts/kof-mothership/templates/prometheus/rules/k8s.rules.container_cpu_usage_seconds_total.yaml
+++ b/charts/kof-mothership/templates/prometheus/rules/k8s.rules.container_cpu_usage_seconds_total.yaml
@@ -26,7 +26,7 @@ spec:
     rules:
     - expr: |-
         sum by ({{ range $.Values.defaultRules.additionalAggregationLabels }}{{ . }},{{ end }}cluster, namespace, pod, container) (
-          rate(container_cpu_usage_seconds_total{job="kubelet", metrics_path="/metrics/cadvisor", image!=""}[5m])
+          rate(container_cpu_usage_seconds_total{job="integrations/kubernetes/cadvisor", image!=""}[5m])
         ) * on ({{ range $.Values.defaultRules.additionalAggregationLabels }}{{ . }},{{ end }}cluster, namespace, pod) group_left(node) topk by ({{ range $.Values.defaultRules.additionalAggregationLabels }}{{ . }},{{ end }}cluster, namespace, pod) (
           1, max by ({{ range $.Values.defaultRules.additionalAggregationLabels }}{{ . }},{{ end }}cluster, namespace, pod, node) (kube_pod_info{node!=""})
         )
@@ -42,7 +42,7 @@ spec:
       {{- end }}
     - expr: |-
         sum by ({{ range $.Values.defaultRules.additionalAggregationLabels }}{{ . }},{{ end }}cluster, namespace, pod, container) (
-          irate(container_cpu_usage_seconds_total{job="kubelet", metrics_path="/metrics/cadvisor", image!=""}[5m])
+          irate(container_cpu_usage_seconds_total{job="integrations/kubernetes/cadvisor", image!=""}[5m])
         ) * on ({{ range $.Values.defaultRules.additionalAggregationLabels }}{{ . }},{{ end }}cluster, namespace, pod) group_left(node) topk by ({{ range $.Values.defaultRules.additionalAggregationLabels }}{{ . }},{{ end }}cluster, namespace, pod) (
           1, max by ({{ range $.Values.defaultRules.additionalAggregationLabels }}{{ . }},{{ end }}cluster, namespace, pod, node) (kube_pod_info{node!=""})
         )

--- a/charts/kof-mothership/templates/prometheus/rules/k8s.rules.container_memory_cache.yaml
+++ b/charts/kof-mothership/templates/prometheus/rules/k8s.rules.container_memory_cache.yaml
@@ -25,7 +25,7 @@ spec:
   - name: k8s.rules.container_memory_cache
     rules:
     - expr: |-
-        container_memory_cache{job="kubelet", metrics_path="/metrics/cadvisor", image!=""}
+        container_memory_cache{job="integrations/kubernetes/cadvisor", image!=""}
         * on ({{ range $.Values.defaultRules.additionalAggregationLabels }}{{ . }},{{ end }}cluster, namespace, pod) group_left(node) topk by ({{ range $.Values.defaultRules.additionalAggregationLabels }}{{ . }},{{ end }}cluster, namespace, pod) (1,
           max by ({{ range $.Values.defaultRules.additionalAggregationLabels }}{{ . }},{{ end }}cluster, namespace, pod, node) (kube_pod_info{node!=""})
         )

--- a/charts/kof-mothership/templates/prometheus/rules/k8s.rules.container_memory_rss.yaml
+++ b/charts/kof-mothership/templates/prometheus/rules/k8s.rules.container_memory_rss.yaml
@@ -25,7 +25,7 @@ spec:
   - name: k8s.rules.container_memory_rss
     rules:
     - expr: |-
-        container_memory_rss{job="kubelet", metrics_path="/metrics/cadvisor", image!=""}
+        container_memory_rss{job="integrations/kubernetes/cadvisor", image!=""}
         * on ({{ range $.Values.defaultRules.additionalAggregationLabels }}{{ . }},{{ end }}cluster, namespace, pod) group_left(node) topk by ({{ range $.Values.defaultRules.additionalAggregationLabels }}{{ . }},{{ end }}cluster, namespace, pod) (1,
           max by ({{ range $.Values.defaultRules.additionalAggregationLabels }}{{ . }},{{ end }}cluster, namespace, pod, node) (kube_pod_info{node!=""})
         )

--- a/charts/kof-mothership/templates/prometheus/rules/k8s.rules.container_memory_swap.yaml
+++ b/charts/kof-mothership/templates/prometheus/rules/k8s.rules.container_memory_swap.yaml
@@ -25,7 +25,7 @@ spec:
   - name: k8s.rules.container_memory_swap
     rules:
     - expr: |-
-        container_memory_swap{job="kubelet", metrics_path="/metrics/cadvisor", image!=""}
+        container_memory_swap{job="integrations/kubernetes/cadvisor", image!=""}
         * on ({{ range $.Values.defaultRules.additionalAggregationLabels }}{{ . }},{{ end }}cluster, namespace, pod) group_left(node) topk by ({{ range $.Values.defaultRules.additionalAggregationLabels }}{{ . }},{{ end }}cluster, namespace, pod) (1,
           max by ({{ range $.Values.defaultRules.additionalAggregationLabels }}{{ . }},{{ end }}cluster, namespace, pod, node) (kube_pod_info{node!=""})
         )

--- a/charts/kof-mothership/templates/prometheus/rules/k8s.rules.container_memory_working_set_bytes.yaml
+++ b/charts/kof-mothership/templates/prometheus/rules/k8s.rules.container_memory_working_set_bytes.yaml
@@ -25,7 +25,7 @@ spec:
   - name: k8s.rules.container_memory_working_set_bytes
     rules:
     - expr: |-
-        container_memory_working_set_bytes{job="kubelet", metrics_path="/metrics/cadvisor", image!=""}
+        container_memory_working_set_bytes{job="integrations/kubernetes/cadvisor", image!=""}
         * on ({{ range $.Values.defaultRules.additionalAggregationLabels }}{{ . }},{{ end }}cluster, namespace, pod) group_left(node) topk by ({{ range $.Values.defaultRules.additionalAggregationLabels }}{{ . }},{{ end }}cluster, namespace, pod) (1,
           max by ({{ range $.Values.defaultRules.additionalAggregationLabels }}{{ . }},{{ end }}cluster, namespace, pod, node) (kube_pod_info{node!=""})
         )

--- a/charts/kof-mothership/templates/prometheus/rules/kubelet.rules.yaml
+++ b/charts/kof-mothership/templates/prometheus/rules/kubelet.rules.yaml
@@ -24,7 +24,7 @@ spec:
   groups:
   - name: kubelet.rules
     rules:
-    - expr: histogram_quantile(0.99, sum(rate(kubelet_pleg_relist_duration_seconds_bucket{job="kubelet", metrics_path="/metrics"}[5m])) by ({{ range $.Values.defaultRules.additionalAggregationLabels }}{{ . }},{{ end }}cluster, instance, le) * on ({{ range $.Values.defaultRules.additionalAggregationLabels }}{{ . }},{{ end }}cluster, instance) group_left(node) kubelet_node_name{job="kubelet", metrics_path="/metrics"})
+    - expr: histogram_quantile(0.99, sum(rate(kubelet_pleg_relist_duration_seconds_bucket{job="integrations/kubernetes/kubelet"}[5m])) by ({{ range $.Values.defaultRules.additionalAggregationLabels }}{{ . }},{{ end }}cluster, instance, le) * on ({{ range $.Values.defaultRules.additionalAggregationLabels }}{{ . }},{{ end }}cluster, instance) group_left(node) kubelet_node_name{job="integrations/kubernetes/kubelet"})
       labels:
         quantile: '0.99'
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.kubelet }}
@@ -36,7 +36,7 @@ spec:
         {{- end }}
       {{- end }}
       record: node_quantile:kubelet_pleg_relist_duration_seconds:histogram_quantile
-    - expr: histogram_quantile(0.9, sum(rate(kubelet_pleg_relist_duration_seconds_bucket{job="kubelet", metrics_path="/metrics"}[5m])) by ({{ range $.Values.defaultRules.additionalAggregationLabels }}{{ . }},{{ end }}cluster, instance, le) * on ({{ range $.Values.defaultRules.additionalAggregationLabels }}{{ . }},{{ end }}cluster, instance) group_left(node) kubelet_node_name{job="kubelet", metrics_path="/metrics"})
+    - expr: histogram_quantile(0.9, sum(rate(kubelet_pleg_relist_duration_seconds_bucket{job="integrations/kubernetes/kubelet"}[5m])) by ({{ range $.Values.defaultRules.additionalAggregationLabels }}{{ . }},{{ end }}cluster, instance, le) * on ({{ range $.Values.defaultRules.additionalAggregationLabels }}{{ . }},{{ end }}cluster, instance) group_left(node) kubelet_node_name{job="integrations/kubernetes/kubelet"})
       labels:
         quantile: '0.9'
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.kubelet }}
@@ -48,7 +48,7 @@ spec:
         {{- end }}
       {{- end }}
       record: node_quantile:kubelet_pleg_relist_duration_seconds:histogram_quantile
-    - expr: histogram_quantile(0.5, sum(rate(kubelet_pleg_relist_duration_seconds_bucket{job="kubelet", metrics_path="/metrics"}[5m])) by ({{ range $.Values.defaultRules.additionalAggregationLabels }}{{ . }},{{ end }}cluster, instance, le) * on ({{ range $.Values.defaultRules.additionalAggregationLabels }}{{ . }},{{ end }}cluster, instance) group_left(node) kubelet_node_name{job="kubelet", metrics_path="/metrics"})
+    - expr: histogram_quantile(0.5, sum(rate(kubelet_pleg_relist_duration_seconds_bucket{job="integrations/kubernetes/kubelet"}[5m])) by ({{ range $.Values.defaultRules.additionalAggregationLabels }}{{ . }},{{ end }}cluster, instance, le) * on ({{ range $.Values.defaultRules.additionalAggregationLabels }}{{ . }},{{ end }}cluster, instance) group_left(node) kubelet_node_name{job="integrations/kubernetes/kubelet"})
       labels:
         quantile: '0.5'
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.kubelet }}

--- a/charts/kof-mothership/templates/prometheus/rules/kubernetes-resources.yaml
+++ b/charts/kof-mothership/templates/prometheus/rules/kubernetes-resources.yaml
@@ -260,9 +260,9 @@ spec:
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/kubernetes/cputhrottlinghigh
         summary: Processes experience elevated CPU throttling.
       expr: |-
-        sum(increase(container_cpu_cfs_throttled_periods_total{container!="", job="kubelet", metrics_path="/metrics/cadvisor", }[5m])) without (id, metrics_path, name, image, endpoint, job, node)
+        sum(increase(container_cpu_cfs_throttled_periods_total{container!="", job="integrations/kubernetes/cadvisor", }[5m])) without (id, metrics_path, name, image, endpoint, job, node)
           / on ({{ range $.Values.defaultRules.additionalAggregationLabels }}{{ . }},{{ end }}cluster, namespace, pod, container, instance) group_left
-        sum(increase(container_cpu_cfs_periods_total{job="kubelet", metrics_path="/metrics/cadvisor", }[5m])) without (id, metrics_path, name, image, endpoint, job, node)
+        sum(increase(container_cpu_cfs_periods_total{job="integrations/kubernetes/cadvisor", }[5m])) without (id, metrics_path, name, image, endpoint, job, node)
           > ( 25 / 100 )
       for: {{ dig "CPUThrottlingHigh" "for" "15m" .Values.customRules }}
       {{- with .Values.defaultRules.keepFiringFor }}

--- a/charts/kof-mothership/templates/prometheus/rules/kubernetes-storage.yaml
+++ b/charts/kof-mothership/templates/prometheus/rules/kubernetes-storage.yaml
@@ -40,12 +40,12 @@ spec:
         summary: PersistentVolume is filling up.
       expr: |-
         (
-          kubelet_volume_stats_available_bytes{job="kubelet", namespace=~"{{ $targetNamespace }}", metrics_path="/metrics"}
+          kubelet_volume_stats_available_bytes{job="integrations/kubernetes/kubelet", namespace=~"{{ $targetNamespace }}"}
             /
-          kubelet_volume_stats_capacity_bytes{job="kubelet", namespace=~"{{ $targetNamespace }}", metrics_path="/metrics"}
+          kubelet_volume_stats_capacity_bytes{job="integrations/kubernetes/kubelet", namespace=~"{{ $targetNamespace }}"}
         ) < 0.03
         and
-        kubelet_volume_stats_used_bytes{job="kubelet", namespace=~"{{ $targetNamespace }}", metrics_path="/metrics"} > 0
+        kubelet_volume_stats_used_bytes{job="integrations/kubernetes/kubelet", namespace=~"{{ $targetNamespace }}"} > 0
         unless on ({{ range $.Values.defaultRules.additionalAggregationLabels }}{{ . }},{{ end }}cluster, namespace, persistentvolumeclaim)
         kube_persistentvolumeclaim_access_mode{ access_mode="ReadOnlyMany"} == 1
         unless on ({{ range $.Values.defaultRules.additionalAggregationLabels }}{{ . }},{{ end }}cluster, namespace, persistentvolumeclaim)
@@ -79,14 +79,14 @@ spec:
         summary: PersistentVolume is filling up.
       expr: |-
         (
-          kubelet_volume_stats_available_bytes{job="kubelet", namespace=~"{{ $targetNamespace }}", metrics_path="/metrics"}
+          kubelet_volume_stats_available_bytes{job="integrations/kubernetes/kubelet", namespace=~"{{ $targetNamespace }}"}
             /
-          kubelet_volume_stats_capacity_bytes{job="kubelet", namespace=~"{{ $targetNamespace }}", metrics_path="/metrics"}
+          kubelet_volume_stats_capacity_bytes{job="integrations/kubernetes/kubelet", namespace=~"{{ $targetNamespace }}"}
         ) < 0.15
         and
-        kubelet_volume_stats_used_bytes{job="kubelet", namespace=~"{{ $targetNamespace }}", metrics_path="/metrics"} > 0
+        kubelet_volume_stats_used_bytes{job="integrations/kubernetes/kubelet", namespace=~"{{ $targetNamespace }}"} > 0
         and
-        predict_linear(kubelet_volume_stats_available_bytes{job="kubelet", namespace=~"{{ $targetNamespace }}", metrics_path="/metrics"}[6h], 4 * 24 * 3600) < 0
+        predict_linear(kubelet_volume_stats_available_bytes{job="integrations/kubernetes/kubelet", namespace=~"{{ $targetNamespace }}"}[6h], 4 * 24 * 3600) < 0
         unless on ({{ range $.Values.defaultRules.additionalAggregationLabels }}{{ . }},{{ end }}cluster, namespace, persistentvolumeclaim)
         kube_persistentvolumeclaim_access_mode{ access_mode="ReadOnlyMany"} == 1
         unless on ({{ range $.Values.defaultRules.additionalAggregationLabels }}{{ . }},{{ end }}cluster, namespace, persistentvolumeclaim)
@@ -120,12 +120,12 @@ spec:
         summary: PersistentVolumeInodes are filling up.
       expr: |-
         (
-          kubelet_volume_stats_inodes_free{job="kubelet", namespace=~"{{ $targetNamespace }}", metrics_path="/metrics"}
+          kubelet_volume_stats_inodes_free{job="integrations/kubernetes/kubelet", namespace=~"{{ $targetNamespace }}"}
             /
-          kubelet_volume_stats_inodes{job="kubelet", namespace=~"{{ $targetNamespace }}", metrics_path="/metrics"}
+          kubelet_volume_stats_inodes{job="integrations/kubernetes/kubelet", namespace=~"{{ $targetNamespace }}"}
         ) < 0.03
         and
-        kubelet_volume_stats_inodes_used{job="kubelet", namespace=~"{{ $targetNamespace }}", metrics_path="/metrics"} > 0
+        kubelet_volume_stats_inodes_used{job="integrations/kubernetes/kubelet", namespace=~"{{ $targetNamespace }}"} > 0
         unless on ({{ range $.Values.defaultRules.additionalAggregationLabels }}{{ . }},{{ end }}cluster, namespace, persistentvolumeclaim)
         kube_persistentvolumeclaim_access_mode{ access_mode="ReadOnlyMany"} == 1
         unless on ({{ range $.Values.defaultRules.additionalAggregationLabels }}{{ . }},{{ end }}cluster, namespace, persistentvolumeclaim)
@@ -159,14 +159,14 @@ spec:
         summary: PersistentVolumeInodes are filling up.
       expr: |-
         (
-          kubelet_volume_stats_inodes_free{job="kubelet", namespace=~"{{ $targetNamespace }}", metrics_path="/metrics"}
+          kubelet_volume_stats_inodes_free{job="integrations/kubernetes/kubelet", namespace=~"{{ $targetNamespace }}"}
             /
-          kubelet_volume_stats_inodes{job="kubelet", namespace=~"{{ $targetNamespace }}", metrics_path="/metrics"}
+          kubelet_volume_stats_inodes{job="integrations/kubernetes/kubelet", namespace=~"{{ $targetNamespace }}"}
         ) < 0.15
         and
-        kubelet_volume_stats_inodes_used{job="kubelet", namespace=~"{{ $targetNamespace }}", metrics_path="/metrics"} > 0
+        kubelet_volume_stats_inodes_used{job="integrations/kubernetes/kubelet", namespace=~"{{ $targetNamespace }}"} > 0
         and
-        predict_linear(kubelet_volume_stats_inodes_free{job="kubelet", namespace=~"{{ $targetNamespace }}", metrics_path="/metrics"}[6h], 4 * 24 * 3600) < 0
+        predict_linear(kubelet_volume_stats_inodes_free{job="integrations/kubernetes/kubelet", namespace=~"{{ $targetNamespace }}"}[6h], 4 * 24 * 3600) < 0
         unless on ({{ range $.Values.defaultRules.additionalAggregationLabels }}{{ . }},{{ end }}cluster, namespace, persistentvolumeclaim)
         kube_persistentvolumeclaim_access_mode{ access_mode="ReadOnlyMany"} == 1
         unless on ({{ range $.Values.defaultRules.additionalAggregationLabels }}{{ . }},{{ end }}cluster, namespace, persistentvolumeclaim)

--- a/charts/kof-mothership/templates/prometheus/rules/kubernetes-system-kubelet.yaml
+++ b/charts/kof-mothership/templates/prometheus/rules/kubernetes-system-kubelet.yaml
@@ -130,11 +130,11 @@ spec:
       expr: |-
         (
           max by ({{ range $.Values.defaultRules.additionalAggregationLabels }}{{ . }},{{ end }}cluster, instance) (
-            kubelet_running_pods{job="kubelet", metrics_path="/metrics"} > 1
+            kubelet_running_pods{job="integrations/kubernetes/kubelet"} > 1
           )
           * on ({{ range $.Values.defaultRules.additionalAggregationLabels }}{{ . }},{{ end }}cluster, instance) group_left(node)
           max by ({{ range $.Values.defaultRules.additionalAggregationLabels }}{{ . }},{{ end }}cluster, instance, node) (
-            kubelet_node_name{job="kubelet", metrics_path="/metrics"}
+            kubelet_node_name{job="integrations/kubernetes/kubelet"}
           )
         )
         / on ({{ range $.Values.defaultRules.additionalAggregationLabels }}{{ . }},{{ end }}cluster, node) group_left()
@@ -200,10 +200,10 @@ spec:
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/kubernetes/kubenodeeviction
         summary: Node is evicting pods.
       expr: |-
-        sum(rate(kubelet_evictions{job="kubelet", metrics_path="/metrics"}[15m])) by ({{ range $.Values.defaultRules.additionalAggregationLabels }}{{ . }},{{ end }}cluster, eviction_signal, instance)
+        sum(rate(kubelet_evictions{job="integrations/kubernetes/kubelet"}[15m])) by ({{ range $.Values.defaultRules.additionalAggregationLabels }}{{ . }},{{ end }}cluster, eviction_signal, instance)
         * on ({{ range $.Values.defaultRules.additionalAggregationLabels }}{{ . }},{{ end }}cluster, instance) group_left(node)
         max by ({{ range $.Values.defaultRules.additionalAggregationLabels }}{{ . }},{{ end }}cluster, instance, node) (
-          kubelet_node_name{job="kubelet", metrics_path="/metrics"}
+          kubelet_node_name{job="integrations/kubernetes/kubelet"}
         )
         > 0
       for: {{ dig "KubeNodeEviction" "for" "0s" .Values.customRules }}
@@ -261,7 +261,7 @@ spec:
         description: Kubelet Pod startup 99th percentile latency is {{`{{`}} $value {{`}}`}} seconds on node {{`{{`}} $labels.node {{`}}`}} on cluster {{`{{`}} $labels.cluster {{`}}`}}.
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/kubernetes/kubeletpodstartuplatencyhigh
         summary: Kubelet Pod startup latency is too high.
-      expr: histogram_quantile(0.99, sum(rate(kubelet_pod_worker_duration_seconds_bucket{job="kubelet", metrics_path="/metrics"}[5m])) by ({{ range $.Values.defaultRules.additionalAggregationLabels }}{{ . }},{{ end }}cluster, instance, le)) * on ({{ range $.Values.defaultRules.additionalAggregationLabels }}{{ . }},{{ end }}cluster, instance) group_left(node) kubelet_node_name{job="kubelet", metrics_path="/metrics"} > 60
+      expr: histogram_quantile(0.99, sum(rate(kubelet_pod_worker_duration_seconds_bucket{job="integrations/kubernetes/kubelet"}[5m])) by ({{ range $.Values.defaultRules.additionalAggregationLabels }}{{ . }},{{ end }}cluster, instance, le)) * on ({{ range $.Values.defaultRules.additionalAggregationLabels }}{{ . }},{{ end }}cluster, instance) group_left(node) kubelet_node_name{job="integrations/kubernetes/kubelet"} > 60
       for: {{ dig "KubeletPodStartUpLatencyHigh" "for" "15m" .Values.customRules }}
       {{- with .Values.defaultRules.keepFiringFor }}
       keep_firing_for: "{{ . }}"
@@ -442,7 +442,7 @@ spec:
         description: Kubelet has disappeared from Prometheus target discovery.
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/kubernetes/kubeletdown
         summary: Target disappeared from Prometheus target discovery.
-      expr: absent(up{job="kubelet", metrics_path="/metrics"} == 1)
+      expr: absent(up{job="integrations/kubernetes/kubelet"} == 1)
       for: {{ dig "KubeletDown" "for" "15m" .Values.customRules }}
       {{- with .Values.defaultRules.keepFiringFor }}
       keep_firing_for: "{{ . }}"

--- a/charts/kof-mothership/templates/prometheus/rules/node-exporter.rules.yaml
+++ b/charts/kof-mothership/templates/prometheus/rules/node-exporter.rules.yaml
@@ -26,7 +26,7 @@ spec:
     rules:
     - expr: |-
         count without (cpu, mode) (
-          node_cpu_seconds_total{job="node-exporter",mode="idle"}
+          node_cpu_seconds_total{job="prometheus-node-exporter",mode="idle"}
         )
       record: instance:node_num_cpu:sum
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.nodeExporterRecording }}
@@ -40,7 +40,7 @@ spec:
       {{- end }}
     - expr: |-
         1 - avg without (cpu) (
-          sum without (mode) (rate(node_cpu_seconds_total{job="node-exporter", mode=~"idle|iowait|steal"}[5m]))
+          sum without (mode) (rate(node_cpu_seconds_total{job="prometheus-node-exporter", mode=~"idle|iowait|steal"}[5m]))
         )
       record: instance:node_cpu_utilisation:rate5m
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.nodeExporterRecording }}
@@ -54,9 +54,9 @@ spec:
       {{- end }}
     - expr: |-
         (
-          node_load1{job="node-exporter"}
+          node_load1{job="prometheus-node-exporter"}
         /
-          instance:node_num_cpu:sum{job="node-exporter"}
+          instance:node_num_cpu:sum{job="prometheus-node-exporter"}
         )
       record: instance:node_load1_per_cpu:ratio
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.nodeExporterRecording }}
@@ -71,20 +71,20 @@ spec:
     - expr: |-
         1 - (
           (
-            node_memory_MemAvailable_bytes{job="node-exporter"}
+            node_memory_MemAvailable_bytes{job="prometheus-node-exporter"}
             or
             (
-              node_memory_Buffers_bytes{job="node-exporter"}
+              node_memory_Buffers_bytes{job="prometheus-node-exporter"}
               +
-              node_memory_Cached_bytes{job="node-exporter"}
+              node_memory_Cached_bytes{job="prometheus-node-exporter"}
               +
-              node_memory_MemFree_bytes{job="node-exporter"}
+              node_memory_MemFree_bytes{job="prometheus-node-exporter"}
               +
-              node_memory_Slab_bytes{job="node-exporter"}
+              node_memory_Slab_bytes{job="prometheus-node-exporter"}
             )
           )
         /
-          node_memory_MemTotal_bytes{job="node-exporter"}
+          node_memory_MemTotal_bytes{job="prometheus-node-exporter"}
         )
       record: instance:node_memory_utilisation:ratio
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.nodeExporterRecording }}
@@ -96,7 +96,7 @@ spec:
           {{- toYaml . | nindent 8 }}
         {{- end }}
       {{- end }}
-    - expr: rate(node_vmstat_pgmajfault{job="node-exporter"}[5m])
+    - expr: rate(node_vmstat_pgmajfault{job="prometheus-node-exporter"}[5m])
       record: instance:node_vmstat_pgmajfault:rate5m
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.nodeExporterRecording }}
       labels:
@@ -107,7 +107,7 @@ spec:
           {{- toYaml . | nindent 8 }}
         {{- end }}
       {{- end }}
-    - expr: rate(node_disk_io_time_seconds_total{job="node-exporter", device=~"(/dev/)?(mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|md.+|dasd.+)"}[5m])
+    - expr: rate(node_disk_io_time_seconds_total{job="prometheus-node-exporter", device=~"(/dev/)?(mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|md.+|dasd.+)"}[5m])
       record: instance_device:node_disk_io_time_seconds:rate5m
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.nodeExporterRecording }}
       labels:
@@ -118,7 +118,7 @@ spec:
           {{- toYaml . | nindent 8 }}
         {{- end }}
       {{- end }}
-    - expr: rate(node_disk_io_time_weighted_seconds_total{job="node-exporter", device=~"(/dev/)?(mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|md.+|dasd.+)"}[5m])
+    - expr: rate(node_disk_io_time_weighted_seconds_total{job="prometheus-node-exporter", device=~"(/dev/)?(mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|md.+|dasd.+)"}[5m])
       record: instance_device:node_disk_io_time_weighted_seconds:rate5m
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.nodeExporterRecording }}
       labels:
@@ -131,7 +131,7 @@ spec:
       {{- end }}
     - expr: |-
         sum without (device) (
-          rate(node_network_receive_bytes_total{job="node-exporter", device!="lo"}[5m])
+          rate(node_network_receive_bytes_total{job="prometheus-node-exporter", device!="lo"}[5m])
         )
       record: instance:node_network_receive_bytes_excluding_lo:rate5m
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.nodeExporterRecording }}
@@ -145,7 +145,7 @@ spec:
       {{- end }}
     - expr: |-
         sum without (device) (
-          rate(node_network_transmit_bytes_total{job="node-exporter", device!="lo"}[5m])
+          rate(node_network_transmit_bytes_total{job="prometheus-node-exporter", device!="lo"}[5m])
         )
       record: instance:node_network_transmit_bytes_excluding_lo:rate5m
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.nodeExporterRecording }}
@@ -159,7 +159,7 @@ spec:
       {{- end }}
     - expr: |-
         sum without (device) (
-          rate(node_network_receive_drop_total{job="node-exporter", device!="lo"}[5m])
+          rate(node_network_receive_drop_total{job="prometheus-node-exporter", device!="lo"}[5m])
         )
       record: instance:node_network_receive_drop_excluding_lo:rate5m
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.nodeExporterRecording }}
@@ -173,7 +173,7 @@ spec:
       {{- end }}
     - expr: |-
         sum without (device) (
-          rate(node_network_transmit_drop_total{job="node-exporter", device!="lo"}[5m])
+          rate(node_network_transmit_drop_total{job="prometheus-node-exporter", device!="lo"}[5m])
         )
       record: instance:node_network_transmit_drop_excluding_lo:rate5m
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.nodeExporterRecording }}

--- a/charts/kof-mothership/templates/prometheus/rules/node-exporter.yaml
+++ b/charts/kof-mothership/templates/prometheus/rules/node-exporter.yaml
@@ -38,11 +38,11 @@ spec:
         summary: Filesystem is predicted to run out of space within the next 24 hours.
       expr: |-
         (
-          node_filesystem_avail_bytes{job="node-exporter",{{ $.Values.defaultRules.node.fsSelector }},mountpoint!=""} / node_filesystem_size_bytes{job="node-exporter",{{ $.Values.defaultRules.node.fsSelector }},mountpoint!=""} * 100 < 15
+          node_filesystem_avail_bytes{job="prometheus-node-exporter",{{ $.Values.defaultRules.node.fsSelector }},mountpoint!=""} / node_filesystem_size_bytes{job="prometheus-node-exporter",{{ $.Values.defaultRules.node.fsSelector }},mountpoint!=""} * 100 < 15
         and
-          predict_linear(node_filesystem_avail_bytes{job="node-exporter",{{ $.Values.defaultRules.node.fsSelector }},mountpoint!=""}[6h], 24*60*60) < 0
+          predict_linear(node_filesystem_avail_bytes{job="prometheus-node-exporter",{{ $.Values.defaultRules.node.fsSelector }},mountpoint!=""}[6h], 24*60*60) < 0
         and
-          node_filesystem_readonly{job="node-exporter",{{ $.Values.defaultRules.node.fsSelector }},mountpoint!=""} == 0
+          node_filesystem_readonly{job="prometheus-node-exporter",{{ $.Values.defaultRules.node.fsSelector }},mountpoint!=""} == 0
         )
       for: {{ dig "NodeFilesystemSpaceFillingUp" "for" "1h" .Values.customRules }}
       {{- with .Values.defaultRules.keepFiringFor }}
@@ -73,11 +73,11 @@ spec:
         summary: Filesystem is predicted to run out of space within the next 4 hours.
       expr: |-
         (
-          node_filesystem_avail_bytes{job="node-exporter",{{ $.Values.defaultRules.node.fsSelector }},mountpoint!=""} / node_filesystem_size_bytes{job="node-exporter",{{ $.Values.defaultRules.node.fsSelector }},mountpoint!=""} * 100 < 10
+          node_filesystem_avail_bytes{job="prometheus-node-exporter",{{ $.Values.defaultRules.node.fsSelector }},mountpoint!=""} / node_filesystem_size_bytes{job="prometheus-node-exporter",{{ $.Values.defaultRules.node.fsSelector }},mountpoint!=""} * 100 < 10
         and
-          predict_linear(node_filesystem_avail_bytes{job="node-exporter",{{ $.Values.defaultRules.node.fsSelector }},mountpoint!=""}[6h], 4*60*60) < 0
+          predict_linear(node_filesystem_avail_bytes{job="prometheus-node-exporter",{{ $.Values.defaultRules.node.fsSelector }},mountpoint!=""}[6h], 4*60*60) < 0
         and
-          node_filesystem_readonly{job="node-exporter",{{ $.Values.defaultRules.node.fsSelector }},mountpoint!=""} == 0
+          node_filesystem_readonly{job="prometheus-node-exporter",{{ $.Values.defaultRules.node.fsSelector }},mountpoint!=""} == 0
         )
       for: {{ dig "NodeFilesystemSpaceFillingUp" "for" "1h" .Values.customRules }}
       {{- with .Values.defaultRules.keepFiringFor }}
@@ -108,9 +108,9 @@ spec:
         summary: Filesystem has less than 5% space left.
       expr: |-
         (
-          node_filesystem_avail_bytes{job="node-exporter",{{ $.Values.defaultRules.node.fsSelector }},mountpoint!=""} / node_filesystem_size_bytes{job="node-exporter",{{ $.Values.defaultRules.node.fsSelector }},mountpoint!=""} * 100 < 5
+          node_filesystem_avail_bytes{job="prometheus-node-exporter",{{ $.Values.defaultRules.node.fsSelector }},mountpoint!=""} / node_filesystem_size_bytes{job="prometheus-node-exporter",{{ $.Values.defaultRules.node.fsSelector }},mountpoint!=""} * 100 < 5
         and
-          node_filesystem_readonly{job="node-exporter",{{ $.Values.defaultRules.node.fsSelector }},mountpoint!=""} == 0
+          node_filesystem_readonly{job="prometheus-node-exporter",{{ $.Values.defaultRules.node.fsSelector }},mountpoint!=""} == 0
         )
       for: {{ dig "NodeFilesystemAlmostOutOfSpace" "for" "30m" .Values.customRules }}
       {{- with .Values.defaultRules.keepFiringFor }}
@@ -141,9 +141,9 @@ spec:
         summary: Filesystem has less than 3% space left.
       expr: |-
         (
-          node_filesystem_avail_bytes{job="node-exporter",{{ $.Values.defaultRules.node.fsSelector }},mountpoint!=""} / node_filesystem_size_bytes{job="node-exporter",{{ $.Values.defaultRules.node.fsSelector }},mountpoint!=""} * 100 < 3
+          node_filesystem_avail_bytes{job="prometheus-node-exporter",{{ $.Values.defaultRules.node.fsSelector }},mountpoint!=""} / node_filesystem_size_bytes{job="prometheus-node-exporter",{{ $.Values.defaultRules.node.fsSelector }},mountpoint!=""} * 100 < 3
         and
-          node_filesystem_readonly{job="node-exporter",{{ $.Values.defaultRules.node.fsSelector }},mountpoint!=""} == 0
+          node_filesystem_readonly{job="prometheus-node-exporter",{{ $.Values.defaultRules.node.fsSelector }},mountpoint!=""} == 0
         )
       for: {{ dig "NodeFilesystemAlmostOutOfSpace" "for" "30m" .Values.customRules }}
       {{- with .Values.defaultRules.keepFiringFor }}
@@ -174,11 +174,11 @@ spec:
         summary: Filesystem is predicted to run out of inodes within the next 24 hours.
       expr: |-
         (
-          node_filesystem_files_free{job="node-exporter",{{ $.Values.defaultRules.node.fsSelector }},mountpoint!=""} / node_filesystem_files{job="node-exporter",{{ $.Values.defaultRules.node.fsSelector }},mountpoint!=""} * 100 < 40
+          node_filesystem_files_free{job="prometheus-node-exporter",{{ $.Values.defaultRules.node.fsSelector }},mountpoint!=""} / node_filesystem_files{job="prometheus-node-exporter",{{ $.Values.defaultRules.node.fsSelector }},mountpoint!=""} * 100 < 40
         and
-          predict_linear(node_filesystem_files_free{job="node-exporter",{{ $.Values.defaultRules.node.fsSelector }},mountpoint!=""}[6h], 24*60*60) < 0
+          predict_linear(node_filesystem_files_free{job="prometheus-node-exporter",{{ $.Values.defaultRules.node.fsSelector }},mountpoint!=""}[6h], 24*60*60) < 0
         and
-          node_filesystem_readonly{job="node-exporter",{{ $.Values.defaultRules.node.fsSelector }},mountpoint!=""} == 0
+          node_filesystem_readonly{job="prometheus-node-exporter",{{ $.Values.defaultRules.node.fsSelector }},mountpoint!=""} == 0
         )
       for: {{ dig "NodeFilesystemFilesFillingUp" "for" "1h" .Values.customRules }}
       {{- with .Values.defaultRules.keepFiringFor }}
@@ -209,11 +209,11 @@ spec:
         summary: Filesystem is predicted to run out of inodes within the next 4 hours.
       expr: |-
         (
-          node_filesystem_files_free{job="node-exporter",{{ $.Values.defaultRules.node.fsSelector }},mountpoint!=""} / node_filesystem_files{job="node-exporter",{{ $.Values.defaultRules.node.fsSelector }},mountpoint!=""} * 100 < 20
+          node_filesystem_files_free{job="prometheus-node-exporter",{{ $.Values.defaultRules.node.fsSelector }},mountpoint!=""} / node_filesystem_files{job="prometheus-node-exporter",{{ $.Values.defaultRules.node.fsSelector }},mountpoint!=""} * 100 < 20
         and
-          predict_linear(node_filesystem_files_free{job="node-exporter",{{ $.Values.defaultRules.node.fsSelector }},mountpoint!=""}[6h], 4*60*60) < 0
+          predict_linear(node_filesystem_files_free{job="prometheus-node-exporter",{{ $.Values.defaultRules.node.fsSelector }},mountpoint!=""}[6h], 4*60*60) < 0
         and
-          node_filesystem_readonly{job="node-exporter",{{ $.Values.defaultRules.node.fsSelector }},mountpoint!=""} == 0
+          node_filesystem_readonly{job="prometheus-node-exporter",{{ $.Values.defaultRules.node.fsSelector }},mountpoint!=""} == 0
         )
       for: {{ dig "NodeFilesystemFilesFillingUp" "for" "1h" .Values.customRules }}
       {{- with .Values.defaultRules.keepFiringFor }}
@@ -244,9 +244,9 @@ spec:
         summary: Filesystem has less than 5% inodes left.
       expr: |-
         (
-          node_filesystem_files_free{job="node-exporter",{{ $.Values.defaultRules.node.fsSelector }},mountpoint!=""} / node_filesystem_files{job="node-exporter",{{ $.Values.defaultRules.node.fsSelector }},mountpoint!=""} * 100 < 5
+          node_filesystem_files_free{job="prometheus-node-exporter",{{ $.Values.defaultRules.node.fsSelector }},mountpoint!=""} / node_filesystem_files{job="prometheus-node-exporter",{{ $.Values.defaultRules.node.fsSelector }},mountpoint!=""} * 100 < 5
         and
-          node_filesystem_readonly{job="node-exporter",{{ $.Values.defaultRules.node.fsSelector }},mountpoint!=""} == 0
+          node_filesystem_readonly{job="prometheus-node-exporter",{{ $.Values.defaultRules.node.fsSelector }},mountpoint!=""} == 0
         )
       for: {{ dig "NodeFilesystemAlmostOutOfFiles" "for" "1h" .Values.customRules }}
       {{- with .Values.defaultRules.keepFiringFor }}
@@ -277,9 +277,9 @@ spec:
         summary: Filesystem has less than 3% inodes left.
       expr: |-
         (
-          node_filesystem_files_free{job="node-exporter",{{ $.Values.defaultRules.node.fsSelector }},mountpoint!=""} / node_filesystem_files{job="node-exporter",{{ $.Values.defaultRules.node.fsSelector }},mountpoint!=""} * 100 < 3
+          node_filesystem_files_free{job="prometheus-node-exporter",{{ $.Values.defaultRules.node.fsSelector }},mountpoint!=""} / node_filesystem_files{job="prometheus-node-exporter",{{ $.Values.defaultRules.node.fsSelector }},mountpoint!=""} * 100 < 3
         and
-          node_filesystem_readonly{job="node-exporter",{{ $.Values.defaultRules.node.fsSelector }},mountpoint!=""} == 0
+          node_filesystem_readonly{job="prometheus-node-exporter",{{ $.Values.defaultRules.node.fsSelector }},mountpoint!=""} == 0
         )
       for: {{ dig "NodeFilesystemAlmostOutOfFiles" "for" "1h" .Values.customRules }}
       {{- with .Values.defaultRules.keepFiringFor }}
@@ -308,7 +308,7 @@ spec:
         description: '{{`{{`}} $labels.instance {{`}}`}} interface {{`{{`}} $labels.device {{`}}`}} has encountered {{`{{`}} printf "%.0f" $value {{`}}`}} receive errors in the last two minutes.'
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/node/nodenetworkreceiveerrs
         summary: Network interface is reporting many receive errors.
-      expr: rate(node_network_receive_errs_total{job="node-exporter"}[2m]) / rate(node_network_receive_packets_total{job="node-exporter"}[2m]) > 0.01
+      expr: rate(node_network_receive_errs_total{job="prometheus-node-exporter"}[2m]) / rate(node_network_receive_packets_total{job="prometheus-node-exporter"}[2m]) > 0.01
       for: {{ dig "NodeNetworkReceiveErrs" "for" "1h" .Values.customRules }}
       {{- with .Values.defaultRules.keepFiringFor }}
       keep_firing_for: "{{ . }}"
@@ -336,7 +336,7 @@ spec:
         description: '{{`{{`}} $labels.instance {{`}}`}} interface {{`{{`}} $labels.device {{`}}`}} has encountered {{`{{`}} printf "%.0f" $value {{`}}`}} transmit errors in the last two minutes.'
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/node/nodenetworktransmiterrs
         summary: Network interface is reporting many transmit errors.
-      expr: rate(node_network_transmit_errs_total{job="node-exporter"}[2m]) / rate(node_network_transmit_packets_total{job="node-exporter"}[2m]) > 0.01
+      expr: rate(node_network_transmit_errs_total{job="prometheus-node-exporter"}[2m]) / rate(node_network_transmit_packets_total{job="prometheus-node-exporter"}[2m]) > 0.01
       for: {{ dig "NodeNetworkTransmitErrs" "for" "1h" .Values.customRules }}
       {{- with .Values.defaultRules.keepFiringFor }}
       keep_firing_for: "{{ . }}"
@@ -364,7 +364,7 @@ spec:
         description: '{{`{{`}} $labels.instance {{`}}`}} {{`{{`}} $value | humanizePercentage {{`}}`}} of conntrack entries are used.'
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/node/nodehighnumberconntrackentriesused
         summary: Number of conntrack are getting close to the limit.
-      expr: (node_nf_conntrack_entries{job="node-exporter"} / node_nf_conntrack_entries_limit) > 0.75
+      expr: (node_nf_conntrack_entries{job="prometheus-node-exporter"} / node_nf_conntrack_entries_limit) > 0.75
       labels:
         severity: {{ dig "NodeHighNumberConntrackEntriesUsed" "severity" "warning" .Values.customRules }}
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.nodeExporterAlerting }}
@@ -388,7 +388,7 @@ spec:
         description: Node Exporter text file collector on {{`{{`}} $labels.instance {{`}}`}} failed to scrape.
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/node/nodetextfilecollectorscrapeerror
         summary: Node Exporter text file collector failed to scrape.
-      expr: node_textfile_scrape_error{job="node-exporter"} == 1
+      expr: node_textfile_scrape_error{job="prometheus-node-exporter"} == 1
       labels:
         severity: {{ dig "NodeTextFileCollectorScrapeError" "severity" "warning" .Values.customRules }}
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.nodeExporterAlerting }}
@@ -414,15 +414,15 @@ spec:
         summary: Clock skew detected.
       expr: |-
         (
-          node_timex_offset_seconds{job="node-exporter"} > 0.05
+          node_timex_offset_seconds{job="prometheus-node-exporter"} > 0.05
         and
-          deriv(node_timex_offset_seconds{job="node-exporter"}[5m]) >= 0
+          deriv(node_timex_offset_seconds{job="prometheus-node-exporter"}[5m]) >= 0
         )
         or
         (
-          node_timex_offset_seconds{job="node-exporter"} < -0.05
+          node_timex_offset_seconds{job="prometheus-node-exporter"} < -0.05
         and
-          deriv(node_timex_offset_seconds{job="node-exporter"}[5m]) <= 0
+          deriv(node_timex_offset_seconds{job="prometheus-node-exporter"}[5m]) <= 0
         )
       for: {{ dig "NodeClockSkewDetected" "for" "10m" .Values.customRules }}
       {{- with .Values.defaultRules.keepFiringFor }}
@@ -452,9 +452,9 @@ spec:
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/node/nodeclocknotsynchronising
         summary: Clock not synchronising.
       expr: |-
-        min_over_time(node_timex_sync_status{job="node-exporter"}[5m]) == 0
+        min_over_time(node_timex_sync_status{job="prometheus-node-exporter"}[5m]) == 0
         and
-        node_timex_maxerror_seconds{job="node-exporter"} >= 16
+        node_timex_maxerror_seconds{job="prometheus-node-exporter"} >= 16
       for: {{ dig "NodeClockNotSynchronising" "for" "10m" .Values.customRules }}
       {{- with .Values.defaultRules.keepFiringFor }}
       keep_firing_for: "{{ . }}"
@@ -482,7 +482,7 @@ spec:
         description: RAID array '{{`{{`}} $labels.device {{`}}`}}' at {{`{{`}} $labels.instance {{`}}`}} is in degraded state due to one or more disks failures. Number of spare drives is insufficient to fix issue automatically.
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/node/noderaiddegraded
         summary: RAID Array is degraded.
-      expr: node_md_disks_required{job="node-exporter",device=~"(/dev/)?(mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|md.+|dasd.+)"} - ignoring (state) (node_md_disks{state="active",job="node-exporter",device=~"(/dev/)?(mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|md.+|dasd.+)"}) > 0
+      expr: node_md_disks_required{job="prometheus-node-exporter",device=~"(/dev/)?(mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|md.+|dasd.+)"} - ignoring (state) (node_md_disks{state="active",job="prometheus-node-exporter",device=~"(/dev/)?(mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|md.+|dasd.+)"}) > 0
       for: {{ dig "NodeRAIDDegraded" "for" "15m" .Values.customRules }}
       {{- with .Values.defaultRules.keepFiringFor }}
       keep_firing_for: "{{ . }}"
@@ -510,7 +510,7 @@ spec:
         description: At least one device in RAID array at {{`{{`}} $labels.instance {{`}}`}} failed. Array '{{`{{`}} $labels.device {{`}}`}}' needs attention and possibly a disk swap.
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/node/noderaiddiskfailure
         summary: Failed device in RAID array.
-      expr: node_md_disks{state="failed",job="node-exporter",device=~"(/dev/)?(mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|md.+|dasd.+)"} > 0
+      expr: node_md_disks{state="failed",job="prometheus-node-exporter",device=~"(/dev/)?(mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|md.+|dasd.+)"} > 0
       labels:
         severity: {{ dig "NodeRAIDDiskFailure" "severity" "warning" .Values.customRules }}
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.nodeExporterAlerting }}
@@ -536,7 +536,7 @@ spec:
         summary: Kernel is predicted to exhaust file descriptors limit soon.
       expr: |-
         (
-          node_filefd_allocated{job="node-exporter"} * 100 / node_filefd_maximum{job="node-exporter"} > 70
+          node_filefd_allocated{job="prometheus-node-exporter"} * 100 / node_filefd_maximum{job="prometheus-node-exporter"} > 70
         )
       for: {{ dig "NodeFileDescriptorLimit" "for" "15m" .Values.customRules }}
       {{- with .Values.defaultRules.keepFiringFor }}
@@ -567,7 +567,7 @@ spec:
         summary: Kernel is predicted to exhaust file descriptors limit soon.
       expr: |-
         (
-          node_filefd_allocated{job="node-exporter"} * 100 / node_filefd_maximum{job="node-exporter"} > 90
+          node_filefd_allocated{job="prometheus-node-exporter"} * 100 / node_filefd_maximum{job="prometheus-node-exporter"} > 90
         )
       for: {{ dig "NodeFileDescriptorLimit" "for" "15m" .Values.customRules }}
       {{- with .Values.defaultRules.keepFiringFor }}
@@ -598,7 +598,7 @@ spec:
           '
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/node/nodecpuhighusage
         summary: High CPU usage.
-      expr: sum without(mode) (avg without (cpu) (rate(node_cpu_seconds_total{job="node-exporter", mode!~"idle|iowait"}[2m]))) * 100 > 90
+      expr: sum without(mode) (avg without (cpu) (rate(node_cpu_seconds_total{job="prometheus-node-exporter", mode!~"idle|iowait"}[2m]))) * 100 > 90
       for: {{ dig "NodeCPUHighUsage" "for" "15m" .Values.customRules }}
       {{- with .Values.defaultRules.keepFiringFor }}
       keep_firing_for: "{{ . }}"
@@ -631,8 +631,8 @@ spec:
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/node/nodesystemsaturation
         summary: System saturated, load per core is very high.
       expr: |-
-        node_load1{job="node-exporter"}
-        / count without (cpu, mode) (node_cpu_seconds_total{job="node-exporter", mode="idle"}) > 2
+        node_load1{job="prometheus-node-exporter"}
+        / count without (cpu, mode) (node_cpu_seconds_total{job="prometheus-node-exporter", mode="idle"}) > 2
       for: {{ dig "NodeSystemSaturation" "for" "15m" .Values.customRules }}
       {{- with .Values.defaultRules.keepFiringFor }}
       keep_firing_for: "{{ . }}"
@@ -664,7 +664,7 @@ spec:
           '
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/node/nodememorymajorpagesfaults
         summary: Memory major page faults are occurring at very high rate.
-      expr: rate(node_vmstat_pgmajfault{job="node-exporter"}[5m]) > 500
+      expr: rate(node_vmstat_pgmajfault{job="prometheus-node-exporter"}[5m]) > 500
       for: {{ dig "NodeMemoryMajorPagesFaults" "for" "15m" .Values.customRules }}
       {{- with .Values.defaultRules.keepFiringFor }}
       keep_firing_for: "{{ . }}"
@@ -694,7 +694,7 @@ spec:
           '
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/node/nodememoryhighutilization
         summary: Host is running out of memory.
-      expr: 100 - (node_memory_MemAvailable_bytes{job="node-exporter"} / node_memory_MemTotal_bytes{job="node-exporter"} * 100) > 90
+      expr: 100 - (node_memory_MemAvailable_bytes{job="prometheus-node-exporter"} / node_memory_MemTotal_bytes{job="prometheus-node-exporter"} * 100) > 90
       for: {{ dig "NodeMemoryHighUtilization" "for" "15m" .Values.customRules }}
       {{- with .Values.defaultRules.keepFiringFor }}
       keep_firing_for: "{{ . }}"
@@ -726,7 +726,7 @@ spec:
           '
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/node/nodediskiosaturation
         summary: Disk IO queue is high.
-      expr: rate(node_disk_io_time_weighted_seconds_total{job="node-exporter", device=~"(/dev/)?(mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|md.+|dasd.+)"}[5m]) > 10
+      expr: rate(node_disk_io_time_weighted_seconds_total{job="prometheus-node-exporter", device=~"(/dev/)?(mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|md.+|dasd.+)"}[5m]) > 10
       for: {{ dig "NodeDiskIOSaturation" "for" "30m" .Values.customRules }}
       {{- with .Values.defaultRules.keepFiringFor }}
       keep_firing_for: "{{ . }}"
@@ -754,7 +754,7 @@ spec:
         description: Systemd service {{`{{`}} $labels.name {{`}}`}} has entered failed state at {{`{{`}} $labels.instance {{`}}`}}
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/node/nodesystemdservicefailed
         summary: Systemd service has entered failed state.
-      expr: node_systemd_unit_state{job="node-exporter", state="failed"} == 1
+      expr: node_systemd_unit_state{job="prometheus-node-exporter", state="failed"} == 1
       for: {{ dig "NodeSystemdServiceFailed" "for" "5m" .Values.customRules }}
       {{- with .Values.defaultRules.keepFiringFor }}
       keep_firing_for: "{{ . }}"
@@ -782,7 +782,7 @@ spec:
         description: Systemd service {{`{{`}} $labels.name {{`}}`}} has being restarted too many times at {{`{{`}} $labels.instance {{`}}`}} for the last 15 minutes. Please check if service is crash looping.
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/node/nodesystemdservicecrashlooping
         summary: Systemd service keeps restaring, possibly crash looping.
-      expr: increase(node_systemd_service_restart_total{job="node-exporter"}[5m]) > 2
+      expr: increase(node_systemd_service_restart_total{job="prometheus-node-exporter"}[5m]) > 2
       for: {{ dig "NodeSystemdServiceCrashlooping" "for" "15m" .Values.customRules }}
       {{- with .Values.defaultRules.keepFiringFor }}
       keep_firing_for: "{{ . }}"

--- a/charts/kof-mothership/templates/prometheus/rules/node-network.yaml
+++ b/charts/kof-mothership/templates/prometheus/rules/node-network.yaml
@@ -36,7 +36,7 @@ spec:
         description: Network interface "{{`{{`}} $labels.device {{`}}`}}" changing its up status often on node-exporter {{`{{`}} $labels.namespace {{`}}`}}/{{`{{`}} $labels.pod {{`}}`}}
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/general/nodenetworkinterfaceflapping
         summary: Network interface is often changing its status
-      expr: changes(node_network_up{job="node-exporter",device!~"veth.+"}[2m]) > 2
+      expr: changes(node_network_up{job="prometheus-node-exporter",device!~"veth.+"}[2m]) > 2
       for: {{ dig "NodeNetworkInterfaceFlapping" "for" "2m" .Values.customRules }}
       {{- with .Values.defaultRules.keepFiringFor }}
       keep_firing_for: "{{ . }}"

--- a/charts/kof-mothership/templates/prometheus/rules/node.rules.yaml
+++ b/charts/kof-mothership/templates/prometheus/rules/node.rules.yaml
@@ -42,7 +42,7 @@ spec:
       {{- end }}
     - expr: |-
         count by ({{ range $.Values.defaultRules.additionalAggregationLabels }}{{ . }},{{ end }}cluster, node) (
-          node_cpu_seconds_total{mode="idle",job="node-exporter"}
+          node_cpu_seconds_total{mode="idle",job="prometheus-node-exporter"}
           * on ({{ range $.Values.defaultRules.additionalAggregationLabels }}{{ . }},{{ end }}cluster, namespace, pod) group_left(node)
           topk by ({{ range $.Values.defaultRules.additionalAggregationLabels }}{{ . }},{{ end }}cluster, namespace, pod) (1, node_namespace_pod:kube_pod_info:)
         )
@@ -58,12 +58,12 @@ spec:
       {{- end }}
     - expr: |-
         sum(
-          node_memory_MemAvailable_bytes{job="node-exporter"} or
+          node_memory_MemAvailable_bytes{job="prometheus-node-exporter"} or
           (
-            node_memory_Buffers_bytes{job="node-exporter"} +
-            node_memory_Cached_bytes{job="node-exporter"} +
-            node_memory_MemFree_bytes{job="node-exporter"} +
-            node_memory_Slab_bytes{job="node-exporter"}
+            node_memory_Buffers_bytes{job="prometheus-node-exporter"} +
+            node_memory_Cached_bytes{job="prometheus-node-exporter"} +
+            node_memory_MemFree_bytes{job="prometheus-node-exporter"} +
+            node_memory_Slab_bytes{job="prometheus-node-exporter"}
           )
         ) by ({{ range $.Values.defaultRules.additionalAggregationLabels }}{{ . }},{{ end }}cluster)
       record: :node_memory_MemAvailable_bytes:sum
@@ -79,7 +79,7 @@ spec:
     - expr: |-
         avg by ({{ range $.Values.defaultRules.additionalAggregationLabels }}{{ . }},{{ end }}cluster, node) (
           sum without (mode) (
-            rate(node_cpu_seconds_total{mode!="idle",mode!="iowait",mode!="steal",job="node-exporter"}[5m])
+            rate(node_cpu_seconds_total{mode!="idle",mode!="iowait",mode!="steal",job="prometheus-node-exporter"}[5m])
           )
         )
       record: node:node_cpu_utilization:ratio_rate5m


### PR DESCRIPTION
* Part of https://github.com/k0rdent/docs/issues/375 caused by https://github.com/k0rdent/kof/issues/242
* Related PRs: https://github.com/k0rdent/kof/pull/248 and https://github.com/k0rdent/docs/pull/397
* Found the new `CPUThrottlingHigh` alert doesn't work against current metrics,
  because [new alert queries](https://github.com/k0rdent/kof/blob/332f66ff03bae8abd37cc7e754dd8d7a42d059a7/charts/kof-mothership/templates/prometheus/rules/kubernetes-resources.yaml#L263-L265)
  `container_cpu_cfs_periods_total{job="kubelet", metrics_path="/metrics/cadvisor"}`,
  while current metrics data `group by (job, metrics_path) (container_cpu_cfs_periods_total)` shows
  `{job="integrations/kubernetes/cadvisor"}`
* The new metrics collectors PR https://github.com/k0rdent/kof/pull/273 is not ready yet and is hard to fix quickly.
* To avoid blocking of upcoming release we have to temporary adapt new alerts to current metrics.

<details><summary>Details of the fix (click to expand)</summary>

* Found jobs in old rules:
  ```
  git checkout v1.0.0
  cd charts/kof-mothership/files/rules/
  rgrep -ohE 'job=".+?"' | sort | uniq

    job="apiserver"
    job="kube-state-metrics"
    job="kubelet"
    job="node-exporter"
  ```
* [Old rule CPUThrottlingHigh](https://github.com/k0rdent/kof/blob/v1.0.0/charts/kof-mothership/files/rules/kubernetes-resources.yaml#L101-L110)
  did not filter by job at all: `container_cpu_cfs_periods_total{}`
* Found jobs in new rules:
  ```
  git checkout main
  cd charts/kof-mothership/templates/prometheus/rules/
  rgrep -ohE 'job=".+?"' | sort | uniq

    job="{{ $alertmanagerJob }}"
    job="{{ $kubeStateMetricsJob }}"
    job="{{ $operatorJob }}"
    job="{{ $prometheusJob }}"
    job="apiserver"
    job="kube-controller-manager"
    job="kube-proxy"
    job="kube-scheduler"
    job="kubelet"
    job="node-exporter"
    job="windows-exporter"

  kubectl get prometheusrule -A -o yaml | grep -oE 'job=".+?"' | sort | uniq

    job="apiserver"
    job="kof-mothership-alertmanager"
    job="kof-mothership-operator"
    job="kof-mothership-prometheus"
    job="kube-state-metrics"
    job="kubelet"
    job="node-exporter"
  ```
* Found jobs in current metrics data:
  ```
  group by (job, metrics_path) (up)

    {job="apiserver"}
    {job="integrations/kubernetes/cadvisor"}
    {job="integrations/kubernetes/kubelet"}
    {job="kof-collectors-opencost"}
    {job="kube-state-metrics"}
    {job="prometheus-node-exporter"}
  ```
* So `apiserver` and `kube-state-metrics` are OK,
  but `kubelet` and `node-exporter` needs replacements.
* Finding and replacing:
  ```
  cd charts/kof-mothership/templates/prometheus/rules/
  rgrep -h 'job="kubelet"' | grep -oE 'metrics_path=".+?"' | sort | uniq

    metrics_path="/metrics"
    metrics_path="/metrics/cadvisor"

  rgrep -h 'job="kubelet"' | grep 'metrics_path="/metrics"'

    kubelet_running_pods{job="kubelet", metrics_path="/metrics"}
    ...
    kubelet_volume_stats_available_bytes{job="kubelet", namespace=~"{{ $targetNamespace }}", metrics_path="/metrics"}

  group by (job, metrics_path) (kubelet_running_pods)

    {job="integrations/kubernetes/kubelet"}

  group by (job, metrics_path) (kubelet_volume_stats_available_bytes)

    {job="integrations/kubernetes/kubelet"}

  sed -i '' 's:job="kubelet", metrics_path="/metrics":job="integrations/kubernetes/kubelet":g' *
  sed -i '' 's:job="kubelet", namespace=~"{{ $targetNamespace }}", metrics_path="/metrics":job="integrations/kubernetes/kubelet", namespace=~"{{ $targetNamespace }}":g' *  

    # See the "Files changed" in this PR.

  rgrep -h 'job="kubelet"' | grep 'metrics_path="/metrics/cadvisor"'

    container_memory_swap{job="kubelet", metrics_path="/metrics/cadvisor", image!=""}
    ...

  group by (job, metrics_path) (container_memory_swap)

    {job="integrations/kubernetes/cadvisor"}

  sed -i '' 's:job="kubelet", metrics_path="/metrics/cadvisor":job="integrations/kubernetes/cadvisor":g' *

  rgrep 'job="kubelet"'

    # None, OK.

  rgrep 'job="node-exporter"'

    node_cpu_seconds_total{mode="idle",job="node-exporter"}
    ...

  group by (job) (node_cpu_seconds_total)

    {job="{job="prometheus-node-exporter"}"}

  sed -i '' 's:job="node-exporter":job="prometheus-node-exporter":g' *

  rgrep 'job="node-exporter"'

    # None, OK.
  ```

</details>

* It works now:

<img width="1233" alt="Screenshot 2025-06-05 at 15 52 54" src="https://github.com/user-attachments/assets/6c1fbb1e-8b56-454b-a472-4d5dfe09a385" />
