### PR TITLE
fix: Typo in `intervalFactor` lead to 500 in "Istio Service Dashboard"

### DIFF
--- a/charts/kof-dashboards/files/dashboards/istio/istio-service-dashboard.yaml
+++ b/charts/kof-dashboards/files/dashboards/istio/istio-service-dashboard.yaml
@@ -720,7 +720,7 @@ panels:
     expr: round(sum(irate(istio_requests_total{connection_security_policy="mutual_tls",destination_service=~"$service",reporter=~"$qrep",source_workload=~"$srcwl",source_workload_namespace=~"$srcns"}[5m]))
       by (source_workload, source_workload_namespace, response_code), 0.001)
     format: time_series
-    intervalFactor: 1 '{{`{{k8s.namespace.name}}`}}'
+    intervalFactor: 1
     legendFormat: '{{`{{ source_workload }}.{{ source_workload_namespace }} : {{ response_code }} (\U0001F510mTLS)`}}'
     refId: A
     step: 2


### PR DESCRIPTION
* Internal Server Error:
  ```
  [plugin.downstreamError] client: failed to query data:
  json: cannot unmarshal string into Go struct field QueryModel.intervalFactor of type int64
  ```
* Tested after the fix, OK.