### PR TITLE
fix: "Cluster Deployments Events" dashboard vs "From Management to Regional" case

### DIFF
--- a/charts/kof-mothership/files/dashboards/kubernetes-events/cluster-deployment-events.yaml
+++ b/charts/kof-mothership/files/dashboards/kubernetes-events/cluster-deployment-events.yaml
@@ -197,7 +197,7 @@ panels:
           | unpack_json from regarding result_prefix "regarding_"
           | unpack_json from metadata result_prefix "metadata_"
           | regarding_kind:in($linked_object)
-          | regarding_name:~"^${cluster_deployment}(-md-.*|-cp-.*)?$"
+          | regarding_name:~"$cluster_deployment"
           | metadata_annotations.generation:in($generation)
         queryType: instant
         refId: A
@@ -408,7 +408,7 @@ panels:
           k8s.namespace.name:in($namespace)
           | unpack_json from regarding result_prefix "regarding_"
           | unpack_json from metadata result_prefix "metadata_"
-          | regarding_name:~"^${cluster_deployment}(-md-.*|-cp-.*)?$"
+          | regarding_name:~"$cluster_deployment"
           | regarding_kind:in($linked_object)
           | metadata_annotations.generation:in($generation)
           | stats by (type) count()
@@ -486,7 +486,7 @@ panels:
           | unpack_json from regarding result_prefix "regarding_"
           | unpack_json from metadata result_prefix "metadata_"
           | regarding_kind:in($linked_object)
-          | regarding_name:~"^${cluster_deployment}(-md-.*|-cp-.*)?$"
+          | regarding_name:~"$cluster_deployment"
           | metadata_annotations.generation:in($generation)
           | stats by (reason) count()
         instant: false
@@ -535,7 +535,7 @@ panels:
           | unpack_json from regarding result_prefix "regarding_"
           | unpack_json from metadata result_prefix "metadata_"
           | regarding_kind:in($linked_object)
-          | regarding_name:~"^${cluster_deployment}(-md-.*|-cp-.*)?$"
+          | regarding_name:~"$cluster_deployment"
           | metadata_annotations.generation:in($generation)
         queryType: instant
         range: true
@@ -561,7 +561,7 @@ templating:
       query: victoriametrics-logs-datasource
       queryValue: ''
       refresh: 1
-      regex: /^logs$/
+      regex: ''
       skipUrlSync: false
       type: datasource
     - current:
@@ -573,7 +573,7 @@ templating:
       hide: 0
       includeAll: false
       label: cluster_deployment
-      multi: false
+      multi: true
       name: cluster_deployment
       options: []
       query:

--- a/charts/kof-storage/files/dashboards/kubernetes-events/kubernetes-events-dashboard.yaml
+++ b/charts/kof-storage/files/dashboards/kubernetes-events/kubernetes-events-dashboard.yaml
@@ -14,7 +14,7 @@ annotations:
         tags: []
         type: dashboard
       type: dashboard
-description: Kubernetes Events
+description: All Kubernetes Events
 editable: true
 fiscalYearStartMonth: 0
 gnetId: 17882
@@ -1306,7 +1306,7 @@ timepicker:
     - 2h
     - 1d
 timezone: ''
-title: Kubernetes Events
+title: All Kubernetes Events
 uid: kubernetes-event-exporter
 version: 39
 weekStart: ''


### PR DESCRIPTION
* [From Management to Regional](https://docs.k0rdent.io/v1.2.0/admin/kof/kof-storing/#from-management-to-regional) case means:
  metrics, logs, and traces from management cluster are sent to regional cluster.
* "Cluster Deployments Events" dashboard stopped supporting this case
  after PR https://github.com/k0rdent/kof/pull/418
  which added `/^logs$/` regex matching only `GrafanaDatasource` named exactly `logs` as in [From Management to Management](https://docs.k0rdent.io/v1.2.0/admin/kof/kof-storing/#from-management-to-management) case.
* That PR tried to fix the issue https://github.com/k0rdent/kof/issues/406
  where selecting a regional datasource in this dashboard lead to `Status: 500`.
* Investigating this error deeper:
  ```
  Status: 500. Message: error from datasource: ...
  cannot parse query [
    k8s.namespace.name:~".*"
    | unpack_json from regarding result_prefix "regarding_"
    | unpack_json from metadata result_prefix "metadata_"
    | regarding_kind:*
    | regarding_name:
    | metadata_annotations.generation:*
  ]:

  unexpected pipe "regarding_name";
  ```
* So the `| regarding_name:` without a value is an invalid query syntax.
* It was caused by the `| regarding_name:$cluster_deployment` variable expansion.
* Current PR fixes it to be `| regarding_name:~"$cluster_deployment"`
  unlike `| regarding_name:~"^${cluster_deployment}(-md-.*|-cp-.*)?$"`
  introduced later in https://github.com/k0rdent/kof/pull/382
  because e.g. the valuable informative `regarding_kind: ClusterSummary`
  has the not matching `regarding_name: kof-regional-cluster-capi-$cluster_deployment`
  and other kinds may contain the `$cluster_deployment` name in a different way.
* This also allows to re-enable multi-selection of ClusterDeployments.
* Also porting `event.name:*` primary filter for performance to 1.1.0.
* Also fixed the issue with folder naming in main:
  ```
  kubectl get GrafanaDashboard -n kof cluster-deployment-events -o yaml | yq .status

  conditions:
    - message: |-
        Dashboard failed to be applied for 1 out of 1 instances. Errors:
        - kof/grafana-vm: [POST /folders][400] createFolderBadRequest {"message":
        "Folder name cannot be the same as one of its dashboards"}
      reason: ApplyFailed
  ```
* Fix in `release/v1.1.0` branch - https://github.com/k0rdent/kof/commit/c9483e27c385b8f10c1e882e639379e6e2184af4
* Fix in `main` - this PR.
* As a result the "From Management to Regional" case, `ClusterSummary` and other kinds are supported now.

1.1.0:

<img width="1226" height="726" alt="1-1-0" src="https://github.com/user-attachments/assets/16b6b101-e06f-4359-b379-fb237af13692" />

main:

<img width="1291" height="733" alt="main" src="https://github.com/user-attachments/assets/7bf6a2a6-abbc-4c2f-8566-0c440fc6c9a3" />
