### PR TITLE
fix: Enabled "self metrics" of `kube-state-metrics`

### DIFF
--- a/charts/kof-collectors/values.yaml
+++ b/charts/kof-collectors/values.yaml
@@ -1126,7 +1126,7 @@ opentelemetry-kube-stack:
       create: true
     releaseLabel: true
     selfMonitor:
-      enabled: false
+      enabled: true
   kubeApiServer:
     enabled: true
     serviceMonitor:


### PR DESCRIPTION
* Part of https://github.com/k0rdent/kof/issues/407
* Missing `kube_state_metrics_*` are "self metrics" [disabled by default](https://github.com/prometheus-community/helm-charts/blob/kube-state-metrics-5.25.1/charts/kube-state-metrics/values.yaml#L433-L434) in `kube-state-metrics` subchart and in `kof-collectors` too.
* Fixed, tested with `kube_state_metrics_list_total{job="kube-state-metrics"}`, OK.
