### PR TITLE
chore: align chart versions; sveltos dashboard bump to 0.54.0

### DIFF
--- a/charts/kof-collectors/Chart.lock
+++ b/charts/kof-collectors/Chart.lock
@@ -8,5 +8,5 @@ dependencies:
 - name: opencost
   repository: https://opencost.github.io/opencost-helm-chart
   version: 1.42.3
-digest: sha256:5d72bb43842150022dccab88096331cfdde00098f6b9e4e7e7067359da949de7
-generated: "2024-12-23T18:30:11.331385+02:00"
+digest: sha256:cd0256130272350db619dd2bc3b328d01496503007b785519ba54261439338f1
+generated: "2025-06-11T12:00:10.758747395-05:00"

--- a/charts/kof-collectors/Chart.yaml
+++ b/charts/kof-collectors/Chart.yaml
@@ -5,14 +5,14 @@ version: "1.0.0"
 appVersion: "1.0.0"
 dependencies:
   - name: prometheus-node-exporter
-    version: "4.39.*"
+    version: "4.39.0"
     repository: https://prometheus-community.github.io/helm-charts
     condition: prometheus-node-exporter.enabled
   - name: kube-state-metrics
-    version: "5.25.*"
+    version: "5.25.1"
     repository: https://prometheus-community.github.io/helm-charts
     condition: kube-state-metrics.enabled
   - name: opencost
-    version: "1.42.*"
+    version: "1.42.3"
     repository: https://opencost.github.io/opencost-helm-chart
     condition: opencost.enabled

--- a/charts/kof-mothership/Chart.lock
+++ b/charts/kof-mothership/Chart.lock
@@ -1,21 +1,21 @@
 dependencies:
 - name: grafana-operator
   repository: oci://ghcr.io/grafana/helm-charts
-  version: v5.13.0
+  version: v5.15.1
 - name: victoria-metrics-operator
   repository: https://victoriametrics.github.io/helm-charts/
-  version: 0.36.0
+  version: 0.40.5
 - name: cluster-api-visualizer
   repository: oci://ghcr.io/k0rdent/cluster-api-visualizer/charts
   version: 1.4.0
 - name: sveltos-dashboard
-  repository: https://projectsveltos.github.io/dashboard-helm-chart
-  version: 0.44.0
+  repository: https://projectsveltos.github.io/helm-charts
+  version: 0.54.0
 - name: kgst
   repository: oci://ghcr.io/k0rdent/catalog/charts
   version: 0.1.1
 - name: kgst
   repository: oci://ghcr.io/k0rdent/catalog/charts
   version: 0.1.1
-digest: sha256:5104a74fd71d9c5be515a9d269e32aaa57879c2b90580d69d904c8e154dcb5ac
-generated: "2025-04-03T11:18:06.899233+02:00"
+digest: sha256:ea05288a05f3d594cf5bbf0ebc655adcd633f3a9169779a402c7e01669facca5
+generated: "2025-06-11T11:58:29.539122516-05:00"

--- a/charts/kof-mothership/Chart.yaml
+++ b/charts/kof-mothership/Chart.yaml
@@ -5,11 +5,11 @@ version: "1.0.0"
 appVersion: "1.0.0"
 dependencies:
   - name: grafana-operator
-    version: v5.13.0
+    version: "v5.15.1"
     repository: "oci://ghcr.io/grafana/helm-charts"
     condition: grafana.enabled
   - name: victoria-metrics-operator
-    version: "0.36.*"
+    version: "0.40.5"
     repository: "https://victoriametrics.github.io/helm-charts/"
     condition: victoria-metrics-operator.enabled
   - name: cluster-api-visualizer
@@ -17,14 +17,14 @@ dependencies:
     repository: "oci://ghcr.io/k0rdent/cluster-api-visualizer/charts"
     condition: cluster-api-visualizer.enabled
   - name: sveltos-dashboard
-    version: "0.44.*"
-    repository: "https://projectsveltos.github.io/dashboard-helm-chart"
+    version: "0.54.0"
+    repository: "https://projectsveltos.github.io/helm-charts"
     condition: sveltos-dashboard.enabled
   - name: kgst
     alias: cert-manager-service-template
-    version: 0.1.1
+    version: "0.1.1"
     repository: oci://ghcr.io/k0rdent/catalog/charts
   - name: kgst
     alias: ingress-nginx-service-template
-    version: 0.1.1
+    version: "0.1.1"
     repository: oci://ghcr.io/k0rdent/catalog/charts

