### PR TITLE
fix: Increase `maxLabelsPerTimeseries` to 50 to prevent label dropping in vmInsert

### DIFF
--- a/charts/kof-mothership/templates/victoria/vmcluster.yaml
+++ b/charts/kof-mothership/templates/victoria/vmcluster.yaml
@@ -11,7 +11,8 @@ spec:
   replicationFactor: {{ .Values.victoriametrics.vmcluster.replicationFactor | default 2 }}
   retentionPeriod: {{ .Values.victoriametrics.vmcluster.retentionPeriod | quote }}
   vminsert:
-    extraArgs: {}
+    extraArgs:
+      maxLabelsPerTimeseries: "50"
     image:
       {{- if $global.registry }}
       repository: {{ $global.registry }}/victoriametrics/vminsert

--- a/charts/kof-storage/templates/victoria/vmcluster.yaml
+++ b/charts/kof-storage/templates/victoria/vmcluster.yaml
@@ -11,7 +11,8 @@ spec:
   replicationFactor: {{ .Values.victoriametrics.vmcluster.replicationFactor | default 2 }}
   retentionPeriod: {{ .Values.victoriametrics.vmcluster.retentionPeriod | quote }}
   vminsert:
-    extraArgs: {}
+    extraArgs:
+      maxLabelsPerTimeseries: "50"
     image:
       {{- with $global.image.registry }}
       repository: {{ . }}/victoriametrics/vminsert


### PR DESCRIPTION
Closes: #410