### PR TITLE
feat: Custom image repos for Grafana and others

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -146,6 +146,7 @@ dev-storage-deploy: dev ## Deploy kof-storage helm chart to the K8s cluster spec
 .PHONY: dev-ms-deploy
 dev-ms-deploy: dev kof-operator-docker-build ## Deploy `kof-mothership` helm chart to the management cluster
 	cp -f $(TEMPLATES_DIR)/kof-mothership/values.yaml dev/mothership-values.yaml
+	@$(YQ) eval -i '.global.registry = "docker.io"' dev/mothership-values.yaml  # TODO: Delete before merge.
 	@$(YQ) eval -i '.kcm.installTemplates = true' dev/mothership-values.yaml
 	@$(YQ) eval -i '.kcm.kof.clusterProfiles.kof-aws-dns-secrets = {"matchLabels": {"k0rdent.mirantis.com/kof-aws-dns-secrets": "true"}, "secrets": ["external-dns-aws-credentials"]}' dev/mothership-values.yaml
 	@$(YQ) eval -i '.kcm.kof.operator.image.repository = "kof-operator-controller"' dev/mothership-values.yaml

--- a/Makefile
+++ b/Makefile
@@ -146,7 +146,6 @@ dev-storage-deploy: dev ## Deploy kof-storage helm chart to the K8s cluster spec
 .PHONY: dev-ms-deploy
 dev-ms-deploy: dev kof-operator-docker-build ## Deploy `kof-mothership` helm chart to the management cluster
 	cp -f $(TEMPLATES_DIR)/kof-mothership/values.yaml dev/mothership-values.yaml
-	@$(YQ) eval -i '.global.registry = "docker.io"' dev/mothership-values.yaml  # TODO: Delete before merge.
 	@$(YQ) eval -i '.kcm.installTemplates = true' dev/mothership-values.yaml
 	@$(YQ) eval -i '.kcm.kof.clusterProfiles.kof-aws-dns-secrets = {"matchLabels": {"k0rdent.mirantis.com/kof-aws-dns-secrets": "true"}, "secrets": ["external-dns-aws-credentials"]}' dev/mothership-values.yaml
 	@$(YQ) eval -i '.kcm.kof.operator.image.repository = "kof-operator-controller"' dev/mothership-values.yaml

--- a/charts/kof-collectors/values.yaml
+++ b/charts/kof-collectors/values.yaml
@@ -419,3 +419,8 @@ opencost:
       extraEnv:
         EMIT_KSM_V1_METRICS: "false"
         EMIT_KSM_V1_METRICS_ONLY: "true"
+      image:
+        registry: ghcr.io
+    ui:
+      image:
+        registry: ghcr.io

--- a/charts/kof-mothership/Chart.lock
+++ b/charts/kof-mothership/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: grafana-operator
   repository: oci://ghcr.io/grafana/helm-charts
-  version: v5.15.1
+  version: v5.16.0
 - name: victoria-metrics-operator
   repository: https://victoriametrics.github.io/helm-charts/
   version: 0.40.5
@@ -17,5 +17,5 @@ dependencies:
 - name: kgst
   repository: oci://ghcr.io/k0rdent/catalog/charts
   version: 0.1.1
-digest: sha256:ea05288a05f3d594cf5bbf0ebc655adcd633f3a9169779a402c7e01669facca5
-generated: "2025-06-11T11:58:29.539122516-05:00"
+digest: sha256:1d5091856fd90f0e881bd56e1e9072b7b2fe08f4573f766d3c843e54b454d89e
+generated: "2025-06-13T15:57:40.430054+02:00"

--- a/charts/kof-mothership/Chart.yaml
+++ b/charts/kof-mothership/Chart.yaml
@@ -5,7 +5,7 @@ version: "1.0.0"
 appVersion: "1.0.0"
 dependencies:
   - name: grafana-operator
-    version: "v5.15.1"
+    version: "v5.16.0"
     repository: "oci://ghcr.io/grafana/helm-charts"
     condition: grafana.enabled
   - name: victoria-metrics-operator

--- a/charts/kof-mothership/README.md
+++ b/charts/kof-mothership/README.md
@@ -10,7 +10,7 @@ A Helm chart that deploys Grafana, Promxy, and VictoriaMetrics.
 |------------|------|---------|
 | https://projectsveltos.github.io/helm-charts | sveltos-dashboard | 0.54.0 |
 | https://victoriametrics.github.io/helm-charts/ | victoria-metrics-operator | 0.40.5 |
