### PR TITLE
feat: `global.registry` for MCS

### DIFF
--- a/charts/kof-child/templates/child-multi-cluster-service.yaml
+++ b/charts/kof-child/templates/child-multi-cluster-service.yaml
@@ -22,11 +22,9 @@ opencost:
     exporter:
       image:
         registry: $R
-        tag: "1.113.0@sha256:ee2486ae56b321bb6dde1ccbcc7786577313b5c679f47501696e2b0e87463b7b"
     ui:
       image:
         registry: $R
-        tag: "1.113.0@sha256:d57af3bd85b73e726a53b8e5063e0fab19cdaecda34da717ff24ef91a63260a7"
 opentelemetry-operator:
   manager:
     image:
@@ -64,7 +62,7 @@ spec:
       {{- if (index .Values "cert-manager" "enabled") }}
       - name: cert-manager
         namespace: {{ .Release.Namespace }}
-        template: cert-manager-1-16-4
+        template: {{ index .Values "cert-manager" "template" }}
         values: |
           crds:
             enabled: true

--- a/charts/kof-child/values.yaml
+++ b/charts/kof-child/values.yaml
@@ -1,7 +1,16 @@
 cert-manager:
   enabled: true
+  template: cert-manager-1-16-4
 
 kcm:
   namespace: kcm-system
 
-collectors: {}
+collectors:
+  opencost:
+    opencost:
+      exporter:
+        image:
+          tag: "1.113.0"
+      ui:
+        image:
+          tag: "1.113.0"

--- a/charts/kof-istio/templates/kof-child-cluster-profile.yaml
+++ b/charts/kof-istio/templates/kof-child-cluster-profile.yaml
@@ -23,11 +23,9 @@ opencost:
     exporter:
       image:
         registry: $R
-        tag: "1.113.0@sha256:ee2486ae56b321bb6dde1ccbcc7786577313b5c679f47501696e2b0e87463b7b"
     ui:
       image:
         registry: $R
-        tag: "1.113.0@sha256:d57af3bd85b73e726a53b8e5063e0fab19cdaecda34da717ff24ef91a63260a7"
 opentelemetry-operator:
   manager:
     image:

--- a/charts/kof-istio/templates/kof-regional-cluster-profile.yaml
+++ b/charts/kof-istio/templates/kof-regional-cluster-profile.yaml
@@ -23,11 +23,9 @@ opencost:
     exporter:
       image:
         registry: $R
-        tag: "1.113.0@sha256:ee2486ae56b321bb6dde1ccbcc7786577313b5c679f47501696e2b0e87463b7b"
     ui:
       image:
         registry: $R
-        tag: "1.113.0@sha256:d57af3bd85b73e726a53b8e5063e0fab19cdaecda34da717ff24ef91a63260a7"
 opentelemetry-operator:
   manager:
     image:

--- a/charts/kof-istio/values.yaml
+++ b/charts/kof-istio/values.yaml
@@ -77,5 +77,12 @@ gateway:
   enabled: false
   name: istio-eastwestgateway
 storage: {}
-collectors: {}
-
+collectors:
+  opencost:
+    opencost:
+      exporter:
+        image:
+          tag: "1.113.0"
+      ui:
+        image:
+          tag: "1.113.0"

--- a/charts/kof-regional/templates/regional-multi-cluster-service.yaml
+++ b/charts/kof-regional/templates/regional-multi-cluster-service.yaml
@@ -22,11 +22,9 @@ opencost:
     exporter:
       image:
         registry: $R
-        tag: "1.113.0@sha256:ee2486ae56b321bb6dde1ccbcc7786577313b5c679f47501696e2b0e87463b7b"
     ui:
       image:
         registry: $R
-        tag: "1.113.0@sha256:d57af3bd85b73e726a53b8e5063e0fab19cdaecda34da717ff24ef91a63260a7"
 opentelemetry-operator:
   manager:
     image:
@@ -56,7 +54,7 @@ spec:
       {{- if (index .Values "cert-manager" "enabled") }}
       - name: cert-manager
         namespace: {{ .Release.Namespace }}
-        template: cert-manager-1-16-4
+        template: {{ index .Values "cert-manager" "template" }}
         values: |
           crds:
             enabled: true
@@ -65,7 +63,7 @@ spec:
       {{- if (index .Values "ingress-nginx" "enabled") }}
       - name: ingress-nginx
         namespace: {{ .Release.Namespace }}
-        template: ingress-nginx-4-12-1
+        template: {{ index .Values "ingress-nginx" "template" }}
         values: |
           {{`{{ if eq .InfrastructureProvider.kind "AzureCluster" }}`}}
           # Workaround for https://github.com/k0rdent/kcm/issues/1119#issuecomment-2721512663

--- a/charts/kof-regional/values.yaml
+++ b/charts/kof-regional/values.yaml
@@ -1,8 +1,19 @@
 cert-manager:
   enabled: true
+  template: cert-manager-1-16-4
 
 ingress-nginx:
   enabled: true
+  template: ingress-nginx-4-12-1
 
-collectors: {}
+collectors:
+  opencost:
+    opencost:
+      exporter:
+        image:
+          tag: "1.113.0"
+      ui:
+        image:
+          tag: "1.113.0"
+
 storage: {}


### PR DESCRIPTION
* Part of https://github.com/k0rdent/kof/issues/315
* Based on https://github.com/k0rdent/kof/pull/326
* Tested `kof-regional` MCS, `kof-child` MCS, `kof-istio` ClusterProfiles,
  with `--set global.registry=registry.mirantis.com/k0rdent-enterprise`
* Images missing in https://get.mirantis.com/k0rdent-enterprise/1.0.0-rc6/full_images_list.txt
  * `registry.mirantis.com/k0rdent-enterprise/open-telemetry/opentelemetry-operator/target-allocator:v0.124.0`
* `opencost` chart [expected](https://github.com/opencost/opencost-helm-chart/blob/1.42.3-helm/charts/opencost/values.yaml#L133-L378) these hashes:
  * `registry.mirantis.com/k0rdent-enterprise/opencost/opencost:1.113.0@sha256:b313d6d320058bbd3841a948fb636182f49b46df2368d91e2ae046ed03c0f83c`
  * `registry.mirantis.com/k0rdent-enterprise/opencost/opencost-ui:1.113.0@sha256:4f408cf765217f889f4cb5cfcc97356e09892045a6ec951b27817a42ecb6748d`
  * However hashes in rc6 did not match. Passed them via values as a temporary workaround, OK.
