### PR TITLE
fix: k8s events processor

### DIFF
--- a/charts/kof-collectors/values.yaml
+++ b/charts/kof-collectors/values.yaml
@@ -48,7 +48,7 @@ opentelemetry-kube-stack:
             log_statements:
               - context: log
                 conditions:
-                  - IsMatch(scope.name, "k8sobjects")
+                  - IsMatch(attributes["k8s.resource.name"], "events")
                 statements:
                   - merge_maps(attributes, body["object"], "upsert") where IsMap(body)
           transform/k8scluster:


### PR DESCRIPTION
events processor that casts event assumes that scope field is nonempty and contains receiver name, but with k8sobjects this is not the case so we resort to another heuristic on detecting that events processors should be applied based on k8s.resource.name