### PR TITLE
fix: Add debug info to kof-operator build to prevent auto-instrumentation crash

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -10,14 +10,15 @@ builds:
       - linux
     goarch:
       - amd64
+    ldflags:
+      - -w=false
+      - -s=false
     flags:
       - -trimpath
     main: ./cmd/main.go
     dir: kof-operator
     binary: bin/manager
     mod_timestamp: "{{ .CommitTimestamp }}"
-    ldflags:
-      - -s -w
     tags:
       - netgo
     builder: go
@@ -29,14 +30,15 @@ builds:
       - linux
     goarch:
       - arm64
+    ldflags:
+      - -w=false
+      - -s=false
     flags:
       - -trimpath
     dir: kof-operator
     main: ./cmd/main.go
     binary: bin/manager
     mod_timestamp: "{{ .CommitTimestamp }}"
-    ldflags:
-      - -s -w
     tags:
       - netgo
     builder: go


### PR DESCRIPTION
- Removed `-w` and `-s` flags that delete debug information