### PR TITLE
fix: Repo of kof-operator compatible with custom registries

### DIFF
--- a/charts/kof-mothership/README.md
+++ b/charts/kof-mothership/README.md
@@ -50,7 +50,7 @@ A Helm chart that deploys Grafana, Promxy, and VictoriaMetrics.
 | kcm<br>.installTemplates | bool | `false` | Installs `ServiceTemplates` to use charts like `kof-storage` in `MultiClusterService`. |
 | kcm<br>.kof<br>.clusterProfiles | object | `{"kof-storage-secrets":{"create_secrets":true,`<br>`"matchLabels":{"k0rdent.mirantis.com/kof-storage-secrets":"true"},`<br>`"secrets":["storage-vmuser-credentials"]}}` | Names of secrets auto-distributed to clusters with matching labels. |
 | kcm<br>.kof<br>.operator<br>.enabled | bool | `true` |  |
-| kcm<br>.kof<br>.operator<br>.image | object | `{"pullPolicy":"IfNotPresent",`<br>`"registry":"ghcr.io",`<br>`"repository":"k0rdent/kof/kof-operator-controller"}` | Image of the kof operator. |
+| kcm<br>.kof<br>.operator<br>.image | object | `{"pullPolicy":"IfNotPresent",`<br>`"registry":"ghcr.io/k0rdent",`<br>`"repository":"kof/kof-operator-controller"}` | Image of the kof operator. |
 | kcm<br>.kof<br>.operator<br>.rbac<br>.create | bool | `true` | Creates the `kof-mothership-kof-operator` cluster role and binds it to the service account of operator. |
 | kcm<br>.kof<br>.operator<br>.replicaCount | int | `1` |  |
 | kcm<br>.kof<br>.operator<br>.resources<br>.limits | object | `{"cpu":"100m",`<br>`"memory":"128Mi"}` | Maximum resources available for operator. |

--- a/charts/kof-mothership/values.yaml
+++ b/charts/kof-mothership/values.yaml
@@ -97,8 +97,8 @@ kcm:
 
       # -- Image of the kof operator.
       image:
-        registry: ghcr.io
-        repository: k0rdent/kof/kof-operator-controller
+        registry: ghcr.io/k0rdent
+        repository: kof/kof-operator-controller
         pullPolicy: IfNotPresent
 
       resources:


### PR DESCRIPTION
Because `registry.mirantis.com/k0rdent-enterprise/kof/kof-operator-controller:v1.0.0`