### PR TITLE
test: add support bundle to troubleshoot CI issues

### DIFF
--- a/.github/workflows/pr_test_upgrade.yml
+++ b/.github/workflows/pr_test_upgrade.yml
@@ -89,8 +89,8 @@ jobs:
         run: |
           make dev-operators-deploy
           make dev-ms-deploy
-          # make dev-storage-deploy
-          # make dev-collectors-deploy
+          make dev-storage-deploy
+          make dev-collectors-deploy
       - name: Fetch PR Ref and Checkout Repo
         uses: ./.github/actions/fetch-pr-ref
       - name: Install KOF CLI
@@ -106,23 +106,34 @@ jobs:
         run: |
           make dev-operators-deploy
           make dev-ms-deploy
-          # TODO: Swap with KIND adopted clusters after fix of https://github.com/k0rdent/kof/issues/352
-          make dev-storage-deploy
-          make dev-collectors-deploy
-      # - name: Run KIND kof regional cluster
-      #   run: |
-      #     make dev-adopted-deploy KIND_CLUSTER_NAME=regional-adopted
-      # - name: Run KIND cloud provider
-      #   run: docker run -d --rm --network kind -v /var/run/docker.sock:/var/run/docker.sock registry.k8s.io/cloud-provider-kind/cloud-controller-manager:v0.6.0
-      # - name: Deploy KOF Components on Adopted regional cluster
-      #   run: |
-      #     make dev-regional-deploy-adopted
-      # - name: Run KIND kof child cluster
-      #   run: |
-      #     make dev-adopted-deploy KIND_CLUSTER_NAME=child-adopted
-      # - name: Configure CoreDNS hosts on child cluster
-      #   run: |
-      #     make dev-child-coredns
-      # - name: Deploy KOF Components on Adopted child cluster
-      #   run: |
-      #     make dev-child-deploy-adopted
+      - name: Cleanup kind clusters if any
+        run: |
+          make dev-adopted-rm KIND_CLUSTER_NAME=child-adopted
+          make dev-adopted-rm KIND_CLUSTER_NAME=regional-adopted
+      - name: Run KIND kof regional cluster
+        run: |
+          make dev-adopted-deploy KIND_CLUSTER_NAME=regional-adopted
+      - name: Run KIND cloud provider
+        run: docker run -d --rm --network kind -v /var/run/docker.sock:/var/run/docker.sock registry.k8s.io/cloud-provider-kind/cloud-controller-manager:v0.6.0
+      - name: Deploy KOF Components on Adopted regional cluster
+        run: |
+          make dev-regional-deploy-adopted
+      - name: Run KIND kof child cluster
+        run: |
+          make dev-adopted-deploy KIND_CLUSTER_NAME=child-adopted
+      - name: Configure CoreDNS hosts on child cluster
+        run: |
+          make dev-child-coredns
+      - name: Deploy KOF Components on Adopted child cluster
+        run: |
+          make dev-child-deploy-adopted
+      - name: Make support-bundle
+        if: ${{ failure() }}
+        run: |
+          make support-bundle
+      - name: Archive support-bundle
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: support-bundle.tar.gz
+          path: ./support-bundle-*.tar.gz

--- a/config/support-bundle.yaml
+++ b/config/support-bundle.yaml
@@ -1,0 +1,21 @@
+apiVersion: troubleshoot.sh/v1beta2
+kind: SupportBundle
+metadata:
+  name: support-bundle
+spec:
+  collectors:
+  - logs:
+      namespace: ${NAMESPACE}
+      name: logs/${NAMESPACE}
+  - logs:
+      namespace: projectsveltos
+      name: logs/projectsveltos
+  - logs:
+      namespace: kube-system
+      name: logs/kube-system
+  - logs:
+      namespace: kubevirt
+      name: logs/kubevirt
+  - logs:
+      namespace: cdi
+      name: logs/cdi

--- a/demo/cluster/adopted-cluster-child.yaml
+++ b/demo/cluster/adopted-cluster-child.yaml
@@ -8,7 +8,7 @@ metadata:
     k0rdent.mirantis.com/kof-cluster-role: child
     k0rdent.mirantis.com/kof-regional-cluster-name: regional-adopted
 spec:
-  template: adopted-cluster-1-0-0
+  template: adopted-cluster-1-0-1
   credential: child-adopted-cred
   config:
     clusterLabels:

--- a/demo/cluster/adopted-cluster-regional.yaml
+++ b/demo/cluster/adopted-cluster-regional.yaml
@@ -7,7 +7,7 @@ metadata:
     k0rdent.mirantis.com/kof-storage-secrets: "true"
     k0rdent.mirantis.com/kof-cluster-role: regional
 spec:
-  template: adopted-cluster-1-0-0
+  template: adopted-cluster-1-0-1
   credential: regional-adopted-cred
   config:
     clusterLabels:


### PR DESCRIPTION
Closes https://github.com/k0rdent/kof/issues/352

- Cleanup kind clusters and cluster deployment if any deployed from the previous CI execution
- Create a support-bundle artifact archive with custom resources and logs if CI fails for troubleshooting