### PR TITLE
fix: move grafana operator to kof-operators helm chart

### DIFF
--- a/charts/kof-child/values.yaml
+++ b/charts/kof-child/values.yaml
@@ -34,4 +34,6 @@ collectors:
             enableMetrics: false
         podAnnotations:
           prometheus.io/ip4: ${env:OTEL_K8S_NODE_IP}
-operators: {}
+operators:
+  grafana-operator:
+    enabled: false

--- a/charts/kof-mothership/Chart.lock
+++ b/charts/kof-mothership/Chart.lock
@@ -1,7 +1,4 @@
 dependencies:
-- name: grafana-operator
-  repository: oci://ghcr.io/grafana/helm-charts
-  version: v5.18.0
 - name: victoria-metrics-operator
   repository: https://victoriametrics.github.io/helm-charts/
   version: 0.43.1
@@ -20,5 +17,5 @@ dependencies:
 - name: kgst
   repository: oci://ghcr.io/k0rdent/catalog/charts
   version: 1.2.0
-digest: sha256:38149109975b3a3bce5734031d302c3efe7662fbb5eff76766d7702688e62011
-generated: "2025-07-31T19:49:02.068702+02:00"
+digest: sha256:3fafd4755b47368564516738997441667d4da64fde7ad717a33819c34f0035f5
+generated: "2025-08-05T11:42:16.088951+03:00"

--- a/charts/kof-mothership/Chart.yaml
+++ b/charts/kof-mothership/Chart.yaml
@@ -4,10 +4,6 @@ description: A Helm chart that deploys Grafana, Promxy, and VictoriaMetrics.
 version: "1.2.0"
 appVersion: "1.2.0"
 dependencies:
-  - name: grafana-operator
-    version: "v5.18.0"
-    repository: "oci://ghcr.io/grafana/helm-charts"
-    condition: grafana.enabled
   - name: victoria-metrics-operator
     version: "0.43.1"
     repository: "https://victoriametrics.github.io/helm-charts/"

--- a/charts/kof-mothership/README.md
+++ b/charts/kof-mothership/README.md
@@ -11,7 +11,6 @@ A Helm chart that deploys Grafana, Promxy, and VictoriaMetrics.
 | https://charts.dexidp.io | dex | 0.23.0 |
 | https://projectsveltos.github.io/helm-charts | sveltos-dashboard | 0.56.0 |
 | https://victoriametrics.github.io/helm-charts/ | victoria-metrics-operator | 0.43.1 |
-| oci://ghcr.io/grafana/helm-charts | grafana-operator | v5.18.0 |
 | oci://ghcr.io/k0rdent/catalog/charts | cert-manager-service-template(kgst) | 1.2.0 |
 | oci://ghcr.io/k0rdent/catalog/charts | ingress-nginx-service-template(kgst) | 1.2.0 |
 | oci://ghcr.io/k0rdent/cluster-api-visualizer/charts | cluster-api-visualizer | 1.4.0 |
