### PR TITLE
fix: Duplicate `version` field in Grafana

### DIFF
--- a/charts/kof-mothership/templates/grafana/grafana.yaml
+++ b/charts/kof-mothership/templates/grafana/grafana.yaml
@@ -26,7 +26,6 @@ spec:
       client_secret: grafana-secret
       tls_skip_verify_insecure: "true"
   {{- end }}
-  version: {{ .Values.grafana.version }}
   disableDefaultAdminSecret: true
   persistentVolumeClaim:
     spec:


### PR DESCRIPTION
* Part of https://github.com/k0rdent/kof/issues/315
* Caused by merge https://github.com/k0rdent/kof/pull/348