--- a/charts/kof-mothership/README.md
+++ b/charts/kof-mothership/README.md
@@ -8,9 +8,9 @@ A Helm chart that deploys Grafana, Promxy, and VictoriaMetrics.
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://projectsveltos.github.io/dashboard-helm-chart | sveltos-dashboard | 0.44.* |
-| https://victoriametrics.github.io/helm-charts/ | victoria-metrics-operator | 0.36.* |
-| oci://ghcr.io/grafana/helm-charts | grafana-operator | v5.13.0 |
+| https://projectsveltos.github.io/helm-charts | sveltos-dashboard | 0.54.0 |
+| https://victoriametrics.github.io/helm-charts/ | victoria-metrics-operator | 0.40.5 |
+| oci://ghcr.io/grafana/helm-charts | grafana-operator | v5.15.1 |
 | oci://ghcr.io/k0rdent/catalog/charts | cert-manager-service-template(kgst) | 0.1.1 |
 | oci://ghcr.io/k0rdent/catalog/charts | ingress-nginx-service-template(kgst) | 0.1.1 |
 | oci://ghcr.io/k0rdent/cluster-api-visualizer/charts | cluster-api-visualizer | 1.4.0 |

--- a/charts/kof-operators/Chart.lock
+++ b/charts/kof-operators/Chart.lock
@@ -5,5 +5,5 @@ dependencies:
 - name: prometheus-operator-crds
   repository: https://prometheus-community.github.io/helm-charts
   version: 15.0.0
-digest: sha256:0f7db56597c5a27edaa4205548477f2d2be43d02e3bde93b2fc0d52eaa871ad0
-generated: "2025-04-11T12:16:31.042352+03:00"
+digest: sha256:6c1255d6ae2aaacadf2663a508d469572a2b5cf09808c7f5687d0a552427d019
+generated: "2025-06-11T12:01:13.066149079-05:00"

--- a/charts/kof-operators/Chart.yaml
+++ b/charts/kof-operators/Chart.yaml
@@ -5,10 +5,10 @@ version: "1.0.0"
 appVersion: "1.0.0"
 dependencies:
   - name: opentelemetry-operator
-    version: "0.84.*"
+    version: "0.84.2"
     repository: "https://open-telemetry.github.io/opentelemetry-helm-charts"
     condition: opentelemetry-operator.enabled
   - name: prometheus-operator-crds
-    version: "15.0.*"
+    version: "15.0.0"
     repository: https://prometheus-community.github.io/helm-charts
     condition: prometheus-operator-crds.enabled

--- a/charts/kof-storage/Chart.lock
+++ b/charts/kof-storage/Chart.lock
@@ -14,5 +14,5 @@ dependencies:
 - name: jaeger-operator
   repository: https://jaegertracing.github.io/helm-charts
   version: 2.50.1
-digest: sha256:74af0d11d9c8b0f10dcc70cf50e162daf360209611413ea4c8e0837cf218457a
-generated: "2025-05-12T17:08:18.363152+03:00"
+digest: sha256:84e13a4e5b376b8a0e5a1902386fea9d14672f21668f68722170bb275d3bf9db
+generated: "2025-06-11T12:01:30.669484791-05:00"

--- a/charts/kof-storage/Chart.yaml
+++ b/charts/kof-storage/Chart.yaml
@@ -5,22 +5,22 @@ version: "1.0.0"
 appVersion: "1.0.0"
 dependencies:
   - name: grafana-operator
-    version: v5.15.1
+    version: "v5.15.1"
     repository: "oci://ghcr.io/grafana/helm-charts"
     condition: grafana.enabled
   - name: victoria-metrics-operator
-    version: "0.40.*"
+    version: "0.40.5"
     repository: "https://victoriametrics.github.io/helm-charts/"
     condition: victoria-metrics-operator.enabled
   - name: victoria-logs-cluster
-    version: "0.0.*"
+    version: "0.0.2"
     repository: https://victoriametrics.github.io/helm-charts/
     condition: victoria-logs-cluster.enabled
   - name: external-dns
-    version: "1.15.*"
+    version: "1.15.2"
     repository: "https://kubernetes-sigs.github.io/external-dns/"
     condition: external-dns.enabled
   - name: jaeger-operator
-    version: "2.50.*"
+    version: "2.50.1"
     repository: https://jaegertracing.github.io/helm-charts
     condition: jaeger-operator.enabled


### PR DESCRIPTION
Align all chart versions across kof charts.
Get rid of any wildcard versions (due to possible ambiguity when rebuilding charts).

`sveltos-dashboard` chart is bumped to 0.54.0 to match all the rest sveltos components in the system.

> [!NOTE]
> This is PR to `v1.0.0` release branch. I will prepare a separate PR to main after this one will be merged.

> [!NOTE]
> I didn't bumped chart version themselves, not sure if it is required or not. If yes I will adjust PR