### PR TITLE
fix: Customizable image registries for `kof-istio-network`, `cert-manager`, `ingress-nginx`

### DIFF
--- a/charts/kof-child/templates/child-multi-cluster-service.yaml
+++ b/charts/kof-child/templates/child-multi-cluster-service.yaml
@@ -1,7 +1,8 @@
 {{- $global := .Values.global | default dict }}
 {{- $globalValues := dict }}
+{{- $customRegistry := "" }}
 {{- if $global.registry }}
-{{- $globalValues = printf `
+  {{- $globalValues = printf `
 global:
   registry: $R
   imageRegistry: $R
@@ -43,6 +44,9 @@ opentelemetry-kube-stack:
       repository: $R/bitnami/kubectl
 
 ` | replace "$R" $global.registry | fromYaml }}
+  {{- if ne $global.registry "docker.io" }}
+    {{- $customRegistry = $global.registry }}
+  {{- end }}
 {{- end -}}
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: MultiClusterService
@@ -67,6 +71,19 @@ spec:
         values: |
           crds:
             enabled: true
+        {{- with $customRegistry }}
+          image:
+            repository: {{ . }}/jetstack/cert-manager-controller
+          acmesolver:
+            image:
+              repository: {{ . }}/jetstack/cert-manager-acmesolver
+          cainjector:
+            image:
+              repository: {{ . }}/jetstack/cert-manager-cainjector
+          webhook:
+            image:
+              repository: {{ . }}/jetstack/cert-manager-webhook
+        {{- end }}
       {{- end }}
 
       - name: kof-operators

--- a/charts/kof-istio/templates/child-cluster-profiles.yaml
+++ b/charts/kof-istio/templates/child-cluster-profiles.yaml
@@ -1,4 +1,9 @@
 {{- if .Values.rootCA.enabled }}
+  {{- $global := .Values.global | default dict }}
+  {{- $customRegistry := "" }}
+  {{- if and $global.registry (ne $global.registry "docker.io") }}
+    {{- $customRegistry = $global.registry }}
+  {{- end }}
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -51,17 +56,33 @@ spec:
 
   helmCharts:
 
-    - repositoryName:   k0rdent-catalog
-      repositoryURL:    oci://ghcr.io/k0rdent/catalog/charts
+    - repositoryName:   cert-manager
+    {{- with $global.helmChartsRepo }}
+      repositoryURL:    {{ . }}
+    {{- else }}
+      repositoryURL:    https://charts.jetstack.io
+    {{- end }}
       chartName:        cert-manager
-      chartVersion:     1.16.2
+      chartVersion:     v1.16.4
       releaseName:      cert-manager
       releaseNamespace: {{ .Release.Namespace }}
       helmChartAction:  Install
       values: |
-        cert-manager:
-          crds:
-            enabled: true
+        crds:
+          enabled: true
+      {{- with $customRegistry }}
+        image:
+          repository: {{ . }}/jetstack/cert-manager-controller
+        acmesolver:
+          image:
+            repository: {{ . }}/jetstack/cert-manager-acmesolver
+        cainjector:
+          image:
+            repository: {{ . }}/jetstack/cert-manager-cainjector
+        webhook:
+          image:
+            repository: {{ . }}/jetstack/cert-manager-webhook
+      {{- end }}
 
     - repositoryName:   {{ .Values.kcm.kof.repo.name }}
       repositoryURL:    {{ .Values.kcm.kof.repo.spec.url }}
@@ -84,10 +105,17 @@ spec:
             certificate: false
             issuer: false
         global:
+        {{- with $customRegistry }}
+          hub: {{ . }}/istio
+        {{- end }}
           multiCluster:
             clusterName: {{ `{{ .Cluster.metadata.name }}` }}
           network: {{ `{{ .Cluster.metadata.name }}` }}-network
         cert-manager-istio-csr:
+        {{- with $customRegistry }}
+          image:
+            repository: {{ . }}/jetstack/cert-manager-istio-csr
+        {{- end }}
           app:
             certmanager:
               issuer:

--- a/charts/kof-istio/templates/kof-regional-cluster-profile.yaml
+++ b/charts/kof-istio/templates/kof-regional-cluster-profile.yaml
@@ -61,7 +61,11 @@ spec:
 
   helmCharts:
     - repositoryName:   istio
+    {{- with $global.helmChartsRepo }}
+      repositoryURL:    {{ . }}
+    {{- else }}
       repositoryURL:    https://istio-release.storage.googleapis.com/charts
+    {{- end }}
       chartName:        istio/gateway
       chartVersion:     1.24.3
       releaseName:      {{ .Release.Name }}-gateway

--- a/charts/kof-regional/templates/regional-multi-cluster-service.yaml
+++ b/charts/kof-regional/templates/regional-multi-cluster-service.yaml
@@ -1,7 +1,8 @@
 {{- $global := .Values.global | default dict }}
 {{- $globalValues := dict }}
+{{- $customRegistry := "" }}
 {{- if $global.registry }}
-{{- $globalValues = printf `
+  {{- $globalValues = printf `
 global:
   registry: $R
   imageRegistry: $R
@@ -43,6 +44,9 @@ opentelemetry-kube-stack:
       repository: $R/bitnami/kubectl
 
 ` | replace "$R" $global.registry | fromYaml }}
+  {{- if ne $global.registry "docker.io" }}
+    {{- $customRegistry = $global.registry }}
+  {{- end }}
 {{- end -}}
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: MultiClusterService
@@ -66,6 +70,19 @@ spec:
         values: |
           crds:
             enabled: true
+        {{- with $customRegistry }}
+          image:
+            repository: {{ . }}/jetstack/cert-manager-controller
+          acmesolver:
+            image:
+              repository: {{ . }}/jetstack/cert-manager-acmesolver
+          cainjector:
+            image:
+              repository: {{ . }}/jetstack/cert-manager-cainjector
+          webhook:
+            image:
+              repository: {{ . }}/jetstack/cert-manager-webhook
+        {{- end }}
       {{- end }}
 
       {{- if (index .Values "ingress-nginx" "enabled") }}
@@ -75,15 +92,26 @@ spec:
         values: |
           {{`{{`}} $ingressNginxValuesFromAnnotation := index .Cluster.metadata.annotations "k0rdent.mirantis.com/kof-ingress-nginx-values" | default "{}" | fromYaml {{`}}`}}
           {{`{{`}} $ingressNginxValuesFromHelm := `{{ index .Values "ingress-nginx" | toYaml | nindent 10 }}` | fromYaml {{`}}`}}
-          {{`{{`}} $ingressNginxValuesHere := `{}` | fromYaml {{`}}`}}
+          {{`{{`}} $ingressNginxValuesHere := `
+          controller:
+            image:
+              digest: ""
+            admissionWebhooks:
+              patch:
+                image:
+                  digest: ""
+          ` | fromYaml {{`}}`}}
           {{`{{`}} if eq (get .InfrastructureProvider "kind") "AzureCluster" {{`}}`}}
-          {{`{{`}} $ingressNginxValuesHere = `
+          {{`{{`}} $ingressNginxValuesAzure = `
           controller:
             service:
               annotations:
-                service.beta.kubernetes.io/azure-load-balancer-health-probe-request-path: /healthz ` | fromYaml {{`}}`}}
+                service.beta.kubernetes.io/azure-load-balancer-health-probe-request-path: /healthz
+          ` | fromYaml {{`}}`}}
+          {{`{{`}} $ingressNginxValuesHere = mergeOverwrite $ingressNginxValuesHere $ingressNginxValuesAzure {{`}}`}}
           {{`{{ end }}`}}
-          {{`{{`}} mergeOverwrite $ingressNginxValuesHere $ingressNginxValuesFromHelm $ingressNginxValuesFromAnnotation | toYaml | nindent 4 {{`}}`}}
+          {{`{{`}} $globalValuesFromHelm := `{{ $globalValues | toYaml | nindent 10 }}` | fromYaml {{`}}`}}
+          {{`{{`}} mergeOverwrite (dict) $globalValuesFromHelm $ingressNginxValuesHere $ingressNginxValuesFromHelm $ingressNginxValuesFromAnnotation | toYaml | nindent 4 {{`}}`}}
       {{- end }}
 
       - name: kof-operators

--- a/docs/workarounds.md
+++ b/docs/workarounds.md
@@ -1,0 +1,23 @@
+# KOF Workarounds
+
+These are temporary workarounds that don't need to be included to the main docs.
+
+## Failed to create temporary file
+
+If you're testing with `kind` cluster on Mac arm64,
+and istio sidecars are crashing with `Failed to create temporary file` error,
+then edit the `istio-sidecar-injector` ConfigMap and add there:
+
+```yaml
+            volumeMounts:
+            - mountPath: /tmp
+              name: tmp
+...
+          volumes:
+          - emptyDir:
+            name: tmp
+```
+
+Alternative is to disable Rosetta and degrade performance:
+* https://github.com/istio/istio/issues/55655
+* https://github.com/kgateway-dev/kgateway/issues/9800


### PR DESCRIPTION
* Part of https://github.com/k0rdent/kof/issues/435
* Before the fix:
  ```
  KUBECONFIG=dev/regional-kubeconfig kubectl get pod -n istio-system -o yaml | grep image:

    image: quay.io/jetstack/cert-manager-controller:v1.16.2
    image: quay.io/jetstack/cert-manager-controller:v1.16.2
    image: quay.io/jetstack/cert-manager-cainjector:v1.16.2
    image: quay.io/jetstack/cert-manager-cainjector:v1.16.2
    image: quay.io/jetstack/cert-manager-istio-csr:v0.14.0
    image: quay.io/jetstack/cert-manager-istio-csr:v0.14.0
    image: quay.io/jetstack/cert-manager-webhook:v1.16.2
    image: quay.io/jetstack/cert-manager-webhook:v1.16.2
    image: docker.io/istio/pilot:1.24.3
    image: docker.io/istio/pilot:1.24.3
    image: docker.io/istio/proxyv2:1.24.3
    image: docker.io/istio/proxyv2:1.24.3
    ...
  
  KUBECONFIG=dev/regional-kubeconfig kubectl get pod -n kof -o yaml | grep image:

    image: docker.io/istio/proxyv2:1.24.3
      (in each pod)
  ```
* After the fix:
  ```
  KUBECONFIG=dev/regional-kubeconfig kubectl get pod -n istio-system -o yaml \
  | yq .items[].spec.containers[].image | sort | uniq

    REDACTED/istio/pilot:1.24.3
    REDACTED/istio/proxyv2:1.24.3
    REDACTED/jetstack/cert-manager-cainjector:v1.16.4
    REDACTED/jetstack/cert-manager-controller:v1.16.4
    REDACTED/jetstack/cert-manager-istio-csr:v0.14.0
    REDACTED/jetstack/cert-manager-webhook:v1.16.4

  KUBECONFIG=dev/regional-kubeconfig kubectl get pod -n kof -o yaml \
  | yq .items[].spec.containers[].image | sort | uniq

    REDACTED/brancz/kube-rbac-proxy:v0.18.1
    REDACTED/grafana/grafana-operator:v5.18.0
    REDACTED/grafana/grafana:10.4.18-security-01
    REDACTED/istio/proxyv2:1.24.3
    REDACTED/jaegertracing/all-in-one:1.52.0
    REDACTED/jaegertracing/jaeger-operator:1.52.0
    REDACTED/jimmidyson/configmap-reload:v0.3.0
    REDACTED/kube-state-metrics/kube-state-metrics:v2.13.0
    REDACTED/opencost/opencost-ui:1.113.0
    REDACTED/opencost/opencost:1.113.0
    REDACTED/opentelemetry-operator/opentelemetry-operator:0.120.0
    REDACTED/opentelemetry-operator/target-allocator:v0.124.0
    REDACTED/otel/opentelemetry-collector-contrib:0.123.0
    REDACTED/prometheus/node-exporter:v1.8.2
    REDACTED/victoriametrics/operator:v0.51.3
    REDACTED/victoriametrics/victoria-logs:v1.21.0-victorialogs
    REDACTED/victoriametrics/vmalert:v1.105.0
    REDACTED/victoriametrics/vminsert:v1.105.0-cluster
    REDACTED/victoriametrics/vmselect:v1.105.0-cluster
    REDACTED/victoriametrics/vmstorage:v1.105.0-cluster
  ```
  where `REDACTED` is the custom image registry, OK.
* Found the same situation with `cert-manager` and `ingress-nginx` in **non-istio** case!
* Before the fix:
  ```
  KUBECONFIG=dev/regional-kubeconfig kubectl get pod -n kof -o yaml \
  | yq .items[].spec.containers[].image | sort | uniq

    quay.io/jetstack/cert-manager-acmesolver:v1.16.4
    quay.io/jetstack/cert-manager-cainjector:v1.16.4
    quay.io/jetstack/cert-manager-controller:v1.16.4
    quay.io/jetstack/cert-manager-webhook:v1.16.4
    registry.k8s.io/ingress-nginx/controller:v1.12.1@sha256:d2fbc4ec70d8aa2050dd91a91506e998765e86c96f32cffb56c503c9c34eed5b
    ...
  ```
* After the fix:
  ```
  KUBECONFIG=dev/regional-kubeconfig kubectl get pod -n kof -o yaml \ 
  | yq .items[].spec.containers[].image | sort | uniq

    REDACTED/brancz/kube-rbac-proxy:v0.18.1
    REDACTED/external-dns/external-dns:v0.15.1
    REDACTED/grafana/grafana-operator:v5.18.0
    REDACTED/grafana/grafana:10.4.18-security-01
    REDACTED/ingress-nginx/controller:v1.12.1
    REDACTED/jaegertracing/all-in-one:1.52.0
    REDACTED/jaegertracing/jaeger-operator:1.52.0
    REDACTED/jetstack/cert-manager-cainjector:v1.16.4
    REDACTED/jetstack/cert-manager-controller:v1.16.4
    REDACTED/jetstack/cert-manager-webhook:v1.16.4
    REDACTED/jimmidyson/configmap-reload:v0.3.0
    REDACTED/kube-state-metrics/kube-state-metrics:v2.13.0
    REDACTED/opencost/opencost-ui:1.113.0
    REDACTED/opencost/opencost:1.113.0
    REDACTED/opentelemetry-operator/opentelemetry-operator:0.120.0
    REDACTED/opentelemetry-operator/target-allocator:v0.124.0
    REDACTED/otel/opentelemetry-collector-contrib:0.123.0
    REDACTED/prometheus-operator/prometheus-config-reloader:v0.68.0
    REDACTED/prometheus/node-exporter:v1.8.2
    REDACTED/victoriametrics/operator:v0.51.3
    REDACTED/victoriametrics/victoria-logs:v1.21.0-victorialogs
    REDACTED/victoriametrics/vmalert:v1.105.0
    REDACTED/victoriametrics/vmauth:v1.108.1
    REDACTED/victoriametrics/vminsert:v1.105.0-cluster
    REDACTED/victoriametrics/vmselect:v1.105.0-cluster
    REDACTED/victoriametrics/vmstorage:v1.105.0-cluster
  ```
* Tested the fix with child cluster too, OK:
  ```
  KUBECONFIG=dev/child-kubeconfig kubectl get pod -n kof -o yaml \
  | yq .items[].spec.containers[].image | sort | uniq

    REDACTED/brancz/kube-rbac-proxy:v0.18.1
    REDACTED/jetstack/cert-manager-cainjector:v1.16.4
    REDACTED/jetstack/cert-manager-controller:v1.16.4
    REDACTED/jetstack/cert-manager-webhook:v1.16.4
    REDACTED/kube-state-metrics/kube-state-metrics:v2.13.0
    REDACTED/opencost/opencost-ui:1.113.0
    REDACTED/opencost/opencost:1.113.0
    REDACTED/opentelemetry-operator/opentelemetry-operator:0.120.0
    REDACTED/opentelemetry-operator/target-allocator:v0.124.0
    REDACTED/otel/opentelemetry-collector-contrib:0.123.0
    REDACTED/prometheus/node-exporter:v1.8.2
  ```
