### PR TITLE
fix: use correct namespace name for MCS

### DIFF
--- a/charts/kof-child/templates/child-multi-cluster-service.yaml
+++ b/charts/kof-child/templates/child-multi-cluster-service.yaml
@@ -11,14 +11,6 @@ spec:
         operator: DoesNotExist
 
   serviceSpec:
-    templateResourceRefs:
-      - identifier: ChildConfig
-        resource:
-          apiVersion: v1
-          kind: ConfigMap
-          name: kof-cluster-config-{{`{{ .Cluster.metadata.name }}`}}
-          namespace: {{ .Values.kcm.namespace }}
-
     services:
       {{- $version := .Chart.Version | replace "." "-" }}
 
@@ -67,3 +59,10 @@ spec:
                 defaultClusterId: %q
           ` $childClusterName $writeMetricsEndpoint $logsEndpoint $tracesEndpoint $readMetricsEndpoint $childClusterName | fromYaml {{`}}`}}
           {{`{{ mergeOverwrite $collectorsValuesHere $collectorsValuesFromHelm $collectorsValuesFromAnnotation | toYaml | nindent 4 }}`}}
+    templateResourceRefs:
+    - identifier: ChildConfig
+      resource:
+        apiVersion: v1
+        kind: ConfigMap
+        name: kof-cluster-config-{{`{{ .Cluster.metadata.name }}`}}
+        namespace: "{{`{{ .Cluster.metadata.namespace }}`}}"


### PR DESCRIPTION
kof controller generates CMs in the same namespace as child cluster however, the templates expect the CM in the KCM namespace, which is incorrect

closes #262 