### PR TITLE
fix: Added letter `v` to `cert-manager:v1.16.4` for compatibility with all registries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -205,7 +205,7 @@ dev-ms-deploy: dev kof-operator-docker-build ## Deploy `kof-mothership` helm cha
 	$(KUBECTL) apply -f ./charts/kof-mothership/crds/kof.k0rdent.mirantis.com_promxyservergroups.yaml
 	$(HELM_UPGRADE) -n kof kof-mothership ./charts/kof-mothership -f dev/mothership-values.yaml
 	$(KUBECTL) rollout restart -n kof deployment/kof-mothership-kof-operator
-	@svctmpls='cert-manager-1-16-4|ingress-nginx-4-12-1|kof-collectors-1-1-0|kof-operators-1-1-0|kof-storage-1-1-0'; \
+	@svctmpls='cert-manager-v1-16-4|ingress-nginx-4-12-1|kof-collectors-1-1-0|kof-operators-1-1-0|kof-storage-1-1-0'; \
 	for attempt in $$(seq 1 10); do \
 		if [ $$($(KUBECTL) get svctmpl -A | grep -E "$$svctmpls" | grep -c true) -eq 5 ]; then break; fi; \
 		echo "|Waiting for the next service templates to become VALID:|$$svctmpls|Found:" | tr "|" "\n"; \

--- a/charts/kof-child/values.yaml
+++ b/charts/kof-child/values.yaml
@@ -1,6 +1,6 @@
 cert-manager:
   enabled: true
-  template: cert-manager-1-16-4
+  template: cert-manager-v1-16-4
 
 kcm:
   namespace: kcm-system

--- a/charts/kof-mothership/README.md
+++ b/charts/kof-mothership/README.md
@@ -20,7 +20,7 @@ A Helm chart that deploys Grafana, Promxy, and VictoriaMetrics.
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| cert-manager-service-template | object | `{"chart":"cert-manager:1.16.4",`<br>`"namespace":"kcm-system",`<br>`"repo":{"name":"cert-manager",`<br>`"url":"https://charts.jetstack.io"}}` | Config of `ServiceTemplate` to use `cert-manager` in `MultiClusterService`. |
+| cert-manager-service-template | object | `{"chart":"cert-manager:v1.16.4",`<br>`"namespace":"kcm-system",`<br>`"repo":{"name":"cert-manager",`<br>`"url":"https://charts.jetstack.io"}}` | Config of `ServiceTemplate` to use `cert-manager` in `MultiClusterService`. |
 | cert-manager<br>.cluster-issuer<br>.create | bool | `false` | Whether to create a default clusterissuer |
 | cert-manager<br>.cluster-issuer<br>.provider | string | `"letsencrypt"` | Default clusterissuer provider |
 | cert-manager<br>.email | string | `"mail@example.net"` | If we use letsencrypt (or similar) which email to use |

--- a/charts/kof-mothership/values.yaml
+++ b/charts/kof-mothership/values.yaml
@@ -40,7 +40,7 @@ cert-manager-service-template:
   repo:
     name: cert-manager
     url: https://charts.jetstack.io
-  chart: cert-manager:1.16.4
+  chart: cert-manager:v1.16.4
   namespace: kcm-system
 
 # -- Config of `ServiceTemplate` to use `ingress-nginx` in `MultiClusterService`.

--- a/charts/kof-regional/values.yaml
+++ b/charts/kof-regional/values.yaml
@@ -1,6 +1,6 @@
 cert-manager:
   enabled: true
-  template: cert-manager-1-16-4
+  template: cert-manager-v1-16-4
 
 ingress-nginx:
   enabled: true


### PR DESCRIPTION
* Part of https://github.com/k0rdent/kof/issues/399
* Values workaround for kof release 1.1.0 will be added to the docs.