### PR TITLE
fix: batch processor order

### DIFF
--- a/charts/kof-collectors/values.yaml
+++ b/charts/kof-collectors/values.yaml
@@ -179,9 +179,9 @@ collectors:
             - otlphttp
             - debug
           processors:
-            - batch
             - resource/k8sobjects
             - transform/events
+            - batch
           receivers:
             - k8sobjects
         metrics:


### PR DESCRIPTION
According to the documentation:

The batch processor should be defined in the pipeline after the memory_limiter as well as any sampling processors. This is because batching should happen after any data drops such as sampling