### PR TITLE
fix: Part 2 of `pattern dist` not found on `kof-operator-release`

### DIFF
--- a/.github/workflows/release_operator.yml
+++ b/.github/workflows/release_operator.yml
@@ -59,7 +59,7 @@ jobs:
         with:
           build-args: |
             LD_FLAGS=-s -w
-          context: "{{defaultContext}}:kof-operator"
+          context: ./kof-operator
           platforms: linux/amd64,linux/arm64
           tags: |
             ${{ env.IMAGE_REPO }}:${{ steps.vars.outputs.version }},${{ env.IMAGE_REPO }}:latest


### PR DESCRIPTION
* Part 2 of https://github.com/k0rdent/kof/pull/353