-| oci://ghcr.io/grafana/helm-charts | grafana-operator | v5.15.1 |
+| oci://ghcr.io/grafana/helm-charts | grafana-operator | v5.16.0 |
 | oci://ghcr.io/k0rdent/catalog/charts | cert-manager-service-template(kgst) | 0.1.1 |
 | oci://ghcr.io/k0rdent/catalog/charts | ingress-nginx-service-template(kgst) | 0.1.1 |
 | oci://ghcr.io/k0rdent/cluster-api-visualizer/charts | cluster-api-visualizer | 1.4.0 |

--- a/charts/kof-mothership/README.md
+++ b/charts/kof-mothership/README.md
@@ -24,7 +24,8 @@ A Helm chart that deploys Grafana, Promxy, and VictoriaMetrics.
 | cert-manager<br>.cluster-issuer<br>.provider | string | `"letsencrypt"` | Default clusterissuer provider |
 | cert-manager<br>.email | string | `"mail@example.net"` | If we use letsencrypt (or similar) which email to use |
 | cert-manager<br>.enabled | bool | `true` | Whether cert-manager is present in the cluster |
-| cluster-api-visualizer | object | `{"enabled":true}` | [Docs](https://github.com/Jont828/cluster-api-visualizer/tree/main/helm#configurable-values) |
+| cluster-api-visualizer | object | `{"enabled":true,`<br>`"image":{"repository":""}}` | [Docs](https://github.com/Jont828/cluster-api-visualizer/tree/main/helm#configurable-values) |
+| cluster-api-visualizer<br>.image<br>.repository | string | `""` | Custom `cluster-api-visualizer` image repository. |
 | global<br>.clusterLabel | string | `"clusterName"` | Name of the label identifying where the time series data points come from. |
 | global<br>.clusterName | string | `"mothership"` | Value of this label. |
 | global<br>.random_password_length | int | `12` | Length of the auto-generated passwords for Grafana and VictoriaMetrics. |

--- a/charts/kof-mothership/README.md
+++ b/charts/kof-mothership/README.md
@@ -30,6 +30,7 @@ A Helm chart that deploys Grafana, Promxy, and VictoriaMetrics.
 | global<br>.random_password_length | int | `12` | Length of the auto-generated passwords for Grafana and VictoriaMetrics. |
 | global<br>.random_username_length | int | `8` | Length of the auto-generated usernames for Grafana and VictoriaMetrics. |
 | global<br>.storageClass | string | `""` | Name of the storage class used by Grafana, `vmstorage` (long-term storage of raw time series data), and `vmselect` (cache of query results). Keep it unset or empty to leverage the advantages of [default storage class](https://kubernetes.io/docs/concepts/storage/storage-classes/#default-storageclass). |
+| grafana-operator<br>.image<br>.repository | string | `""` | Custom `grafana-operator` image repository. |
 | grafana<br>.alerts<br>.enabled | bool | `true` | Creates [VMRule](https://docs.victoriametrics.com/operator/resources/vmrule/)-s based on [files/rules/](files/rules/). |
 | grafana<br>.dashboard<br>.datasource<br>.current | object | `{"text":"promxy",`<br>`"value":"promxy"}` | Values of current datasource |
 | grafana<br>.dashboard<br>.datasource<br>.regex | string | `"/promxy/"` | Regex pattern to filter datasources. |

--- a/charts/kof-mothership/README.md
+++ b/charts/kof-mothership/README.md
@@ -24,14 +24,14 @@ A Helm chart that deploys Grafana, Promxy, and VictoriaMetrics.
 | cert-manager<br>.cluster-issuer<br>.provider | string | `"letsencrypt"` | Default clusterissuer provider |
 | cert-manager<br>.email | string | `"mail@example.net"` | If we use letsencrypt (or similar) which email to use |
 | cert-manager<br>.enabled | bool | `true` | Whether cert-manager is present in the cluster |
-| cluster-api-visualizer | object | `{"enabled":true,`<br>`"image":{"repository":""}}` | [Docs](https://github.com/Jont828/cluster-api-visualizer/tree/main/helm#configurable-values) |
-| cluster-api-visualizer<br>.image<br>.repository | string | `""` | Custom `cluster-api-visualizer` image repository. |
+| cluster-api-visualizer | object | `{"enabled":true,`<br>`"image":{"repository":"ghcr.io/k0rdent"}}` | [Docs](https://github.com/Jont828/cluster-api-visualizer/tree/main/helm#configurable-values) |
+| cluster-api-visualizer<br>.image<br>.repository | string | `"ghcr.io/k0rdent"` | Custom `cluster-api-visualizer` image repository. |
 | global<br>.clusterLabel | string | `"clusterName"` | Name of the label identifying where the time series data points come from. |
 | global<br>.clusterName | string | `"mothership"` | Value of this label. |
 | global<br>.random_password_length | int | `12` | Length of the auto-generated passwords for Grafana and VictoriaMetrics. |
 | global<br>.random_username_length | int | `8` | Length of the auto-generated usernames for Grafana and VictoriaMetrics. |
 | global<br>.storageClass | string | `""` | Name of the storage class used by Grafana, `vmstorage` (long-term storage of raw time series data), and `vmselect` (cache of query results). Keep it unset or empty to leverage the advantages of [default storage class](https://kubernetes.io/docs/concepts/storage/storage-classes/#default-storageclass). |
-| grafana-operator<br>.image<br>.repository | string | `""` | Custom `grafana-operator` image repository. |
+| grafana-operator<br>.image<br>.repository | string | `"ghcr.io/grafana/grafana-operator"` | Custom `grafana-operator` image repository. |
 | grafana<br>.alerts<br>.enabled | bool | `true` | Creates [VMRule](https://docs.victoriametrics.com/operator/resources/vmrule/)-s based on [files/rules/](files/rules/). |
 | grafana<br>.dashboard<br>.datasource<br>.current | object | `{"text":"promxy",`<br>`"value":"promxy"}` | Values of current datasource |
 | grafana<br>.dashboard<br>.datasource<br>.regex | string | `"/promxy/"` | Regex pattern to filter datasources. |

--- a/charts/kof-mothership/templates/grafana/grafana.yaml
+++ b/charts/kof-mothership/templates/grafana/grafana.yaml
@@ -1,4 +1,5 @@
 {{- if index .Values "grafana" "enabled" | default false }}
+{{- $global := .Values.global | default dict }}
 apiVersion: grafana.integreatly.org/v1beta1
 kind: Grafana
 metadata:
@@ -7,7 +8,11 @@ metadata:
     dashboards: grafana
     namespace: {{ .Release.Namespace }}
 spec:
+  {{- if or (.Values.grafana.version | regexMatch "[:/@]") (not $global.registry) }}
   version: {{ .Values.grafana.version }}
+  {{- else }}
+  version: {{ $global.registry }}/grafana/grafana:{{ .Values.grafana.version }}
+  {{- end }}
   persistentVolumeClaim:
     spec:
       accessModes:

--- a/charts/kof-mothership/templates/promxy/promxy-deployment.yaml
+++ b/charts/kof-mothership/templates/promxy/promxy-deployment.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.promxy.enabled }}
+{{- $global := .Values.global | default dict }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -99,7 +100,7 @@ spec:
         args:
         - "--volume-dir=/etc/promxy"
         - "--webhook-url=http://localhost:8082/-/reload"
-        image: jimmidyson/configmap-reload:v0.5.0
+        image: {{ with $global.registry }}{{ . }}/{{ end }}jimmidyson/configmap-reload:v0.5.0
         volumeMounts:
         - mountPath: "/etc/promxy/"
           name: config

--- a/charts/kof-mothership/templates/victoria/vmalert.yaml
+++ b/charts/kof-mothership/templates/victoria/vmalert.yaml
@@ -1,5 +1,6 @@
 {{- if .Values.victoriametrics.enabled }}
 {{- if .Values.victoriametrics.vmalert.enabled }}
+{{- $global := .Values.global | default dict }}
 apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMAlert
 metadata:
@@ -16,6 +17,7 @@ spec:
     remoteWrite.disablePathAppend: "true"
   image:
     tag: v1.105.0
+  configReloaderImageTag: {{ with $global.registry }}{{ . }}/{{ end }}jimmidyson/configmap-reload:v0.3.0
   license: {}
   notifiers:
     - url: http://vmalertmanager-cluster.{{ .Release.Namespace }}.svc:9093

--- a/charts/kof-mothership/values.yaml
+++ b/charts/kof-mothership/values.yaml
@@ -17,6 +17,11 @@ global:
   # -- Length of the auto-generated passwords for Grafana and VictoriaMetrics.
   random_password_length: 12
 
+grafana-operator:
+  image:
+    # -- Custom `grafana-operator` image repository.
+    repository: ""
+
 cert-manager:
   # -- Whether cert-manager is present in the cluster
   enabled: true

--- a/charts/kof-mothership/values.yaml
+++ b/charts/kof-mothership/values.yaml
@@ -227,6 +227,9 @@ victoria-metrics-operator:
 # -- [Docs](https://github.com/Jont828/cluster-api-visualizer/tree/main/helm#configurable-values)
 cluster-api-visualizer:
   enabled: true
+  image:
+    # -- Custom `cluster-api-visualizer` image repository.
+    repository: ""
 
 # -- [Docs](https://projectsveltos.github.io/dashboard-helm-chart/#values)
 sveltos-dashboard:

--- a/charts/kof-mothership/values.yaml
+++ b/charts/kof-mothership/values.yaml
@@ -20,7 +20,7 @@ global:
 grafana-operator:
   image:
     # -- Custom `grafana-operator` image repository.
-    repository: ""
+    repository: ghcr.io/grafana/grafana-operator
 
 cert-manager:
   # -- Whether cert-manager is present in the cluster
@@ -229,7 +229,7 @@ cluster-api-visualizer:
   enabled: true
   image:
     # -- Custom `cluster-api-visualizer` image repository.
-    repository: ""
+    repository: ghcr.io/k0rdent
 
 # -- [Docs](https://projectsveltos.github.io/dashboard-helm-chart/#values)
 sveltos-dashboard:

--- a/charts/kof-storage/Chart.lock
+++ b/charts/kof-storage/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: grafana-operator
   repository: oci://ghcr.io/grafana/helm-charts
-  version: v5.15.1
+  version: v5.16.0
 - name: victoria-metrics-operator
   repository: https://victoriametrics.github.io/helm-charts/
   version: 0.40.5
@@ -14,5 +14,5 @@ dependencies:
 - name: jaeger-operator
   repository: https://jaegertracing.github.io/helm-charts
   version: 2.50.1
-digest: sha256:84e13a4e5b376b8a0e5a1902386fea9d14672f21668f68722170bb275d3bf9db
-generated: "2025-06-11T12:01:30.669484791-05:00"
+digest: sha256:137b24b426a6a17951f868fa4870e32242cbc9869c378c1c0fdc6b32dc36fd8a
+generated: "2025-06-13T16:35:58.206359+02:00"

--- a/charts/kof-storage/Chart.yaml
+++ b/charts/kof-storage/Chart.yaml
@@ -5,7 +5,7 @@ version: "1.0.0"
 appVersion: "1.0.0"
 dependencies:
   - name: grafana-operator
-    version: "v5.15.1"
+    version: "v5.16.0"
     repository: "oci://ghcr.io/grafana/helm-charts"
     condition: grafana.enabled
   - name: victoria-metrics-operator

--- a/charts/kof-storage/templates/grafana/grafana.yaml
+++ b/charts/kof-storage/templates/grafana/grafana.yaml
@@ -1,4 +1,5 @@
 {{- if index .Values "grafana" "enabled" | default false }}
+{{- $global := .Values.global | default dict }}
 apiVersion: grafana.integreatly.org/v1beta1
 kind: Grafana
 metadata:
@@ -7,7 +8,11 @@ metadata:
     dashboards: grafana
     namespace: {{ .Release.Namespace }}
 spec:
-  version: "10.4.7"
+  {{- if or (.Values.grafana.version | regexMatch "[:/@]") (not $global.registry) }}
+  version: {{ .Values.grafana.version }}
+  {{- else }}
+  version: {{ $global.registry }}/grafana/grafana:{{ .Values.grafana.version }}
+  {{- end }}
   persistentVolumeClaim:
     spec:
       accessModes:

--- a/charts/kof-storage/templates/jaeger/jaeger.yaml
+++ b/charts/kof-storage/templates/jaeger/jaeger.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.jaeger.enabled }}
+{{- $global := .Values.global | default dict }}
 apiVersion: jaegertracing.io/v1
 kind: Jaeger
 metadata:
@@ -9,6 +10,7 @@ spec:
   annotations:
     sidecar.istio.io/inject: "true"
   allInOne:
+    image: {{ with $global.registry }}{{ . }}/{{ end }}jaegertracing/all-in-one:{{ .Values.jaeger.image.tag }}
     labels: 
       {{- toYaml .Values.jaeger.collector.podLabels | nindent 6 }}
   collector:

--- a/charts/kof-storage/templates/victoria/vmalert.yaml
+++ b/charts/kof-storage/templates/victoria/vmalert.yaml
@@ -1,5 +1,6 @@
 {{- if .Values.victoriametrics.enabled }}
 {{- if .Values.victoriametrics.vmalert.enabled }}
+{{- $global := .Values.global | default dict }}
 apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMAlert
 metadata:
@@ -16,6 +17,7 @@ spec:
     remoteWrite.disablePathAppend: "true"
   image:
     tag: v1.105.0
+  configReloaderImageTag: {{ with $global.registry }}{{ . }}/{{ end }}jimmidyson/configmap-reload:v0.3.0
   license: {}
   notifiers:
   - url: http://vmalertmanager-cluster-0.vmalertmanager-cluster.{{ .Release.Namespace }}.svc:9093/

--- a/charts/kof-storage/values.yaml
+++ b/charts/kof-storage/values.yaml
@@ -10,7 +10,7 @@ global:
 grafana-operator:
   image:
     # -- Custom `grafana-operator` image repository.
-    repository: ""
+    repository: ghcr.io/grafana/grafana-operator
 
 cert-manager:
   enabled: true

--- a/charts/kof-storage/values.yaml
+++ b/charts/kof-storage/values.yaml
@@ -7,6 +7,11 @@ global:
   # https://kubernetes.io/docs/concepts/storage/storage-classes/#default-storageclass
   # storageClass: ebs-csi-default-sc
 
+grafana-operator:
+  image:
+    # -- Custom `grafana-operator` image repository.
+    repository: ""
+
 cert-manager:
   enabled: true
   cluster-issuer:

--- a/charts/kof-storage/values.yaml
+++ b/charts/kof-storage/values.yaml
@@ -66,6 +66,7 @@ victoriametrics:
     enabled: false
 grafana:
   enabled: true
+  version: "10.4.7"
   datasources:
     - name: metrics
       url: http://vmselect-cluster:8481/select/0/prometheus

--- a/charts/kof-storage/values.yaml
+++ b/charts/kof-storage/values.yaml
@@ -113,8 +113,12 @@ promxy:
   enabled: false
 jaeger-operator:
   enabled: true
+  image:
+    repository: jaegertracing/jaeger-operator
 jaeger:
   enabled: true
+  image:
+    tag: "1.52.0"
   security:
     credentials_secret_name: jaeger-credentials
     htpasswd_secret_name: jaeger-htpasswd

--- a/docs/DEV.md
+++ b/docs/DEV.md
@@ -47,6 +47,13 @@
   kubectl get pod -n kof
   ```
 
+## Required after upgrade
+
+* Run after upgrade to [grafana-operator v5.16.0](https://github.com/grafana/grafana-operator/releases/tag/v5.16.0):
+  ```bash
+  kubectl apply --server-side --force-conflicts -f https://github.com/grafana/grafana-operator/releases/download/v5.16.0/crds.yaml
+  ```
+
 ## Local deployment
 
 Quick option without regional/child clusters.

--- a/docs/DEV.md
+++ b/docs/DEV.md
@@ -53,6 +53,7 @@
   ```bash
   kubectl apply --server-side --force-conflicts -f https://github.com/grafana/grafana-operator/releases/download/v5.16.0/crds.yaml
   ```
+  for management cluster and for each regional cluster via `KUBECONFIG=regional-kubeconfig kubectl` from [here](https://docs.k0rdent.io/next/admin/kof/kof-verification/#verification-steps).
 
 ## Local deployment
 


### PR DESCRIPTION
* Part of https://github.com/k0rdent/kof/issues/315
* Run after upgrade to [grafana-operator v5.16.0](https://github.com/grafana/grafana-operator/releases/tag/v5.16.0):
  ```bash
  kubectl apply --server-side --force-conflicts -f https://github.com/grafana/grafana-operator/releases/download/v5.16.0/crds.yaml
  ```
  for management cluster and for each regional cluster via `KUBECONFIG=regional-kubeconfig kubectl` from [here](https://docs.k0rdent.io/next/admin/kof/kof-verification/#verification-steps).
* Values to set in kof charts:
  * `global.registry`
  * `global.image.registry` - for VictoriaMetrics [here](https://github.com/VictoriaMetrics/helm-charts/blob/f601e33f4059bb6fd14791be9dd0bf8fa3339002/charts/victoria-metrics-common/templates/_image.tpl#L54).
  * `cluster-api-visualizer.image.repository`
  * `grafana-operator.image.repository`
  * `jaeger-operator.image.repository`
  * `opencost.opencost.exporter.image.registry`
  * `opencost.opencost.ui.image.registry`
  * `kcm.kof.repo.spec.url` - for `kof-mothership` `HelmRepos` used in `ServiceTemplates`,
    should be e.g. `registry.mirantis.com/k0rdent-enterprise/charts`,
    while other values above should be e.g. `registry.mirantis.com/k0rdent-enterprise` only.
