### PR TITLE
fix: Added `ServiceTemplateChain` `cert-manager-v1-16-4-from-1-16-4` required for upgrade to KOF 1.2.0

### DIFF
--- a/charts/kof-mothership/templates/k0rdent/kof/svctmpl.yaml
+++ b/charts/kof-mothership/templates/k0rdent/kof/svctmpl.yaml
@@ -43,3 +43,17 @@ spec:
     {{- end }}
   {{- end }}
 {{- end }}
+---
+apiVersion: k0rdent.mirantis.com/v1beta1
+kind: ServiceTemplateChain
+metadata:
+  name: cert-manager-v1-16-4-from-1-16-4
+  namespace: {{ $.Values.kcm.namespace }}
+  annotations:
+    helm.sh/resource-policy: keep
+spec:
+  supportedTemplates:
+    - name: cert-manager-v1-16-4
+    - name: cert-manager-1-16-4
+      availableUpgrades:
+        - name: cert-manager-v1-16-4


### PR DESCRIPTION
* Thanks to @aglarendil for spotting this.
* Will cherry-pick to https://github.com/k0rdent/kof/tree/release/v1.2.0 after the merge.
* Should be included to KOF 1.2.1 patch release if we decide to make it.
