### PR TITLE
fix: `pattern dist` not found on `kof-operator-release`

### DIFF
--- a/.github/workflows/release_operator.yml
+++ b/.github/workflows/release_operator.yml
@@ -35,6 +35,11 @@ jobs:
         working-directory: ./kof-operator
         run: |
           make test
+      - name: Build web application
+        working-directory: ./kof-operator
+        run: make build-web-app
+        # Creates `kof-operator/webapp/collector/dist`
+        # which will be embedded at `docker/build-push-action` step.
       - name: Set up Buildx
         uses: docker/setup-buildx-action@v3
       - name: Login to GHCR


### PR DESCRIPTION
* CI `kof-operator-release` https://github.com/k0rdent/kof/actions/runs/15870213164/job/44744835120
  failed with:
  ```
  webapp/collector/webapp.go:9:12: pattern dist: no matching files found
  ```
* This PR tries to fix this bug.