@@ -64,7 +63,6 @@ A Helm chart that deploys Grafana, Promxy, and VictoriaMetrics.
 | global<br>.random_username_length | int | `8` | Length of the auto-generated usernames for Grafana and VictoriaMetrics. |
 | global<br>.registry | string | `"docker.io"` | Custom image registry, `sveltos-dashboard` requires not empty value. |
 | global<br>.storageClass | string | `""` | Name of the storage class used by Grafana, `vmstorage` (long-term storage of raw time series data), and `vmselect` (cache of query results). Keep it unset or empty to leverage the advantages of [default storage class](https://kubernetes.io/docs/concepts/storage/storage-classes/#default-storageclass). |
-| grafana-operator<br>.image<br>.repository | string | `"ghcr.io/grafana/grafana-operator"` | Custom `grafana-operator` image repository. |
 | grafana<br>.dashboard<br>.datasource<br>.current | object | `{"text":"promxy",`<br>`"value":"promxy"}` | Values of current datasource |
 | grafana<br>.dashboard<br>.datasource<br>.regex | string | `"/promxy/"` | Regex pattern to filter datasources. |
 | grafana<br>.dashboard<br>.filters | object | `{"cluster":"mothership"}` | Values of filters to apply. |

--- a/charts/kof-mothership/values.yaml
+++ b/charts/kof-mothership/values.yaml
@@ -19,11 +19,6 @@ global:
   # -- Custom image registry, `sveltos-dashboard` requires not empty value.
   registry: docker.io
 
-grafana-operator:
-  image:
-    # -- Custom `grafana-operator` image repository.
-    repository: ghcr.io/grafana/grafana-operator
-
 cert-manager:
   # -- Whether cert-manager is present in the cluster
   enabled: true
@@ -457,8 +452,7 @@ windowsMonitoring: {}
 ## custom Rules to override "for" and "severity" in defaultRules
 ##
 # @ignored
-customRules:
-  {}
+customRules: {}
   # AlertmanagerFailedReload:
   #   for: 3m
   # AlertmanagerMembersInconsistent:
@@ -610,8 +604,7 @@ defaultRules:
 # -- Cluster-specific patch of Prometheus alerting rules,
 # e.g. `cluster1.alertgroup1.alert1.expr` overriding the threshold `> ( 25 / 100 )`
 # and adding `{cluster="cluster1"}` filter, or just adding whole new rules
-clusterAlertRules:
-  {}
+clusterAlertRules: {}
   # cluster1:
   #   kubernetes-resources:
   #     CPUThrottlingHigh:
@@ -653,8 +646,7 @@ defaultAlertRules:
 # -- Cluster-specific patch of Prometheus recording rules,
 # e.g. `regionalCluster1.recordGroup1` overriding whole group of rules
 # (because `record` is not unique), or adding new groups
-clusterRecordRules:
-  {}
+clusterRecordRules: {}
   # regional1:
   #   kube-prometheus-general.rules:
   #     - expr: count without(instance, pod, node) (up == 1)
@@ -667,8 +659,7 @@ clusterRecordRules:
 # -- Patch of default Prometheus recording rules,
 # e.g. `recordgroup1` overriding whole group of rules (`record` is not unique),
 # or adding new groups
-defaultRecordRules:
-  {}
+defaultRecordRules: {}
   # kube-prometheus-general.rules:
   #   - expr: count without(instance, pod, node) (up == 1)
   #     record: count:up1

--- a/charts/kof-operators/Chart.lock
+++ b/charts/kof-operators/Chart.lock
@@ -1,9 +1,12 @@
 dependencies:
+- name: grafana-operator
+  repository: oci://ghcr.io/grafana/helm-charts
+  version: v5.18.0
 - name: opentelemetry-operator
   repository: https://open-telemetry.github.io/opentelemetry-helm-charts
   version: 0.84.2
 - name: prometheus-operator-crds
   repository: https://prometheus-community.github.io/helm-charts
   version: 15.0.0
-digest: sha256:6c1255d6ae2aaacadf2663a508d469572a2b5cf09808c7f5687d0a552427d019
-generated: "2025-06-11T12:01:13.066149079-05:00"
+digest: sha256:eee3f5794e12a89ac591902606b9e108154c2fe2498653b9bb2e8e491bdcb50c
+generated: "2025-08-05T11:42:24.223357+03:00"

--- a/charts/kof-operators/Chart.yaml
+++ b/charts/kof-operators/Chart.yaml
@@ -4,6 +4,10 @@ description: A Helm chart that deploys opentelemetry-operator and prometheus CRD
 version: "1.2.0"
 appVersion: "1.2.0"
 dependencies:
+  - name: grafana-operator
+    version: "v5.18.0"
+    repository: "oci://ghcr.io/grafana/helm-charts"
+    condition: grafana-operator.enabled
   - name: opentelemetry-operator
     version: "0.84.2"
     repository: "https://open-telemetry.github.io/opentelemetry-helm-charts"

--- a/charts/kof-operators/values.yaml
+++ b/charts/kof-operators/values.yaml
@@ -22,3 +22,8 @@ opentelemetry-operator:
   kubeRBACProxy:
     image:
       repository: quay.io/brancz/kube-rbac-proxy
+grafana-operator:
+  enables: true
+  image:
+    # -- Custom `grafana-operator` image repository.
+    repository: ghcr.io/grafana/grafana-operator


### PR DESCRIPTION
Close https://github.com/k0rdent/kof/issues/397

As grafana operator now is removed with mothership chart, the operator cannot finalize dashboards, sources, etc.