### PR TITLE
feat: customize image repository

### DIFF
--- a/charts/kof-collectors/templates/opentelemetry/node-collector.yaml
+++ b/charts/kof-collectors/templates/opentelemetry/node-collector.yaml
@@ -1,3 +1,4 @@
+{{- $global := .Values.global | default dict }}
 {{- if .Values.collectors.enabled }}
 apiVersion: opentelemetry.io/v1beta1
 kind: OpenTelemetryCollector
@@ -24,7 +25,7 @@ spec:
       readOnly: true
   serviceAccount: "{{ .Release.Name }}-k8s-cluster-collector"
   targetAllocator:
-    image: "ghcr.io/open-telemetry/opentelemetry-operator/target-allocator:v0.124.0"
+    image: "{{ $global.imageRegistry | default "ghrc.io"}}/open-telemetry/opentelemetry-operator/target-allocator:v0.124.0"
     enabled: true
     serviceAccount: "{{ .Release.Name }}-node-exporter-ta"
     allocationStrategy: per-node

--- a/charts/kof-collectors/values.yaml
+++ b/charts/kof-collectors/values.yaml
@@ -1,6 +1,8 @@
 global:
   clusterLabel: clusterName
   clusterName: mothership
+  # custom image registry for kube-state-metrics and prometheus-node-exporter charts
+  imageRegistry: ""
 kof:
   basic_auth: true
   logs:

--- a/charts/kof-mothership/README.md
+++ b/charts/kof-mothership/README.md
@@ -29,6 +29,7 @@ A Helm chart that deploys Grafana, Promxy, and VictoriaMetrics.
 | global<br>.clusterName | string | `"mothership"` | Value of this label. |
 | global<br>.random_password_length | int | `12` | Length of the auto-generated passwords for Grafana and VictoriaMetrics. |
 | global<br>.random_username_length | int | `8` | Length of the auto-generated usernames for Grafana and VictoriaMetrics. |
