### PR TITLE
fix: change Opencost prometheus URL to HTTP

### DIFF
--- a/charts/kof-collectors/values.yaml
+++ b/charts/kof-collectors/values.yaml
@@ -1468,7 +1468,7 @@ opencost:
       password_key: password
       external:
         enabled: true
-        url: https://vmselect-cluster:8481/select/0/prometheus
+        url: http://vmselect-cluster:8481/select/0/prometheus
       internal:
         enabled: false
     metrics:


### PR DESCRIPTION
- Fix invalid Prometheus URL to resolve `Prometheus communication error` on Mothership and regional clusters