### PR TITLE
fix: Custom registry for `configmap-reload` in `vmalertmanager`

### DIFF
--- a/charts/kof-mothership/templates/victoria/vmalertmanager.yaml
+++ b/charts/kof-mothership/templates/victoria/vmalertmanager.yaml
@@ -10,12 +10,9 @@ spec:
   configRawYaml: |-
 {{ .Values.victoriametrics.vmalert.vmalertmanager.config | nindent 4 }}
   image:
-    {{- if $global.registry }}
-    repository: {{ $global.registry }}/prom/alertmanager
-    {{- else }}
-    repository: prom/alertmanager
-    {{- end }}
+    repository: {{ with $global.registry }}{{ . }}/{{ end }}prom/alertmanager
     tag: v0.27.0
+  configReloaderImageTag: {{ with $global.registry }}{{ . }}/{{ end }}jimmidyson/configmap-reload:v0.3.0
   port: "9093"
 {{- end }}
 {{- end }}


### PR DESCRIPTION
* Part of https://github.com/k0rdent/kof/issues/315
* Closes https://github.com/k0rdent/kof/issues/343
* Tested:
  ```
  helm upgrade -n kof kof-mothership ./charts/kof-mothership \
  -f dev/mothership-values.yaml -f global-values.yaml

  kubectl -n kof get sts vmalertmanager-cluster -o yaml | grep image:

  image: registry.mirantis.com/k0rdent-enterprise/prom/alertmanager:v0.27.0
  image: registry.mirantis.com/k0rdent-enterprise/jimmidyson/configmap-reload:v0.3.0
  ```
