### PR TITLE
fix: Custom `registryCredentialsConfig` in `helmCharts` of `kof-istio`

### DIFF
--- a/charts/kof-istio/templates/_helpers.tpl
+++ b/charts/kof-istio/templates/_helpers.tpl
@@ -6,6 +6,16 @@ chartName: {{ .repo }}/{{ .name }}
 {{- end }}
 {{- end -}}
 
+{{- define "helm_repo_creds" }}
+      registryCredentialsConfig:
+        {{- with .secretRef }}
+        credentials: {{- . | toYaml | nindent 10 }}
+        {{- end }}
+        {{- with .certSecretRef }}
+        ca: {{- . | toYaml | nindent 10 }}
+        {{- end }}
+{{- end }}
+
 {{- define "collectors_values_format" -}}
         global:
           clusterName: {childClusterName}

--- a/charts/kof-istio/templates/child-cluster-profiles.yaml
+++ b/charts/kof-istio/templates/child-cluster-profiles.yaml
@@ -57,6 +57,7 @@ spec:
   helmCharts:
 
     - repositoryName:   cert-manager
+    {{- include "helm_repo_creds" ($global.helmRepoCreds | default .Values.kcm.kof.repo.spec) }}
     {{- with $global.helmChartsRepo }}
       repositoryURL:    {{ . }}
     {{- else }}
@@ -89,6 +90,7 @@ spec:
 
     - repositoryName:   {{ .Values.kcm.kof.repo.name }}
       repositoryURL:    {{ .Values.kcm.kof.repo.spec.url }}
+      {{- include "helm_repo_creds" .Values.kcm.kof.repo.spec }}
       {{- include "repo_chart_name" (dict "name" "kof-istio" "type" .Values.kcm.kof.repo.spec.type "repo" .Values.kcm.kof.repo.name) | nindent 6 }}
       chartVersion:     {{ .Chart.Version }}
       releaseName:      kof-istio

--- a/charts/kof-istio/templates/kof-child-cluster-profile.yaml
+++ b/charts/kof-istio/templates/kof-child-cluster-profile.yaml
@@ -86,6 +86,7 @@ spec:
 
     - repositoryName:   {{ .Values.kcm.kof.repo.name }}
       repositoryURL:    {{ .Values.kcm.kof.repo.spec.url }}
+      {{- include "helm_repo_creds" .Values.kcm.kof.repo.spec }}
       {{- include "repo_chart_name" (dict "name" "kof-operators" "type" .Values.kcm.kof.repo.spec.type "repo" .Values.kcm.kof.repo.name) | nindent 6 }}
       chartVersion:     {{ .Chart.Version }}
       releaseName:      kof-operators
@@ -98,6 +99,7 @@ spec:
 
     - repositoryName:   {{ .Values.kcm.kof.repo.name }}
       repositoryURL:    {{ .Values.kcm.kof.repo.spec.url }}
+      {{- include "helm_repo_creds" .Values.kcm.kof.repo.spec }}
       {{- include "repo_chart_name" (dict "name" "kof-collectors" "type" .Values.kcm.kof.repo.spec.type "repo" .Values.kcm.kof.repo.name) | nindent 6 }}
       chartVersion:     {{ .Chart.Version }}
       releaseName:      kof-collectors

--- a/charts/kof-istio/templates/kof-regional-cluster-profile.yaml
+++ b/charts/kof-istio/templates/kof-regional-cluster-profile.yaml
@@ -61,6 +61,7 @@ spec:
 
   helmCharts:
     - repositoryName:   istio
+    {{- include "helm_repo_creds" ($global.helmRepoCreds | default .Values.kcm.kof.repo.spec) }}
     {{- with $global.helmChartsRepo }}
       repositoryURL:    {{ . }}
       chartName:        {{ with $global.helmChartsRepoIstioPrefix }}{{ . }}{{ end }}gateway
@@ -83,6 +84,7 @@ spec:
 
     - repositoryName:   {{ .Values.kcm.kof.repo.name }}
       repositoryURL:    {{ .Values.kcm.kof.repo.spec.url }}
+      {{- include "helm_repo_creds" .Values.kcm.kof.repo.spec }}
       {{- include "repo_chart_name" (dict "name" "kof-storage" "type" .Values.kcm.kof.repo.spec.type "repo" .Values.kcm.kof.repo.name) | nindent 6 }}
       chartVersion:     {{ .Chart.Version }}
       releaseName:      kof-storage
@@ -124,6 +126,7 @@ spec:
 
     - repositoryName:   {{ .Values.kcm.kof.repo.name }}
       repositoryURL:    {{ .Values.kcm.kof.repo.spec.url }}
+      {{- include "helm_repo_creds" .Values.kcm.kof.repo.spec }}
       {{- include "repo_chart_name" (dict "name" "kof-operators" "type" .Values.kcm.kof.repo.spec.type "repo" .Values.kcm.kof.repo.name) | nindent 6 }}
       chartVersion:     {{ .Chart.Version }}
       releaseName:      kof-operators
@@ -136,6 +139,7 @@ spec:
 
     - repositoryName:   {{ .Values.kcm.kof.repo.name }}
       repositoryURL:    {{ .Values.kcm.kof.repo.spec.url }}
+      {{- include "helm_repo_creds" .Values.kcm.kof.repo.spec }}
       {{- include "repo_chart_name" (dict "name" "kof-collectors" "type" .Values.kcm.kof.repo.spec.type "repo" .Values.kcm.kof.repo.name) | nindent 6 }}
       chartVersion:     {{ .Chart.Version }}
       releaseName:      kof-collectors


### PR DESCRIPTION
* `kof-istio` does not use `ServiceTemplates` (where we added cert/secretRefs already) because it needs `dependsOn` feature not supported by MCS yet.
* Despite `CASecretRef` mentioned in https://projectsveltos.github.io/sveltos/addons/helm_charts/#example-private-registry the expected JSON field name is `ca` - https://github.com/projectsveltos/addon-controller/blob/v0.57.2/api/v1beta1/spec.go#L167
* Testing with values:
  ```
  kcm:
    kof:
      repo:
        spec:
          secretRef:
            name: foo
          certSecretRef:
            name: bar
  ```
* Result:
  ```
  kubectl get ClusterProfile -o yaml | grep -C5 registryCredentialsConfig

      helmCharts:
      - chartName: kof/kof-operators
        chartVersion: 1.2.0
        helmChartAction: Install
        registryCredentialsConfig:
          ca:
            name: bar
          credentials:
            name: foo
        releaseName: kof-operators
  --
      - chartName: kof/kof-collectors
        chartVersion: 1.2.0
        helmChartAction: Install
        registryCredentialsConfig:
          ca:
            name: bar
          credentials:
            name: foo
        releaseName: kof-collectors
  --
      - chartName: cert-manager
        chartVersion: v1.16.4
        helmChartAction: Install
        registryCredentialsConfig:
          ca:
            name: bar
          credentials:
            name: foo
        releaseName: cert-manager
  ```
  and 5 more, OK.
