### PR TITLE
fix: Switching to kgst 0.2.0 to use k0rdent v1beta1 instead of deleted v1alpha1

### DIFF
--- a/charts/kof-mothership/Chart.lock
+++ b/charts/kof-mothership/Chart.lock
@@ -16,9 +16,9 @@ dependencies:
   version: 0.23.0
 - name: kgst
   repository: oci://ghcr.io/k0rdent/catalog/charts
-  version: 0.1.1
+  version: 0.2.0
 - name: kgst
   repository: oci://ghcr.io/k0rdent/catalog/charts
-  version: 0.1.1
-digest: sha256:350c5db6be64517a615cf0b336be5f22d8d97f7f368e4314d7c1f009144fd024
-generated: "2025-06-18T18:17:11.716011+03:00"
+  version: 0.2.0
+digest: sha256:f12de850e89693582f6ac88bfb6722db8b041d82b8fd54a9cb01ed9399d47252
+generated: "2025-06-26T19:26:38.082999+02:00"

--- a/charts/kof-mothership/Chart.yaml
+++ b/charts/kof-mothership/Chart.yaml
@@ -26,9 +26,9 @@ dependencies:
     condition: dex.enabled
   - name: kgst
     alias: cert-manager-service-template
-    version: "0.1.1"
+    version: "0.2.0"
     repository: oci://ghcr.io/k0rdent/catalog/charts
   - name: kgst
     alias: ingress-nginx-service-template
-    version: "0.1.1"
+    version: "0.2.0"
     repository: oci://ghcr.io/k0rdent/catalog/charts

--- a/charts/kof-mothership/README.md
+++ b/charts/kof-mothership/README.md
@@ -12,8 +12,8 @@ A Helm chart that deploys Grafana, Promxy, and VictoriaMetrics.
 | https://projectsveltos.github.io/helm-charts | sveltos-dashboard | 0.56.0 |
 | https://victoriametrics.github.io/helm-charts/ | victoria-metrics-operator | 0.40.5 |
 | oci://ghcr.io/grafana/helm-charts | grafana-operator | v5.18.0 |
-| oci://ghcr.io/k0rdent/catalog/charts | cert-manager-service-template(kgst) | 0.1.1 |
-| oci://ghcr.io/k0rdent/catalog/charts | ingress-nginx-service-template(kgst) | 0.1.1 |
+| oci://ghcr.io/k0rdent/catalog/charts | cert-manager-service-template(kgst) | 0.2.0 |
+| oci://ghcr.io/k0rdent/catalog/charts | ingress-nginx-service-template(kgst) | 0.2.0 |
 | oci://ghcr.io/k0rdent/cluster-api-visualizer/charts | cluster-api-visualizer | 1.4.0 |
 
 ## Values


### PR DESCRIPTION
* Why: https://github.com/k0rdent/catalog/issues/468#issuecomment-3004582639