### PR TITLE
fix: Prevent regional clusters selection from cluster-deployments-events dashboard

### DIFF
--- a/charts/kof-mothership/files/dashboards/cluster-deployment-events.yaml
+++ b/charts/kof-mothership/files/dashboards/cluster-deployment-events.yaml
@@ -185,7 +185,7 @@ panels:
       sortBy:
         - desc: true
           displayName: Last Seen
-    pluginVersion: 10.4.7
+    pluginVersion: 10.4.18+security-01
     targets:
       - datasource:
           type: loki
@@ -558,7 +558,7 @@ templating:
       query: victoriametrics-logs-datasource
       queryValue: ''
       refresh: 1
-      regex: ''
+      regex: /^logs/
       skipUrlSync: false
       type: datasource
     - current:


### PR DESCRIPTION
Closes: #406 