### PR TITLE
fix: Do not replace `expr` with int zero `0` if `expr` is not overridden

### DIFF
--- a/kof-operator/internal/controller/configmap_controller.go
+++ b/kof-operator/internal/controller/configmap_controller.go
@@ -383,7 +383,7 @@ func unmarshalRules[T AlertRules | RecordRules](
 
 // Patch `oldRule` with `newRule`.
 func patchRule(oldRule *promv1.Rule, newRule *promv1.Rule) {
-	if newRule.Expr.String() != "" {
+	if !(newRule.Expr.StrVal == "" && newRule.Expr.IntVal == 0) {
 		oldRule.Expr = newRule.Expr
 	}
 	if newRule.For != nil {


### PR DESCRIPTION
* Fixes https://github.com/k0rdent/kof/issues/366