+| global<br>.registry | string | `""` | Custom image registry |
 | global<br>.storageClass | string | `""` | Name of the storage class used by Grafana, `vmstorage` (long-term storage of raw time series data), and `vmselect` (cache of query results). Keep it unset or empty to leverage the advantages of [default storage class](https://kubernetes.io/docs/concepts/storage/storage-classes/#default-storageclass). |
 | grafana<br>.alerts<br>.enabled | bool | `true` | Creates [VMRule](https://docs.victoriametrics.com/operator/resources/vmrule/)-s based on [files/rules/](files/rules/). |
 | grafana<br>.dashboard<br>.datasource<br>.current | object | `{"text":"promxy",`<br>`"value":"promxy"}` | Values of current datasource |
@@ -62,7 +63,7 @@ A Helm chart that deploys Grafana, Promxy, and VictoriaMetrics.
 | promxy<br>.configmapReload<br>.resources<br>.requests | object | `{"cpu":0.02,`<br>`"memory":"20Mi"}` | Minimum resources required for the `promxy-server-configmap-reload` container in the pods of `kof-mothership-promxy` deployment. |
 | promxy<br>.enabled | bool | `true` | Enables `kof-mothership-promxy` deployment. |
 | promxy<br>.extraArgs | object | `{"log-level":"info"}` | Extra command line arguments passed as `--key=value` to the `/bin/promxy`. |
-| promxy<br>.image | object | `{"pullPolicy":"IfNotPresent",`<br>`"repository":"quay.io/jacksontj/promxy",`<br>`"tag":"latest"}` | Promxy image to use. |
+| promxy<br>.image | object | `{"pullPolicy":"IfNotPresent",`<br>`"registry":"quay.io",`<br>`"repository":"jacksontj/promxy",`<br>`"tag":"latest"}` | Promxy image to use. |
 | promxy<br>.ingress | object | `{"annotations":{},`<br>`"enabled":false,`<br>`"extraLabels":{},`<br>`"hosts":["example.com"],`<br>`"ingressClassName":"nginx",`<br>`"path":"/",`<br>`"pathType":"Prefix",`<br>`"tls":[]}` | Config of `kof-mothership-promxy` [Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/). |
 | promxy<br>.replicaCount | int | `1` | Number of replicated promxy pods. |
 | promxy<br>.resources<br>.limits | object | `{"cpu":"100m",`<br>`"memory":"128Mi"}` | Maximum resources available for the `promxy` container in the pods of `kof-mothership-promxy` deployment. |

--- a/charts/kof-mothership/README.md
+++ b/charts/kof-mothership/README.md
@@ -29,7 +29,7 @@ A Helm chart that deploys Grafana, Promxy, and VictoriaMetrics.
 | global<br>.clusterName | string | `"mothership"` | Value of this label. |
 | global<br>.random_password_length | int | `12` | Length of the auto-generated passwords for Grafana and VictoriaMetrics. |
 | global<br>.random_username_length | int | `8` | Length of the auto-generated usernames for Grafana and VictoriaMetrics. |
-| global<br>.registry | string | `""` | Custom image registry |
+| global<br>.registry | string | `""` | Custom image registry for kof-mothership and sveltos-dashboards charts |
 | global<br>.storageClass | string | `""` | Name of the storage class used by Grafana, `vmstorage` (long-term storage of raw time series data), and `vmselect` (cache of query results). Keep it unset or empty to leverage the advantages of [default storage class](https://kubernetes.io/docs/concepts/storage/storage-classes/#default-storageclass). |
 | grafana<br>.alerts<br>.enabled | bool | `true` | Creates [VMRule](https://docs.victoriametrics.com/operator/resources/vmrule/)-s based on [files/rules/](files/rules/). |
 | grafana<br>.dashboard<br>.datasource<br>.current | object | `{"text":"promxy",`<br>`"value":"promxy"}` | Values of current datasource |

--- a/charts/kof-mothership/README.md
+++ b/charts/kof-mothership/README.md
@@ -48,7 +48,7 @@ A Helm chart that deploys Grafana, Promxy, and VictoriaMetrics.
 | kcm<br>.installTemplates | bool | `false` | Installs `ServiceTemplates` to use charts like `kof-storage` in `MultiClusterService`. |
 | kcm<br>.kof<br>.clusterProfiles | object | `{"kof-storage-secrets":{"create_secrets":true,`<br>`"matchLabels":{"k0rdent.mirantis.com/kof-storage-secrets":"true"},`<br>`"secrets":["storage-vmuser-credentials"]}}` | Names of secrets auto-distributed to clusters with matching labels. |
 | kcm<br>.kof<br>.operator<br>.enabled | bool | `true` |  |
-| kcm<br>.kof<br>.operator<br>.image | object | `{"pullPolicy":"IfNotPresent",`<br>`"repository":"ghcr.io/k0rdent/kof/kof-operator-controller"}` | Image of the kof operator. |
+| kcm<br>.kof<br>.operator<br>.image | object | `{"pullPolicy":"IfNotPresent",`<br>`"registry":"ghcr.io",`<br>`"repository":"k0rdent/kof/kof-operator-controller"}` | Image of the kof operator. |
 | kcm<br>.kof<br>.operator<br>.rbac<br>.create | bool | `true` | Creates the `kof-mothership-kof-operator` cluster role and binds it to the service account of operator. |
 | kcm<br>.kof<br>.operator<br>.replicaCount | int | `1` |  |
 | kcm<br>.kof<br>.operator<br>.resources<br>.limits | object | `{"cpu":"100m",`<br>`"memory":"128Mi"}` | Maximum resources available for operator. |

--- a/charts/kof-mothership/templates/kof-operator/operator-deployment.yaml
+++ b/charts/kof-mothership/templates/kof-operator/operator-deployment.yaml
@@ -1,3 +1,4 @@
+{{- $global := .Values.global | default dict }}
 {{- if .Values.kcm.kof.operator.enabled }}
 apiVersion: apps/v1
 kind: Deployment
@@ -58,7 +59,7 @@ spec:
             value: "http://{{ .Release.Name }}-promxy:{{ .Values.promxy.service.servicePort }}/-/reload"
           - name: "RELEASE_NAMESPACE"
             value: {{ .Release.Namespace }}
-        image: "{{ .Values.kcm.kof.operator.image.repository }}:v{{ .Chart.Version }}"
+        image: "{{ $global.registry | default .Values.kcm.kof.operator.image.registry}}/{{ .Values.kcm.kof.operator.image.repository }}:v{{ .Chart.Version }}"
         imagePullPolicy: {{ .Values.kcm.kof.operator.image.pullPolicy }}
         livenessProbe:
           failureThreshold: 6

--- a/charts/kof-mothership/templates/promxy/promxy-deployment.yaml
+++ b/charts/kof-mothership/templates/promxy/promxy-deployment.yaml
@@ -1,3 +1,4 @@
+{{- $global := .Values.global | default dict }}
 {{- if .Values.promxy.enabled }}
 apiVersion: apps/v1
 kind: Deployment
@@ -65,7 +66,7 @@ spec:
         {{- end }}
         command:
         - "/bin/promxy"
-        image: "{{ .Values.promxy.image.repository }}:{{ default .Chart.AppVersion .Values.promxy.image.tag }}"
+        image: "{{ $global.registry | default .Values.promxy.registry }}/{{.Values.promxy.image.repository }}:{{ default .Chart.AppVersion .Values.promxy.image.tag }}"
         imagePullPolicy: {{ .Values.promxy.image.pullPolicy }}
         livenessProbe:
           failureThreshold: 6

--- a/charts/kof-mothership/templates/victoria/vmalertmanager.yaml
+++ b/charts/kof-mothership/templates/victoria/vmalertmanager.yaml
@@ -1,3 +1,4 @@
+{{- $global := .Values.global | default dict }}
 {{- if .Values.victoriametrics.enabled }}
 {{- if .Values.victoriametrics.vmalert.enabled }}
 apiVersion: operator.victoriametrics.com/v1beta1
@@ -9,7 +10,11 @@ spec:
   configRawYaml: |-
 {{ .Values.victoriametrics.vmalert.vmalertmanager.config | nindent 4 }}
   image:
+    {{- if $global.registry }}
+    repository: {{ $global.registry }}/prom/alertmanager
+    {{- else }}
     repository: prom/alertmanager
+    {{- end }}
     tag: v0.27.0
   port: "9093"
 {{- end }}

--- a/charts/kof-mothership/values.yaml
+++ b/charts/kof-mothership/values.yaml
@@ -17,6 +17,9 @@ global:
   # -- Length of the auto-generated passwords for Grafana and VictoriaMetrics.
   random_password_length: 12
 
+  # -- Custom image registry
+  registry: ""
+
 cert-manager:
   # -- Whether cert-manager is present in the cluster
   enabled: true
@@ -243,7 +246,8 @@ promxy:
 
   # -- Promxy image to use.
   image:
-    repository: quay.io/jacksontj/promxy
+    registry: quay.io
+    repository: jacksontj/promxy
     tag: "latest"
     pullPolicy: IfNotPresent
 

--- a/charts/kof-mothership/values.yaml
+++ b/charts/kof-mothership/values.yaml
@@ -17,7 +17,7 @@ global:
   # -- Length of the auto-generated passwords for Grafana and VictoriaMetrics.
   random_password_length: 12
 
-  # -- Custom image registry
+  # -- Custom image registry for kof-mothership and sveltos-dashboards charts
   registry: ""
 
 cert-manager:

--- a/charts/kof-mothership/values.yaml
+++ b/charts/kof-mothership/values.yaml
@@ -92,7 +92,8 @@ kcm:
 
       # -- Image of the kof operator.
       image:
-        repository: ghcr.io/k0rdent/kof/kof-operator-controller
+        registry: ghcr.io
+        repository: k0rdent/kof/kof-operator-controller
         pullPolicy: IfNotPresent
 
       resources:

--- a/charts/kof-operators/values.yaml
+++ b/charts/kof-operators/values.yaml
@@ -3,6 +3,8 @@ prometheus-operator-crds:
 opentelemetry-operator:
   enabled: true
   manager:
+    image:
+      repository: ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator
     collectorImage:
       repository: "otel/opentelemetry-collector-contrib"
       tag: "0.123.0"

--- a/charts/kof-operators/values.yaml
+++ b/charts/kof-operators/values.yaml
@@ -17,3 +17,6 @@ opentelemetry-operator:
   admissionWebhooks:
     certManager:
       enabled: true
+  kubeRBACProxy:
+    image:
+      repository: quay.io/brancz/kube-rbac-proxy

--- a/charts/kof-storage/templates/victoria/vmalert.yaml
+++ b/charts/kof-storage/templates/victoria/vmalert.yaml
@@ -1,3 +1,4 @@
+{{- $global := .Values.global | default (dict "image" dict) }}
 {{- if .Values.victoriametrics.enabled }}
 {{- if .Values.victoriametrics.vmalert.enabled }}
 apiVersion: operator.victoriametrics.com/v1beta1
@@ -15,6 +16,9 @@ spec:
     http.pathPrefix: /
     remoteWrite.disablePathAppend: "true"
   image:
+    {{- with $global.image.registry }}
+    repository: {{ . }}/victoriametrics/vmalert
+    {{- end }}
     tag: v1.105.0
   license: {}
   notifiers:

--- a/charts/kof-storage/templates/victoria/vmcluster.yaml
+++ b/charts/kof-storage/templates/victoria/vmcluster.yaml
@@ -1,3 +1,4 @@
+{{- $global := .Values.global | default (dict "image" dict) }}
 {{- if .Values.victoriametrics.enabled }}
 {{- if .Values.victoriametrics.vmcluster.enabled }}
 apiVersion: operator.victoriametrics.com/v1beta1
@@ -12,6 +13,9 @@ spec:
   vminsert:
     extraArgs: {}
     image:
+      {{- with $global.image.registry }}
+      repository: {{ . }}/victoriametrics/vminsert
+      {{- end }}
       tag: v1.105.0-cluster
     port: "8480"
     replicaCount: {{ .Values.victoriametrics.vmcluster.vminsert.replicaCount }}
@@ -24,6 +28,9 @@ spec:
     extraArgs:
       vmalert.proxyURL: http://vmalert-cluster.{{ .Release.Namespace }}.svc:8080/
     image:
+      {{- with $global.image.registry }}
+      repository: {{ . }}/victoriametrics/vmselect
+      {{- end }}
       tag: v1.105.0-cluster
     port: "8481"
     replicaCount: {{ .Values.victoriametrics.vmcluster.vmselect.replicaCount }}
@@ -43,6 +50,9 @@ spec:
           {{- end }}
   vmstorage:
     image:
+      {{- with $global.image.registry }}
+      repository: {{ . }}/victoriametrics/vmstorage
+      {{- end }}
       tag: v1.105.0-cluster
     replicaCount: {{ .Values.victoriametrics.vmcluster.vmstorage.replicaCount }}
     # https://docs.victoriametrics.com/operator/api/#vmstorage-resources

--- a/charts/kof-storage/values.yaml
+++ b/charts/kof-storage/values.yaml
@@ -3,6 +3,9 @@ global:
   clusterName: storage
   random_username_length: 8
   random_password_length: 12
+  image:
+    # custom image registry for victoriametrics charts
+    registry: ""
 
   # https://kubernetes.io/docs/concepts/storage/storage-classes/#default-storageclass
   # storageClass: ebs-csi-default-sc


### PR DESCRIPTION
* Part of https://github.com/k0rdent/kof/issues/315

Values to customize registry:

- charts/kof-collectors/values.yaml `global.imageRegistry`
- charts/kof-mothership/values.yaml `global.registry`
- charts/kof-operators/values.yaml `opentelemetry-operator.manager.image.repository`
- charts/kof-operators/values.yaml `opentelemetry-operator.kubeRBACProxy.image.repository`
- charts/kof-storage/values.yaml `global.image.registry`