### PR TITLE
fix: Aligned versions of `autoinstrumentation-go` to v0.21.0 in all image registries

### DIFF
--- a/charts/kof-collectors/templates/opentelemetry/instrumentation.yaml
+++ b/charts/kof-collectors/templates/opentelemetry/instrumentation.yaml
@@ -15,11 +15,10 @@ spec:
     type: parentbased_traceidratio
     argument: "1"
   go:
-  {{- if and $global.registry (ne $global.registry "docker.io") }}
-    image: {{ $global.registry }}/opentelemetry-go-instrumentation/autoinstrumentation-go:v0.19.0-alpha
-  {{- else }}
-    image: ghcr.io/open-telemetry/opentelemetry-go-instrumentation/autoinstrumentation-go:v0.21.0
-  {{- end }}
+    image: "
+      {{- if and $global.registry (ne $global.registry "docker.io") }}{{ $global.registry }}
+      {{- else }}ghcr.io/open-telemetry
+      {{- end }}/opentelemetry-go-instrumentation/autoinstrumentation-go:v0.21.0"
     resourceRequirements:
       {{- toYaml .Values.kof.instrumentation.resources | nindent 6 }}
 {{- end }}


### PR DESCRIPTION
* Part of https://github.com/k0rdent/kof/issues/399
* Follow up for https://github.com/k0rdent/kof/pull/426