### PR TITLE
fix: patch up incorrect alertmanager rules job label variable

### DIFF
--- a/charts/kof-mothership/templates/prometheus/rules/alertmanager.rules.yaml
+++ b/charts/kof-mothership/templates/prometheus/rules/alertmanager.rules.yaml
@@ -5,7 +5,7 @@ https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-promet
 */ -}}
 {{- $kubeTargetVersion := default .Capabilities.KubeVersion.GitVersion .Values.kubeTargetVersionOverride }}
 {{- if and (semverCompare ">=1.14.0-0" $kubeTargetVersion) (semverCompare "<9.9.9-9" $kubeTargetVersion) .Values.defaultRules.create .Values.defaultRules.rules.alertmanager }}
-{{- $alertmanagerJob := printf "%s-%s" (include "kube-prometheus-stack.fullname" .) "alertmanager" }}
+{{- $alertmanagerJob := "vmalertmanager-cluster" }}
 {{- $namespace := printf "%s" (include "kube-prometheus-stack.namespace" .) }}
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule


### PR DESCRIPTION
partially closes #407 

we user vmalertmanager from vmcluster, job name should be different
