### PR TITLE
fix: Registry for `opentelemetry-operator/target-allocator`

### DIFF
--- a/charts/kof-collectors/templates/opentelemetry/node-collector.yaml
+++ b/charts/kof-collectors/templates/opentelemetry/node-collector.yaml
@@ -25,7 +25,7 @@ spec:
       readOnly: true
   serviceAccount: "{{ .Release.Name }}-k8s-cluster-collector"
   targetAllocator:
-    image: "{{ $global.imageRegistry | default "ghcr.io"}}/open-telemetry/opentelemetry-operator/target-allocator:v0.124.0"
+    image: "{{ $global.imageRegistry | default "ghcr.io/open-telemetry"}}/opentelemetry-operator/target-allocator:v0.124.0"
     enabled: true
     serviceAccount: "{{ .Release.Name }}-node-exporter-ta"
     allocationStrategy: per-node


### PR DESCRIPTION
I guess we'd better update `registry.mirantis.com/k0rdent-enterprise` instead, as we need to re-release anyway.