### PR TITLE
fix: Pinned versions of Grafana plugins and Promxy as part of aig-gap solution

### DIFF
--- a/charts/kof-mothership/README.md
+++ b/charts/kof-mothership/README.md
@@ -99,7 +99,7 @@ A Helm chart that deploys Grafana, Promxy, and VictoriaMetrics.
 | promxy<br>.configmapReload<br>.resources<br>.requests | object | `{"cpu":0.02,`<br>`"memory":"20Mi"}` | Minimum resources required for the `promxy-server-configmap-reload` container in the pods of `kof-mothership-promxy` deployment. |
 | promxy<br>.enabled | bool | `true` | Enables `kof-mothership-promxy` deployment. |
 | promxy<br>.extraArgs | object | `{"log-level":"info",`<br>`"web.external-url":"http://127.0.0.1:8082"}` | Extra command line arguments passed as `--key=value` to the `/bin/promxy`. |
-| promxy<br>.image | object | `{"pullPolicy":"IfNotPresent",`<br>`"registry":"quay.io",`<br>`"repository":"jacksontj/promxy",`<br>`"tag":"latest"}` | Promxy image to use. |
+| promxy<br>.image | object | `{"pullPolicy":"IfNotPresent",`<br>`"registry":"quay.io",`<br>`"repository":"jacksontj/promxy",`<br>`"tag":"v0.0.93"}` | Promxy image to use. |
 | promxy<br>.ingress | object | `{"annotations":{},`<br>`"enabled":false,`<br>`"extraLabels":{},`<br>`"hosts":["example.com"],`<br>`"ingressClassName":"nginx",`<br>`"path":"/",`<br>`"pathType":"Prefix",`<br>`"tls":[]}` | Config of `kof-mothership-promxy` [Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/). |
 | promxy<br>.replicaCount | int | `1` | Number of replicated promxy pods. |
 | promxy<br>.resources<br>.limits | object | `{"cpu":"100m",`<br>`"memory":"128Mi"}` | Maximum resources available for the `promxy` container in the pods of `kof-mothership-promxy` deployment. |

--- a/charts/kof-mothership/templates/grafana/grafana.yaml
+++ b/charts/kof-mothership/templates/grafana/grafana.yaml
@@ -60,7 +60,9 @@ spec:
                       key: GF_SECURITY_ADMIN_PASSWORD
                       name: {{ .Values.grafana.security.credentials_secret_name }}
                 - name: GF_INSTALL_PLUGINS
-                  value: "victoriametrics-logs-datasource,victoriametrics-metrics-datasource"
+                  value: "victoriametrics-logs-datasource 0.17.0,victoriametrics-metrics-datasource 0.16.0"
+                  # https://grafana.com/api/plugins/victoriametrics-logs-datasource
+                  # https://grafana.com/api/plugins/victoriametrics-metrics-datasource
 
   {{- if .Values.grafana.ingress.enabled }}
   ingress:

--- a/charts/kof-mothership/values.yaml
+++ b/charts/kof-mothership/values.yaml
@@ -327,7 +327,7 @@ promxy:
   image:
     registry: quay.io
     repository: jacksontj/promxy
-    tag: "latest"
+    tag: v0.0.93
     pullPolicy: IfNotPresent
 
   serviceAccount:

--- a/charts/kof-storage/templates/grafana/grafana.yaml
+++ b/charts/kof-storage/templates/grafana/grafana.yaml
@@ -50,7 +50,9 @@ spec:
                       key: GF_SECURITY_ADMIN_PASSWORD
                       name: {{ .Values.grafana.security.credentials_secret_name }}
                 - name: GF_INSTALL_PLUGINS
-                  value: "victoriametrics-logs-datasource,victoriametrics-metrics-datasource"
+                  value: "victoriametrics-logs-datasource 0.17.0,victoriametrics-metrics-datasource 0.16.0"
+                  # https://grafana.com/api/plugins/victoriametrics-logs-datasource
+                  # https://grafana.com/api/plugins/victoriametrics-metrics-datasource
 
 {{- if .Values.grafana.ingress.enabled }}
   ingress:


### PR DESCRIPTION
* Part of https://github.com/k0rdent/kof/issues/315
* Old logs:
  ```
  kubectl logs -n kof deploy/grafana-vm-deployment | head

    Downloaded and extracted victoriametrics-logs-datasource v0.17.0 zip successfully to /var/lib/grafana/plugins/victoriametrics-logs-datasource
    Downloaded and extracted victoriametrics-metrics-datasource v0.16.0 zip successfully to /var/lib/grafana/plugins/victoriametrics-metrics-datasource
    Please restart Grafana after installing or removing plugins. Refer to Grafana documentation for instructions if necessary.
  ```
* Considered using `initContainers` with a new image built from unpacked plugins files,
  or reusing `kof-operator` image and release process,
  but @a13x5 suggested a better option to try first.
* Pinned versions of Grafana plugins and Promxy.
* Now the logs show Grafana does not download existing plugins:
  ```
  kubectl logs -n kof deploy/grafana-vm-deployment | head

    ✔ Plugin victoriametrics-logs-datasource v0.17.0 already installed.
    ✔ Plugin victoriametrics-metrics-datasource v0.16.0 already installed.
    Please restart Grafana after installing or removing plugins. Refer to Grafana documentation for instructions if necessary.
  ```
* Custom registry should [Build a Grafana Docker image with pre-installed plugins](https://grafana.com/docs/grafana/latest/setup-grafana/configure-docker/#build-a-grafana-docker-image-with-pre-installed-plugins)
  * passing build-time `GF_INSTALL_PLUGINS` from `charts/kof-mothership/templates/grafana/grafana.yaml`
  * and publishing image as `grafana/grafana:10.4.18-security-01`,
  * taking version from `charts/kof-mothership/values.yaml` - `.grafana.version`
* This way there is no conflict between air-gap and OSS versions,
  everything is kept simple and fast at runtime.
