### PR TITLE
fix: override only defined properties with annotation on config update

### DIFF
--- a/kof-operator/internal/controller/clusterdeployment_controller_test.go
+++ b/kof-operator/internal/controller/clusterdeployment_controller_test.go
@@ -835,7 +835,7 @@ var _ = Describe("ClusterDeployment Controller", func() {
 			Expect(updatedPromxyServerGroup.Spec.HttpClient).NotTo(Equal(promxyServerGroup.Spec.HttpClient))
 			Expect(updatedPromxyServerGroup.Spec.HttpClient.TLSConfig.InsecureSkipVerify).To(BeTrue())
 			Expect(updatedPromxyServerGroup.Spec.HttpClient.DialTimeout.Duration).To(Equal(1 * time.Second))
-			Expect(updatedPromxyServerGroup.Spec.HttpClient.BasicAuth.CredentialsSecretName).To(BeEmpty())
+			Expect(updatedPromxyServerGroup.Spec.HttpClient.BasicAuth.CredentialsSecretName).To(Equal("storage-vmuser-credentials"))
 		})
 
 		It("should update the GrafanaDatasource when regional cluster annotation changes", func() {

--- a/kof-operator/internal/controller/configmap_cluster_regional.go
+++ b/kof-operator/internal/controller/configmap_cluster_regional.go
@@ -316,7 +316,7 @@ func (c *RegionalClusterConfigMap) UpdatePromxyServerGroup(promxyServerGroup *ko
 	}
 
 	if httpClientConfig == nil {
-		httpClientConfig = &kofv1beta1.HTTPClientConfig{}
+		httpClientConfig = &promxyServerGroup.Spec.HttpClient
 	}
 
 	if newMetrics.Scheme == promxyServerGroup.Spec.Scheme &&
@@ -329,7 +329,9 @@ func (c *RegionalClusterConfigMap) UpdatePromxyServerGroup(promxyServerGroup *ko
 	promxyServerGroup.Spec.Scheme = newMetrics.Scheme
 	promxyServerGroup.Spec.Targets = []string{newMetrics.Target}
 	promxyServerGroup.Spec.PathPrefix = newMetrics.EscapedPath()
-	promxyServerGroup.Spec.HttpClient = *httpClientConfig
+	if err := utils.MergeConfig(&promxyServerGroup.Spec.HttpClient, httpClientConfig); err != nil {
+		return err
+	}
 
 	if err := c.client.Update(c.ctx, promxyServerGroup); err != nil {
 		utils.LogEvent(

--- a/kof-operator/internal/controller/utils/utils.go
+++ b/kof-operator/internal/controller/utils/utils.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"strconv"
@@ -170,4 +171,15 @@ func LogEvent(
 
 func IsEmptyString(s string) bool {
 	return s == ""
+}
+
+func MergeConfig(dst, src any) error {
+	srcBytes, err := json.Marshal(src)
+	if err != nil {
+		return err
+	}
+	if err = json.Unmarshal(srcBytes, dst); err != nil {
+		return err
+	}
+	return nil
 }


### PR DESCRIPTION
Currently basic_auth config managed by kof-operator and if any of http_config params are overrided by annotation like
```
k0rdent.mirantis.com/kof-http-config: '{"dial_timeout": "1s", "tls_config": {"insecure_skip_verify": true }}
```
it leads to empty basic_auth config in PromxyServerGroup which has to be kept.
