### PR TITLE
fix: Redundant kof-istio values moved to kof-collectors

### DIFF
--- a/charts/kof-istio/values.yaml
+++ b/charts/kof-istio/values.yaml
@@ -77,12 +77,4 @@ gateway:
   enabled: false
   name: istio-eastwestgateway
 storage: {}
-collectors:
-  opencost:
-    opencost:
-      exporter:
-        image:
-          tag: "1.113.0"
-      ui:
-        image:
-          tag: "1.113.0"
+collectors: {}


### PR DESCRIPTION
* Part of https://github.com/k0rdent/kof/issues/315
* Detected on review of https://github.com/k0rdent/kof/pull/346
* Improves opencost fix in https://github.com/k0rdent/kof/pull/335