### PR TITLE
fix: `istio/gateway` chart repo compatibility with custom registry

### DIFF
--- a/charts/kof-istio/templates/kof-regional-cluster-profile.yaml
+++ b/charts/kof-istio/templates/kof-regional-cluster-profile.yaml
@@ -63,10 +63,12 @@ spec:
     - repositoryName:   istio
     {{- with $global.helmChartsRepo }}
       repositoryURL:    {{ . }}
+      chartName:        {{ with $global.helmChartsRepoIstioPrefix }}{{ . }}{{ end }}gateway
+      {{/* This prefix can be "istio/" or "istio-" or empty in OCI repo */}}
     {{- else }}
       repositoryURL:    https://istio-release.storage.googleapis.com/charts
-    {{- end }}
       chartName:        istio/gateway
+    {{- end }}
       chartVersion:     1.24.3
       releaseName:      {{ .Release.Name }}-gateway
       releaseNamespace: {{ .Release.Namespace }}


### PR DESCRIPTION
* Tested, OK:
  ```
  Installing chart gateway from repo oci://REDACTED/charts istio)
  ...
  Pulled: REDACTED/charts/gateway:1.24.3
  ...
  release istio-system/kof-istio-gateway (version 1.24.3) status: deployed
  ```
