### PR TITLE
fix: correctly parse and render total metric values and labels (not just last label) in kof UI

### DIFF
--- a/kof-operator/internal/metrics/health.go
+++ b/kof-operator/internal/metrics/health.go
@@ -10,18 +10,18 @@ func (s *Service) CollectHealth() {
 	condition := getReadyCondition(s.config.Pod.Status.Conditions)
 
 	if condition == nil {
-		s.send(ConditionReadyHealthy, "unhealthy")
-		s.send(ConditionReadyReason, "MissingReadyCondition")
-		s.send(ConditionReadyMessage, "Pod status does not contain Ready condition")
+		s.send(ConditionReadyHealthy, &MetricValue{Value: "unhealthy"})
+		s.send(ConditionReadyReason, &MetricValue{Value: "MissingReadyCondition"})
+		s.send(ConditionReadyMessage, &MetricValue{Value: "Pod status does not contain Ready condition"})
 		s.error(fmt.Errorf("Ready condition not found in pod status"))
 		return
 	}
 
 	if condition.Status == corev1.ConditionTrue {
-		s.send(ConditionReadyHealthy, "healthy")
+		s.send(ConditionReadyHealthy, &MetricValue{Value: "healthy"})
 	} else {
-		s.send(ConditionReadyHealthy, "unhealthy")
-		s.send(ConditionReadyReason, condition.Reason)
-		s.send(ConditionReadyMessage, condition.Message)
+		s.send(ConditionReadyHealthy, &MetricValue{Value: "unhealthy"})
+		s.send(ConditionReadyReason, &MetricValue{Value: condition.Reason})
+		s.send(ConditionReadyMessage, &MetricValue{Value: condition.Message})
 	}
 }

--- a/kof-operator/internal/metrics/internal.go
+++ b/kof-operator/internal/metrics/internal.go
@@ -25,7 +25,9 @@ func (s *Service) CollectInternal() {
 		return
 	}
 
-	for name, val := range metrics {
-		s.send(name, val)
+	for name, values := range metrics {
+		for _, value := range values {
+			s.send(name, value)
+		}
 	}
 }

--- a/kof-operator/internal/metrics/metrics.go
+++ b/kof-operator/internal/metrics/metrics.go
@@ -1,19 +1,19 @@
 package metrics
 
-func (c ClusterMetrics) Add(m *Metric) {
+func (c Cluster) Add(m *Metric) {
 	if cluster := c[m.Cluster]; cluster == nil {
-		c[m.Cluster] = make(PodMetrics)
+		c[m.Cluster] = make(Pod)
 	}
 	c[m.Cluster].Add(m)
 }
 
-func (p PodMetrics) Add(m *Metric) {
+func (p Pod) Add(m *Metric) {
 	if pod := p[m.Pod]; pod == nil {
 		p[m.Pod] = make(Metrics)
 	}
-	p[m.Pod].Add(m.Name, m.Value)
+	p[m.Pod].Add(m.Name, m.Data)
 }
 
-func (m Metrics) Add(name string, value any) {
-	m[name] = value
+func (m Metrics) Add(name string, labels *MetricValue) {
+	m[name] = append(m[name], labels)
 }

--- a/kof-operator/internal/metrics/resources.go
+++ b/kof-operator/internal/metrics/resources.go
@@ -18,8 +18,8 @@ func (s *Service) CollectResources() {
 		return
 	}
 
-	s.send(ContainerCPUUsage, usage.CPU)
-	s.send(ContainerMemoryUsage, usage.Memory)
+	s.send(ContainerCPUUsage, &MetricValue{Value: usage.CPU})
+	s.send(ContainerMemoryUsage, &MetricValue{Value: usage.Memory})
 
 	limits, err := s.getContainerLimits()
 	if err != nil {
@@ -28,8 +28,8 @@ func (s *Service) CollectResources() {
 	}
 
 	if limits.CPU > 0 && limits.Memory > 0 {
-		s.send(ContainerCPULimit, limits.CPU)
-		s.send(ContainerMemoryLimit, limits.Memory)
+		s.send(ContainerCPULimit, &MetricValue{Value: limits.CPU})
+		s.send(ContainerMemoryLimit, &MetricValue{Value: limits.Memory})
 		return
 	}
 
@@ -38,8 +38,8 @@ func (s *Service) CollectResources() {
 		s.error(fmt.Errorf("failed to get node limits: %v", err))
 		return
 	}
-	s.send(ContainerCPULimit, nodeAvailableNow.CPU+usage.CPU)
-	s.send(ContainerMemoryLimit, nodeAvailableNow.Memory+usage.Memory)
+	s.send(ContainerCPULimit, &MetricValue{Value: nodeAvailableNow.CPU + usage.CPU})
+	s.send(ContainerMemoryLimit, &MetricValue{Value: nodeAvailableNow.Memory + usage.Memory})
 }
 
 func (s *Service) getContainerLimits() (*Resource, error) {

--- a/kof-operator/internal/metrics/types.go
+++ b/kof-operator/internal/metrics/types.go
@@ -8,9 +8,13 @@ import (
 )
 
 type MetricChannel chan *Metric
-type ClusterMetrics map[string]PodMetrics
-type PodMetrics map[string]Metrics
-type Metrics map[string]any
+type Cluster map[string]Pod
+type Pod map[string]Metrics
+type Metrics map[string][]*MetricValue
+type MetricValue struct {
+	Labels map[string]string `json:"labels,omitempty"`
+	Value  any               `json:"value"`
+}
 
 type Resource struct {
 	CPU    int64
@@ -21,8 +25,8 @@ type Metric struct {
 	Cluster string
 	Pod     string
 	Name    string
-	Value   any
 	Err     error
+	Data    *MetricValue
 }
 
 type ServiceConfig struct {

--- a/kof-operator/internal/server/handlers/collector_metrics_handler.go
+++ b/kof-operator/internal/server/handlers/collector_metrics_handler.go
@@ -11,7 +11,7 @@ import (
 )
 
 type Response struct {
-	Clusters metrics.ClusterMetrics `json:"clusters"`
+	Clusters metrics.Cluster `json:"clusters"`
 }
 
 const (

--- a/kof-operator/internal/server/handlers/metrics_handler.go
+++ b/kof-operator/internal/server/handlers/metrics_handler.go
@@ -44,7 +44,7 @@ func NewBaseMetricsHandler(ctx context.Context, kubeClient *k8s.KubeClient, logg
 	}
 }
 
-func (h *BaseMetricsHandler) GetMetrics() metrics.ClusterMetrics {
+func (h *BaseMetricsHandler) GetMetrics() metrics.Cluster {
 	var cancel context.CancelFunc
 	h.ctx, cancel = context.WithTimeout(h.ctx, CollectorMaxResponseTime)
 	defer cancel()
@@ -57,7 +57,7 @@ func (h *BaseMetricsHandler) GetMetrics() metrics.ClusterMetrics {
 		close(h.metricCh)
 	}()
 
-	metrics := make(metrics.ClusterMetrics)
+	metrics := make(metrics.Cluster)
 	errs := make([]error, 0)
 
 	for metric := range h.metricCh {

--- a/kof-operator/webapp/collector/package-lock.json
+++ b/kof-operator/webapp/collector/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@radix-ui/react-checkbox": "^1.3.2",
-        "@radix-ui/react-collapsible": "^1.1.11",
+        "@radix-ui/react-collapsible": "^1.1.12",
         "@radix-ui/react-dialog": "^1.1.14",
         "@radix-ui/react-hover-card": "^1.1.14",
         "@radix-ui/react-label": "^2.1.7",
@@ -1557,18 +1557,48 @@
       }
     },
     "node_modules/@radix-ui/react-collapsible": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-collapsible/-/react-collapsible-1.1.11.tgz",
-      "integrity": "sha512-2qrRsVGSCYasSz1RFOorXwl0H7g7J1frQtgpQgYrt+MOidtPAINHn9CPovQXb83r8ahapdx3Tu0fa/pdFFSdPg==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collapsible/-/react-collapsible-1.1.12.tgz",
+      "integrity": "sha512-Uu+mSh4agx2ib1uIGPP4/CKNULyajb3p92LsVXmH2EHVMTfZWpll88XJ0j4W0z3f8NK1eYl1+Mf/szHPmcHzyA==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/primitive": "1.1.2",
+        "@radix-ui/primitive": "1.1.3",
         "@radix-ui/react-compose-refs": "1.1.2",
         "@radix-ui/react-context": "1.1.2",
         "@radix-ui/react-id": "1.1.1",
-        "@radix-ui/react-presence": "1.1.4",
+        "@radix-ui/react-presence": "1.1.5",
         "@radix-ui/react-primitive": "2.1.3",
         "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-collapsible/node_modules/@radix-ui/primitive": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.3.tgz",
+      "integrity": "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-collapsible/node_modules/@radix-ui/react-presence": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.5.tgz",
+      "integrity": "sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
         "@radix-ui/react-use-layout-effect": "1.1.1"
       },
       "peerDependencies": {

--- a/kof-operator/webapp/collector/package.json
+++ b/kof-operator/webapp/collector/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@radix-ui/react-checkbox": "^1.3.2",
-    "@radix-ui/react-collapsible": "^1.1.11",
+    "@radix-ui/react-collapsible": "^1.1.12",
     "@radix-ui/react-dialog": "^1.1.14",
     "@radix-ui/react-hover-card": "^1.1.14",
     "@radix-ui/react-label": "^2.1.7",

--- a/kof-operator/webapp/collector/src/components/pages/collectorPage/components/collector-details/CollectorExporterTab.tsx
+++ b/kof-operator/webapp/collector/src/components/pages/collectorPage/components/collector-details/CollectorExporterTab.tsx
@@ -5,7 +5,7 @@ import { Separator } from "@/components/generated/ui/separator";
 import { METRICS } from "@/constants/metrics.constants";
 import { formatNumber } from "@/utils/formatter";
 import { useCollectorMetricsState } from "@/providers/collectors_metrics/CollectorsMetricsProvider";
-import { MetricCardRow, MetricsCard } from "@/components/shared/MetricsCard";
+import { MetricRow, MetricsCard } from "@/components/shared/MetricsCard";
 import { Clock, Send, TriangleAlert } from "lucide-react";
 
 const CollectorExporterTabContent = (): JSX.Element => {
@@ -28,7 +28,7 @@ const QueueCard = (): JSX.Element => {
     return <></>;
   }
 
-  const rows: MetricCardRow[] = [
+  const rows: MetricRow[] = [
     {
       title: "Capacity",
       metricName: METRICS.OTELCOL_EXPORTER_QUEUE_CAPACITY.name,
@@ -42,18 +42,33 @@ const QueueCard = (): JSX.Element => {
     {
       title: "Utilization",
       metricFetchFn: (pod) => {
-        const cap = pod.getMetric(METRICS.OTELCOL_EXPORTER_QUEUE_CAPACITY.name);
-        const size = pod.getMetric(METRICS.OTELCOL_EXPORTER_QUEUE_SIZE.name);
+        const cap = pod.getMetric(
+          METRICS.OTELCOL_EXPORTER_QUEUE_CAPACITY.name
+        )?.totalValue;
+
+        const size = pod.getMetric(
+          METRICS.OTELCOL_EXPORTER_QUEUE_SIZE.name
+        )?.totalValue;
+        
+        if (!cap || !size) return 0;
+
         return (size / cap) * 100;
       },
       metricFormat: (val) => `${val.toFixed(1)}%`,
-      hint: "Percentage of the exporter queue currently in use"
+      hint: "Percentage of the exporter queue currently in use",
     },
     {
       title: "Utilization Bar",
       metricFetchFn: (pod) => {
-        const cap = pod.getMetric(METRICS.OTELCOL_EXPORTER_QUEUE_CAPACITY.name);
-        const size = pod.getMetric(METRICS.OTELCOL_EXPORTER_QUEUE_SIZE.name);
+        const cap = pod.getMetric(
+          METRICS.OTELCOL_EXPORTER_QUEUE_CAPACITY.name
+        )?.totalValue;
+
+        const size = pod.getMetric(
+          METRICS.OTELCOL_EXPORTER_QUEUE_SIZE.name
+        )?.totalValue;
+        
+        if (!cap || !size) return 0;
         return (size / cap) * 100;
       },
       customRow: ({ rawValue, title }) => (
@@ -73,7 +88,7 @@ const QueueCard = (): JSX.Element => {
 };
 
 const SentRecordsCard = (): JSX.Element => {
-  const rows: MetricCardRow[] = [
+  const rows: MetricRow[] = [
     {
       title: "Log Records",
       metricName: METRICS.OTELCOL_EXPORTER_SENT_LOG_RECORDS.name,
@@ -115,7 +130,7 @@ const SentRecordsCard = (): JSX.Element => {
 };
 
 const FailedRecordsCard = (): JSX.Element => {
-  const rows: MetricCardRow[] = [
+  const rows: MetricRow[] = [
     {
       title: "Failed Log Records",
       metricName: METRICS.OTELCOL_EXPORTER_SEND_FAILED_LOG_RECORDS.name,

--- a/kof-operator/webapp/collector/src/components/pages/collectorPage/components/collector-details/CollectorOverviewTab.tsx
+++ b/kof-operator/webapp/collector/src/components/pages/collectorPage/components/collector-details/CollectorOverviewTab.tsx
@@ -21,27 +21,33 @@ import { bytesToUnits, formatNumber } from "@/utils/formatter";
 import { useCollectorMetricsState } from "@/providers/collectors_metrics/CollectorsMetricsProvider";
 import { useTimePeriod } from "@/providers/collectors_metrics/TimePeriodState";
 import { getMetricTrendData } from "@/utils/metrics";
-import { MetricCardRow, MetricsCard } from "@/components/shared/MetricsCard";
+import { MetricRow, MetricsCard } from "@/components/shared/MetricsCard";
 
 const CollectorOverviewTabContent = ({
   collector,
 }: {
   collector: Pod;
 }): JSX.Element => {
-  const memoryUsage: number = collector.getMetric(
-    METRICS.CONTAINER_RESOURCE_MEMORY_USAGE.name
-  );
-  const memoryLimit: number = collector.getMetric(
-    METRICS.CONTAINER_RESOURCE_MEMORY_LIMIT.name
-  );
+  const memoryUsage: number =
+    collector.getMetric(METRICS.CONTAINER_RESOURCE_MEMORY_USAGE.name)
+      ?.totalValue ?? 0;
+  const memoryLimit: number =
+    collector.getMetric(METRICS.CONTAINER_RESOURCE_MEMORY_LIMIT.name)
+      ?.totalValue ?? 0;
 
-  const queueSize = collector.getMetric(METRICS.OTELCOL_EXPORTER_QUEUE_SIZE.name);
-  const queueCapacity = collector.getMetric(
-    METRICS.OTELCOL_EXPORTER_QUEUE_CAPACITY.name
-  );
+  const queueSize =
+    collector.getMetric(METRICS.OTELCOL_EXPORTER_QUEUE_SIZE.name)?.totalValue ??
+    0;
+  const queueCapacity =
+    collector.getMetric(METRICS.OTELCOL_EXPORTER_QUEUE_CAPACITY.name)
+      ?.totalValue ?? 0;
 
-  const cpuUsage = collector.getMetric(METRICS.CONTAINER_RESOURCE_CPU_USAGE.name);
-  const cpuLimit = collector.getMetric(METRICS.CONTAINER_RESOURCE_CPU_LIMIT.name);
+  const cpuUsage =
+    collector.getMetric(METRICS.CONTAINER_RESOURCE_CPU_USAGE.name)
+      ?.totalValue ?? 0;
+  const cpuLimit =
+    collector.getMetric(METRICS.CONTAINER_RESOURCE_CPU_LIMIT.name)
+      ?.totalValue ?? 0;
 
   return (
     <TabsContent value="overview" className="flex flex-col gap-5">
@@ -187,7 +193,7 @@ const MetricsStatCard = (): JSX.Element => {
 };
 
 const ExportPerformanceCard = (): JSX.Element => {
-  const rows: MetricCardRow[] = [
+  const rows: MetricRow[] = [
     {
       title: "Sent Batches",
       metricName: METRICS.OTELCOL_EXPORTER_PROM_WRITE_SENT_BATCHES.name,

--- a/kof-operator/webapp/collector/src/components/pages/collectorPage/components/collector-details/CollectorProcessTab.tsx
+++ b/kof-operator/webapp/collector/src/components/pages/collectorPage/components/collector-details/CollectorProcessTab.tsx
@@ -6,7 +6,7 @@ import { bytesToUnits, formatTime } from "@/utils/formatter";
 import { useCollectorMetricsState } from "@/providers/collectors_metrics/CollectorsMetricsProvider";
 import { getAverageValue } from "@/utils/metrics";
 import { useTimePeriod } from "@/providers/collectors_metrics/TimePeriodState";
-import { MetricCardRow, MetricsCard } from "@/components/shared/MetricsCard";
+import { MetricRow, MetricsCard } from "@/components/shared/MetricsCard";
 
 const CollectorProcessTab = (): JSX.Element => {
   return (
@@ -24,7 +24,7 @@ const CollectorProcessTab = (): JSX.Element => {
 export default CollectorProcessTab;
 
 const UptimeCard = (): JSX.Element => {
-  const rows: MetricCardRow[] = [
+  const rows: MetricRow[] = [
     {
       title: "Process Uptime",
       metricName: METRICS.OTELCOL_PROCESS_UPTIME_SECONDS.name,
@@ -59,7 +59,7 @@ const UptimeCard = (): JSX.Element => {
 };
 
 const FileStatsCard = (): JSX.Element => {
-  const rows: MetricCardRow[] = [
+  const rows: MetricRow[] = [
     {
       title: "Open Files",
       metricName: METRICS.OTELCOL_FILECONSUMER_OPEN_FILES.name,
@@ -86,7 +86,7 @@ const MemoryStatsCard = (): JSX.Element => {
   const { timePeriod } = useTimePeriod();
   const { metricsHistory } = useCollectorMetricsState();
 
-  const rows: MetricCardRow[] = [
+  const rows: MetricRow[] = [
     {
       title: "RSS",
       metricFetchFn: (pod) =>

--- a/kof-operator/webapp/collector/src/components/pages/collectorPage/components/collector-details/CollectorProcessorTab.tsx
+++ b/kof-operator/webapp/collector/src/components/pages/collectorPage/components/collector-details/CollectorProcessorTab.tsx
@@ -3,7 +3,7 @@ import { JSX } from "react";
 import { METRICS } from "@/constants/metrics.constants";
 import { formatNumber } from "@/utils/formatter";
 import { useCollectorMetricsState } from "@/providers/collectors_metrics/CollectorsMetricsProvider";
-import { MetricCardRow, MetricsCard } from "@/components/shared/MetricsCard";
+import { MetricRow, MetricsCard } from "@/components/shared/MetricsCard";
 import { BarChart2, Shuffle } from "lucide-react";
 
 const CollectorProcessorTab = (): JSX.Element => {
@@ -18,7 +18,7 @@ const CollectorProcessorTab = (): JSX.Element => {
 export default CollectorProcessorTab;
 
 const BatchStatsCard = (): JSX.Element => {
-  const rows: MetricCardRow[] = [
+  const rows: MetricRow[] = [
     {
       title: "Batch Send Size",
       metricName: METRICS.OTELCOL_PROCESSOR_BATCH_SEND_SIZE.name,
@@ -58,7 +58,7 @@ const BatchStatsCard = (): JSX.Element => {
 };
 
 const ItemFlowCard = (): JSX.Element => {
-  const rows: MetricCardRow[] = [
+  const rows: MetricRow[] = [
     {
       title: "Incoming Items",
       metricName: METRICS.OTELCOL_PROCESSOR_INCOMING_ITEMS.name,

--- a/kof-operator/webapp/collector/src/components/pages/collectorPage/components/collector-details/CollectorReceiverTab.tsx
+++ b/kof-operator/webapp/collector/src/components/pages/collectorPage/components/collector-details/CollectorReceiverTab.tsx
@@ -3,7 +3,7 @@ import { TabsContent } from "@/components/generated/ui/tabs";
 import { METRICS } from "@/constants/metrics.constants";
 import { formatNumber } from "@/utils/formatter";
 import { useCollectorMetricsState } from "@/providers/collectors_metrics/CollectorsMetricsProvider";
-import { MetricCardRow, MetricsCard } from "@/components/shared/MetricsCard";
+import { MetricRow, MetricsCard } from "@/components/shared/MetricsCard";
 import { CheckCircle, TriangleAlert } from "lucide-react";
 
 const CollectorReceiverTab = (): JSX.Element => {
@@ -20,7 +20,7 @@ const CollectorReceiverTab = (): JSX.Element => {
 export default CollectorReceiverTab;
 
 const AcceptedRecordsCard = (): JSX.Element => {
-  const rows: MetricCardRow[] = [
+  const rows: MetricRow[] = [
     {
       title: "Log Records",
       metricName: METRICS.OTELCOL_RECEIVER_ACCEPTED_LOG_RECORDS.name,
@@ -48,7 +48,7 @@ const AcceptedRecordsCard = (): JSX.Element => {
 };
 
 const RefusedRecordsCard = (): JSX.Element => {
-  const rows: MetricCardRow[] = [
+  const rows: MetricRow[] = [
     {
       title: "Log Records",
       metricName: METRICS.OTELCOL_RECEIVER_REFUSED_LOG_RECORDS.name,

--- a/kof-operator/webapp/collector/src/components/pages/collectorPage/components/collector-list/MetricTrendCell.tsx
+++ b/kof-operator/webapp/collector/src/components/pages/collectorPage/components/collector-list/MetricTrendCell.tsx
@@ -5,12 +5,12 @@ import { getMetricTrendData } from "@/utils/metrics";
 import { formatNumber } from "@/utils/formatter";
 import { TableCell } from "@/components/generated/ui/table";
 import { TrendingUp } from "lucide-react";
-import { CollectorMetricsRecordsManager } from "@/providers/collectors_metrics/CollectorsMetricsRecordManager";
+import { MetricsRecordsManager } from "@/providers/collectors_metrics/CollectorsMetricsRecordManager";
 
 interface MetricTrendCellProps {
   metric: string;
   pod: Pod;
-  metricsHistory: CollectorMetricsRecordsManager;
+  metricsHistory: MetricsRecordsManager;
 }
 
 const MetricTrendCell = ({

--- a/kof-operator/webapp/collector/src/components/pages/collectorPage/components/collector-list/UtilizationCell.tsx
+++ b/kof-operator/webapp/collector/src/components/pages/collectorPage/components/collector-list/UtilizationCell.tsx
@@ -14,8 +14,8 @@ const UtilizationCell = ({
   usageMetric,
   limitMetric,
 }: UtilizationCellProps): JSX.Element => {
-  const currentUsage: number = pod.getMetric(usageMetric);
-  const currentLimit: number = pod.getMetric(limitMetric);
+  const currentUsage: number = pod.getMetric(usageMetric)?.totalValue ?? 0;
+  const currentLimit: number = pod.getMetric(limitMetric)?.totalValue ?? 0;
 
   const usagePercentage =
     currentLimit > 0 ? (currentUsage / currentLimit) * 100 : 0;

--- a/kof-operator/webapp/collector/src/components/pages/victoriaPage/victoria-details/VictoriaGoRuntimeTab.tsx
+++ b/kof-operator/webapp/collector/src/components/pages/victoriaPage/victoria-details/VictoriaGoRuntimeTab.tsx
@@ -1,5 +1,5 @@
 import { TabsContent } from "@/components/generated/ui/tabs";
-import { MetricCardRow, MetricsCard } from "@/components/shared/MetricsCard";
+import { MetricRow, MetricsCard } from "@/components/shared/MetricsCard";
 import { VICTORIA_METRICS } from "@/constants/metrics.constants";
 import { useVictoriaMetricsState } from "@/providers/victoria_metrics/VictoriaMetricsProvider";
 import { bytesToUnits, formatNumber } from "@/utils/formatter";
@@ -20,7 +20,7 @@ const VictoriaGoRuntimeTab = (): JSX.Element => {
 export default VictoriaGoRuntimeTab;
 
 const GoRuntimeCard = (): JSX.Element => {
-  const rows: MetricCardRow[] = [
+  const rows: MetricRow[] = [
     {
       title: "Goroutines",
       metricName: VICTORIA_METRICS.GO_GOROUTINES.name,
@@ -55,7 +55,7 @@ const GoRuntimeCard = (): JSX.Element => {
 };
 
 const GoMemoryStatsCard = (): JSX.Element => {
-  const rows: MetricCardRow[] = [
+  const rows: MetricRow[] = [
     {
       title: "Heap Allocated",
       metricName: VICTORIA_METRICS.GO_MEMSTATS_HEAP_ALLOC_BYTES.name,

--- a/kof-operator/webapp/collector/src/components/pages/victoriaPage/victoria-details/VictoriaLogsInsertTab.tsx
+++ b/kof-operator/webapp/collector/src/components/pages/victoriaPage/victoria-details/VictoriaLogsInsertTab.tsx
@@ -1,5 +1,5 @@
 import { TabsContent } from "@/components/generated/ui/tabs";
-import { MetricCardRow, MetricsCard } from "@/components/shared/MetricsCard";
+import { MetricRow, MetricsCard } from "@/components/shared/MetricsCard";
 import { VICTORIA_METRICS } from "@/constants/metrics.constants";
 import { useVictoriaMetricsState } from "@/providers/victoria_metrics/VictoriaMetricsProvider";
 import { bytesToUnits, formatNumber } from "@/utils/formatter";
@@ -21,7 +21,7 @@ const VictoriaLogsInsertTab = (): JSX.Element => {
 export default VictoriaLogsInsertTab;
 
 const ThroughputCard = (): JSX.Element => {
-  const rows: MetricCardRow[] = [
+  const rows: MetricRow[] = [
     {
       title: "Bytes written",
       metricName: VICTORIA_METRICS.VLINSERT_BACKEND_CONNS_BYTE_WRITTEN.name,
@@ -63,7 +63,7 @@ const ThroughputCard = (): JSX.Element => {
 };
 
 const DialHealthCard = (): JSX.Element => {
-  const rows: MetricCardRow[] = [
+  const rows: MetricRow[] = [
     {
       title: "Dial attempts",
       metricName: VICTORIA_METRICS.VLINSERT_BACKEND_DIALS_TOTAL.name,
@@ -84,10 +84,11 @@ const DialHealthCard = (): JSX.Element => {
       metricFetchFn: (pod) => {
         const total = pod.getMetric(
           VICTORIA_METRICS.VLINSERT_BACKEND_DIALS_TOTAL.name
-        );
+        )?.totalValue;
         const error = pod.getMetric(
           VICTORIA_METRICS.VLINSERT_BACKEND_DIALS_ERRORS_TOTAL.name
-        );
+        )?.totalValue;
+        if (!total || !error) return 0;
         return ((total - error) / total) * 100;
       },
       metricFormat: (value: number) => `${value.toFixed(2)}%`,
@@ -111,7 +112,7 @@ const DialHealthCard = (): JSX.Element => {
 };
 
 const IOHealthCard = (): JSX.Element => {
-  const rows: MetricCardRow[] = [
+  const rows: MetricRow[] = [
     {
       title: "Read errors",
       metricName:
@@ -135,16 +136,17 @@ const IOHealthCard = (): JSX.Element => {
       metricFetchFn: (pod) => {
         const readErrors = pod.getMetric(
           VICTORIA_METRICS.VLINSERT_BACKEND_CONNS_READ_ERRORS_TOTAL.name
-        );
+        )?.totalValue;
         const writeErrors = pod.getMetric(
           VICTORIA_METRICS.VLINSERT_BACKEND_CONNS_WRITE_ERRORS_TOTAL.name
-        );
+        )?.totalValue;
         const writeTotal = pod.getMetric(
           VICTORIA_METRICS.VLINSERT_BACKEND_CONNS_WRITES_TOTAL.name
-        );
+        )?.totalValue;
         const readTotal = pod.getMetric(
           VICTORIA_METRICS.VLINSERT_BACKEND_CONNS_READS_TOTAL.name
-        );
+        )?.totalValue;
+        if (!readErrors || !writeErrors || !writeTotal || !readTotal) return 0;
         return ((readErrors + writeErrors) / (writeTotal + readTotal)) * 100;
       },
       metricFormat: (value: number) => `${value.toFixed(2)}%`,

--- a/kof-operator/webapp/collector/src/components/pages/victoriaPage/victoria-details/VictoriaLogsSelectTab.tsx
+++ b/kof-operator/webapp/collector/src/components/pages/victoriaPage/victoria-details/VictoriaLogsSelectTab.tsx
@@ -1,4 +1,4 @@
-import { MetricCardRow, MetricsCard } from "@/components/shared/MetricsCard";
+import { MetricRow, MetricsCard } from "@/components/shared/MetricsCard";
 import { VICTORIA_METRICS } from "@/constants/metrics.constants";
 import { useVictoriaMetricsState } from "@/providers/victoria_metrics/VictoriaMetricsProvider";
 import { bytesToUnits, formatNumber } from "@/utils/formatter";
@@ -20,7 +20,7 @@ const VictoriaLogsSelectTab = (): JSX.Element => {
 export default VictoriaLogsSelectTab;
 
 const ConnectionsCard = (): JSX.Element => {
-  const rows: MetricCardRow[] = [
+  const rows: MetricRow[] = [
     {
       title: "Bytes Read",
       metricName: VICTORIA_METRICS.VLSELECT_BACKEND_CONN_BYTES_READ_TOTAL.name,
@@ -55,7 +55,7 @@ const ConnectionsCard = (): JSX.Element => {
 };
 
 const ErrorsCard = (): JSX.Element => {
-  const rows: MetricCardRow[] = [
+  const rows: MetricRow[] = [
     {
       title: "Read errors",
       metricName: VICTORIA_METRICS.VLSELECT_BACKEND_CONN_READ_ERRORS_TOTAL.name,

--- a/kof-operator/webapp/collector/src/components/pages/victoriaPage/victoria-details/VictoriaLogsStorageTab.tsx
+++ b/kof-operator/webapp/collector/src/components/pages/victoriaPage/victoria-details/VictoriaLogsStorageTab.tsx
@@ -1,5 +1,5 @@
 import { TabsContent } from "@/components/generated/ui/tabs";
-import { MetricCardRow, MetricsCard } from "@/components/shared/MetricsCard";
+import { MetricRow, MetricsCard } from "@/components/shared/MetricsCard";
 import StatRow from "@/components/shared/StatRow";
 import { VICTORIA_METRICS } from "@/constants/metrics.constants";
 import { useVictoriaMetricsState } from "@/providers/victoria_metrics/VictoriaMetricsProvider";
@@ -22,7 +22,7 @@ const VictoriaLogsStorageTab = (): JSX.Element => {
 export default VictoriaLogsStorageTab;
 
 const OverviewCard = (): JSX.Element => {
-  const row: MetricCardRow[] = [
+  const row: MetricRow[] = [
     {
       title: "Rows ingested",
       metricName: VICTORIA_METRICS.VL_ROWS_INGESTED_TOTAL.name,
@@ -57,7 +57,7 @@ const OverviewCard = (): JSX.Element => {
 };
 
 const StorageObjectsCard = (): JSX.Element => {
-  const row: MetricCardRow[] = [
+  const row: MetricRow[] = [
     {
       title: "Storage parts",
       metricName: VICTORIA_METRICS.VL_STORAGE_PARTS.name,
@@ -89,7 +89,7 @@ const StorageObjectsCard = (): JSX.Element => {
 };
 
 const StorageCard = (): JSX.Element => {
-  const row: MetricCardRow[] = [
+  const row: MetricRow[] = [
     {
       title: "Data Size",
       metricName: VICTORIA_METRICS.VL_DATA_SIZE_BYTES.name,

--- a/kof-operator/webapp/collector/src/components/pages/victoriaPage/victoria-details/VictoriaMetricsInsertTab.tsx
+++ b/kof-operator/webapp/collector/src/components/pages/victoriaPage/victoria-details/VictoriaMetricsInsertTab.tsx
@@ -1,5 +1,5 @@
 import { TabsContent } from "@/components/generated/ui/tabs";
-import { MetricCardRow, MetricsCard } from "@/components/shared/MetricsCard";
+import { MetricRow, MetricsCard } from "@/components/shared/MetricsCard";
 import StatRow from "@/components/shared/StatRow";
 import { VICTORIA_METRICS } from "@/constants/metrics.constants";
 import { useVictoriaMetricsState } from "@/providers/victoria_metrics/VictoriaMetricsProvider";
@@ -22,7 +22,7 @@ const VictoriaMetricsInsertTab = (): JSX.Element => {
 export default VictoriaMetricsInsertTab;
 
 const InsertRPCHealth = (): JSX.Element => {
-  const row: MetricCardRow[] = [
+  const row: MetricRow[] = [
     {
       title: "VMStorage reachable",
       metricName: VICTORIA_METRICS.VM_RPC_VMSTORAGE_IS_REACHABLE.name,
@@ -77,7 +77,7 @@ const InsertRPCHealth = (): JSX.Element => {
 };
 
 const OverloadAndReplicationCard = (): JSX.Element => {
-  const row: MetricCardRow[] = [
+  const row: MetricRow[] = [
     {
       title: "Dropped on overload",
       metricName: VICTORIA_METRICS.VM_RPC_ROWS_DROPPED_ON_OVERLOAD_TOTAL.name,
@@ -123,7 +123,7 @@ const OverloadAndReplicationCard = (): JSX.Element => {
 };
 
 const VictoriaMetricsOverviewCard = (): JSX.Element => {
-  const row: MetricCardRow[] = [
+  const row: MetricRow[] = [
     {
       title: "Rows sent",
       metricName: VICTORIA_METRICS.VM_RPC_ROWS_SENT_TOTAL.name,

--- a/kof-operator/webapp/collector/src/components/pages/victoriaPage/victoria-details/VictoriaMetricsSelectTab.tsx
+++ b/kof-operator/webapp/collector/src/components/pages/victoriaPage/victoria-details/VictoriaMetricsSelectTab.tsx
@@ -1,5 +1,5 @@
 import { TabsContent } from "@/components/generated/ui/tabs";
-import { MetricCardRow, MetricsCard } from "@/components/shared/MetricsCard";
+import { MetricRow, MetricsCard } from "@/components/shared/MetricsCard";
 import { VICTORIA_METRICS } from "@/constants/metrics.constants";
 import { useVictoriaMetricsState } from "@/providers/victoria_metrics/VictoriaMetricsProvider";
 import { bytesToUnits, formatNumber } from "@/utils/formatter";
@@ -21,7 +21,7 @@ const VictoriaMetricsSelectTab = (): JSX.Element => {
 export default VictoriaMetricsSelectTab;
 
 const TempBlocksCard = (): JSX.Element => {
-  const row: MetricCardRow[] = [
+  const row: MetricRow[] = [
     {
       title: "Tmp Files Created",
       metricName: VICTORIA_METRICS.VM_TMP_BLOCK_FILES_CREATED_TOTAL.name,
@@ -53,7 +53,7 @@ const TempBlocksCard = (): JSX.Element => {
 };
 
 const RollupResultCacheCard = (): JSX.Element => {
-  const row: MetricCardRow[] = [
+  const row: MetricRow[] = [
     {
       title: "Full hits",
       metricName: VICTORIA_METRICS.VM_ROLLUP_RESULT_CACHE_FULL_HITS_TOTAL.name,
@@ -85,7 +85,7 @@ const RollupResultCacheCard = (): JSX.Element => {
 };
 
 const ReadPathThroughputCard = (): JSX.Element => {
-  const row: MetricCardRow[] = [
+  const row: MetricRow[] = [
     {
       title: "Metric rows read",
       metricName: VICTORIA_METRICS.VM_METRIC_ROWS_READ_TOTAL.name,

--- a/kof-operator/webapp/collector/src/components/pages/victoriaPage/victoria-details/VictoriaMetricsStorageTab.tsx
+++ b/kof-operator/webapp/collector/src/components/pages/victoriaPage/victoria-details/VictoriaMetricsStorageTab.tsx
@@ -1,5 +1,5 @@
 import { TabsContent } from "@/components/generated/ui/tabs";
-import { MetricCardRow, MetricsCard } from "@/components/shared/MetricsCard";
+import { MetricRow, MetricsCard } from "@/components/shared/MetricsCard";
 import { VICTORIA_METRICS } from "@/constants/metrics.constants";
 import { useVictoriaMetricsState } from "@/providers/victoria_metrics/VictoriaMetricsProvider";
 import { bytesToUnits, formatNumber } from "@/utils/formatter";
@@ -25,7 +25,7 @@ const VictoriaMetricsStorageTab = (): JSX.Element => {
 export default VictoriaMetricsStorageTab;
 
 const OverviewCard = (): JSX.Element => {
-  const row: MetricCardRow[] = [
+  const row: MetricRow[] = [
     {
       title: "Rows Received",
       metricName: VICTORIA_METRICS.VM_ROWS_RECEIVED_BY_STORAGE_TOTAL.name,
@@ -59,7 +59,7 @@ const OverviewCard = (): JSX.Element => {
 };
 
 const IngestQualityCard = (): JSX.Element => {
-  const row: MetricCardRow[] = [
+  const row: MetricRow[] = [
     {
       title: "Rows Invalid",
       metricName: VICTORIA_METRICS.VM_ROWS_INVALID_TOTAL.name,
@@ -103,7 +103,7 @@ const IngestQualityCard = (): JSX.Element => {
 };
 
 const VMInsertLinkCard = (): JSX.Element => {
-  const row: MetricCardRow[] = [
+  const row: MetricRow[] = [
     {
       title: "Metrics Read",
       metricName: VICTORIA_METRICS.VM_VMINSERT_METRICS_READ_TOTAL.name,
@@ -138,7 +138,7 @@ const VMInsertLinkCard = (): JSX.Element => {
 };
 
 const VMSelectLinkCard = (): JSX.Element => {
-  const row: MetricCardRow[] = [
+  const row: MetricRow[] = [
     {
       title: "Rows Read for Queries",
       metricName: VICTORIA_METRICS.VM_VMSELECT_METRIC_ROWS_READ_TOTAL.name,
@@ -173,7 +173,7 @@ const VMSelectLinkCard = (): JSX.Element => {
 };
 
 const CompressionCard = (): JSX.Element => {
-  const row: MetricCardRow[] = [
+  const row: MetricRow[] = [
     {
       title: "Original Byte",
       metricName: VICTORIA_METRICS.VM_ZSTD_BLOCK_ORIGINAL_BYTES_TOTAL.name,

--- a/kof-operator/webapp/collector/src/components/pages/victoriaPage/victoria-details/VictoriaNetworkTab.tsx
+++ b/kof-operator/webapp/collector/src/components/pages/victoriaPage/victoria-details/VictoriaNetworkTab.tsx
@@ -1,5 +1,5 @@
 import { TabsContent } from "@/components/generated/ui/tabs";
-import { MetricCardRow, MetricsCard } from "@/components/shared/MetricsCard";
+import { MetricRow, MetricsCard } from "@/components/shared/MetricsCard";
 import { VICTORIA_METRICS } from "@/constants/metrics.constants";
 import { useVictoriaMetricsState } from "@/providers/victoria_metrics/VictoriaMetricsProvider";
 import { bytesToUnits, formatNumber } from "@/utils/formatter";
@@ -35,7 +35,7 @@ const VictoriaNetworkTab = (): JSX.Element => {
 export default VictoriaNetworkTab;
 
 const TCPConnectionDetailsCard = (): JSX.Element => {
-  const rows: MetricCardRow[] = [
+  const rows: MetricRow[] = [
     {
       title: "Data Read",
       metricName: VICTORIA_METRICS.VM_TCPLISTENER_READ_BYTES_TOTAL.name,
@@ -76,7 +76,7 @@ const TCPConnectionDetailsCard = (): JSX.Element => {
 };
 
 const HTTPPerformanceDetailsCard = (): JSX.Element => {
-  const rows: MetricCardRow[] = [
+  const rows: MetricRow[] = [
     {
       title: "Total HTTP Requests",
       metricName: VICTORIA_METRICS.VM_HTTP_REQUESTS_ALL_TOTAL.name,
@@ -106,10 +106,11 @@ const HTTPPerformanceDetailsCard = (): JSX.Element => {
       metricFetchFn: (pod: Pod): number => {
         const requestDurationSec = pod.getMetric(
           VICTORIA_METRICS.VM_HTTP_REQUEST_DURATION_SECONDS_SUM.name
-        );
+        )?.totalValue;
         const requestDurationCount = pod.getMetric(
           VICTORIA_METRICS.VM_HTTP_REQUEST_DURATION_SECONDS_COUNT.name
-        );
+        )?.totalValue;
+        if (!requestDurationCount || !requestDurationSec) return 0;
         return (requestDurationSec / requestDurationCount) * 1000;
       },
       hint: "Average response time for HTTP requests in milliseconds",
@@ -127,7 +128,7 @@ const HTTPPerformanceDetailsCard = (): JSX.Element => {
 };
 
 const VictoriaLogsNetworkCard = (): JSX.Element => {
-  const rows: MetricCardRow[] = [
+  const rows: MetricRow[] = [
     {
       title: "UDP Requests",
       metricName: VICTORIA_METRICS.VL_UDP_REQESTS_TOTAL.name,

--- a/kof-operator/webapp/collector/src/components/pages/victoriaPage/victoria-details/VictoriaOverviewTab.tsx
+++ b/kof-operator/webapp/collector/src/components/pages/victoriaPage/victoria-details/VictoriaOverviewTab.tsx
@@ -6,7 +6,7 @@ import {
 } from "@/components/generated/ui/card";
 import { Progress } from "@/components/generated/ui/progress";
 import { TabsContent } from "@/components/generated/ui/tabs";
-import { MetricCardRow, MetricsCard } from "@/components/shared/MetricsCard";
+import { MetricRow, MetricsCard } from "@/components/shared/MetricsCard";
 import { METRICS, VICTORIA_METRICS } from "@/constants/metrics.constants";
 import { useVictoriaMetricsState } from "@/providers/victoria_metrics/VictoriaMetricsProvider";
 import { bytesToUnits, formatNumber } from "@/utils/formatter";
@@ -67,8 +67,13 @@ const CPUUsageCard = (): JSX.Element => {
     return <></>;
   }
 
-  const cpuUsage = pod.getMetric(METRICS.CONTAINER_RESOURCE_CPU_USAGE.name);
-  const cpuLimit = pod.getMetric(METRICS.CONTAINER_RESOURCE_CPU_LIMIT.name);
+  const cpuUsage =
+    pod.getMetric(METRICS.CONTAINER_RESOURCE_CPU_USAGE.name)?.metricValues[0]
+      .numValue ?? 0;
+
+  const cpuLimit =
+    pod.getMetric(METRICS.CONTAINER_RESOURCE_CPU_LIMIT.name)?.metricValues[0]
+      .numValue ?? 0;
 
   const usagePercentage = cpuLimit > 0 ? (cpuUsage / cpuLimit) * 100 : 0;
   const cpuLimitInCores = cpuLimit / 1000;
@@ -99,8 +104,13 @@ const MemoryUsageCard = (): JSX.Element => {
     return <></>;
   }
 
-  const memoryUsage = pod.getMetric(METRICS.CONTAINER_RESOURCE_MEMORY_USAGE.name);
-  const memoryLimit = pod.getMetric(METRICS.CONTAINER_RESOURCE_MEMORY_LIMIT.name);
+  const memoryUsage =
+    pod.getMetric(METRICS.CONTAINER_RESOURCE_MEMORY_USAGE.name)?.metricValues[0]
+      .numValue ?? 0;
+
+  const memoryLimit =
+    pod.getMetric(METRICS.CONTAINER_RESOURCE_MEMORY_LIMIT.name)?.metricValues[0]
+      .numValue ?? 0;
 
   const usagePercentage =
     memoryLimit > 0 ? (memoryUsage / memoryLimit) * 100 : 0;
@@ -125,7 +135,7 @@ const MemoryUsageCard = (): JSX.Element => {
 };
 
 const NetworkActivityCard = (): JSX.Element => {
-  const row: MetricCardRow[] = [
+  const row: MetricRow[] = [
     {
       title: "Data Read",
       metricName: VICTORIA_METRICS.VM_TCPLISTENER_READ_BYTES_TOTAL.name,
@@ -158,7 +168,7 @@ const NetworkActivityCard = (): JSX.Element => {
 };
 
 const ErrorsSummaryCard = (): JSX.Element => {
-  const row: MetricCardRow[] = [
+  const row: MetricRow[] = [
     {
       title: "VL Errors",
       metricName: VICTORIA_METRICS.VL_ERRORS_TOTAL.name,
@@ -196,7 +206,7 @@ const ErrorsSummaryCard = (): JSX.Element => {
 };
 
 const PerformanceCard = (): JSX.Element => {
-  const row: MetricCardRow[] = [
+  const row: MetricRow[] = [
     {
       title: "Total HTTP Requests",
       metricName: VICTORIA_METRICS.VM_HTTP_REQUESTS_ALL_TOTAL.name,
@@ -216,12 +226,14 @@ const PerformanceCard = (): JSX.Element => {
       title: "Avg Response Time",
       metricFormat: (value: number) => `${value.toFixed(2)}ms`,
       metricFetchFn: (pod: Pod): number => {
-        const requestDurationSec = pod.getMetric(
-          VICTORIA_METRICS.VM_HTTP_REQUEST_DURATION_SECONDS_SUM.name
-        );
-        const requestDurationCount = pod.getMetric(
-          VICTORIA_METRICS.VM_HTTP_REQUEST_DURATION_SECONDS_COUNT.name
-        );
+        const requestDurationSec =
+          pod.getMetric(
+            VICTORIA_METRICS.VM_HTTP_REQUEST_DURATION_SECONDS_SUM.name
+          )?.totalValue ?? 0;
+        const requestDurationCount =
+          pod.getMetric(
+            VICTORIA_METRICS.VM_HTTP_REQUEST_DURATION_SECONDS_COUNT.name
+          )?.totalValue ?? 0;
         return (requestDurationSec / requestDurationCount) * 1000;
       },
       hint: "Average response time for HTTP requests",
@@ -239,7 +251,7 @@ const PerformanceCard = (): JSX.Element => {
 };
 
 const VictoriaLogsInsertCard = (): JSX.Element => {
-  const row: MetricCardRow[] = [
+  const row: MetricRow[] = [
     {
       title: "Bytes written",
       metricName: VICTORIA_METRICS.VLINSERT_BACKEND_CONNS_BYTE_WRITTEN.name,
@@ -272,7 +284,7 @@ const VictoriaLogsInsertCard = (): JSX.Element => {
 };
 
 const VictoriaLogsDropsCard = (): JSX.Element => {
-  const row: MetricCardRow[] = [
+  const row: MetricRow[] = [
     {
       title: "Rows dropped",
       metricName: VICTORIA_METRICS.VL_ROWS_DROPPED_TOTAL.name,
@@ -302,7 +314,7 @@ const VictoriaLogsDropsCard = (): JSX.Element => {
 };
 
 const VictoriaMetricsInsertOverviewCard = (): JSX.Element => {
-  const row: MetricCardRow[] = [
+  const row: MetricRow[] = [
     {
       title: "Rows Sent",
       metricName: VICTORIA_METRICS.VM_RPC_ROWS_SENT_TOTAL.name,
@@ -331,7 +343,7 @@ const VictoriaMetricsInsertOverviewCard = (): JSX.Element => {
 };
 
 const VictoriaMetricsSelectOverviewCard = (): JSX.Element => {
-  const row: MetricCardRow[] = [
+  const row: MetricRow[] = [
     {
       title: "Select requests",
       metricName: VICTORIA_METRICS.VM_TENANT_SELECT_REQUEST_TOTAL.name,

--- a/kof-operator/webapp/collector/src/components/pages/victoriaPage/victoria-details/VictoriaSystemTab.tsx
+++ b/kof-operator/webapp/collector/src/components/pages/victoriaPage/victoria-details/VictoriaSystemTab.tsx
@@ -1,5 +1,5 @@
 import { TabsContent } from "@/components/generated/ui/tabs";
-import { MetricCardRow, MetricsCard } from "@/components/shared/MetricsCard";
+import { MetricRow, MetricsCard } from "@/components/shared/MetricsCard";
 import { METRICS, VICTORIA_METRICS } from "@/constants/metrics.constants";
 import { useVictoriaMetricsState } from "@/providers/victoria_metrics/VictoriaMetricsProvider";
 import { bytesToUnits, formatNumber } from "@/utils/formatter";
@@ -21,7 +21,7 @@ const VictoriaSystemTab = (): JSX.Element => {
 export default VictoriaSystemTab;
 
 const CpuMetricsCard = (): JSX.Element => {
-  const rows: MetricCardRow[] = [
+  const rows: MetricRow[] = [
     {
       title: "CPU Cores Available",
       metricName: VICTORIA_METRICS.VM_AVAILABLE_CPU_CORES.name,
@@ -58,7 +58,7 @@ const CpuMetricsCard = (): JSX.Element => {
 };
 
 const MemoryMetricsCard = (): JSX.Element => {
-  const rows: MetricCardRow[] = [
+  const rows: MetricRow[] = [
     {
       title: "Resident Memory",
       metricName: VICTORIA_METRICS.PROCESS_RESIDENT_MEMORY_BYTES.name,
@@ -96,7 +96,7 @@ const MemoryMetricsCard = (): JSX.Element => {
 };
 
 const ProcessIOActivityCard = (): JSX.Element => {
-  const rows: MetricCardRow[] = [
+  const rows: MetricRow[] = [
     {
       title: "Read Bytes",
       metricName: VICTORIA_METRICS.PROCESS_IO_READ_BYTES_TOTAL.name,

--- a/kof-operator/webapp/collector/src/components/shared/StatRow.tsx
+++ b/kof-operator/webapp/collector/src/components/shared/StatRow.tsx
@@ -18,15 +18,15 @@ const StatRow = ({
   text,
   value,
   hint,
-  textStyles,
-  valueStyles,
-  containerStyle,
+  textStyles = "",
+  valueStyles = "",
+  containerStyle = "",
 }: StatRowProps): JSX.Element => {
   return (
-    <div className={`flex justify-between ${containerStyle}`}>
+    <div className={`flex gap-6 justify-between ${containerStyle}`}>
       <Tooltip>
         <TooltipTrigger asChild>
-          <span className={`text-sm cursor-default ${textStyles}`}>{text}</span>
+          <span className={`text-sm break-all cursor-default ${textStyles}`}>{text}</span>
         </TooltipTrigger>
         {hint && (
           <TooltipContent sideOffset={-6}>

--- a/kof-operator/webapp/collector/src/components/shared/StatRowWithTrend.tsx
+++ b/kof-operator/webapp/collector/src/components/shared/StatRowWithTrend.tsx
@@ -10,7 +10,7 @@ import {
 interface StatRowProps {
   text: string;
   textStyles?: string;
-  value: string | number;
+  value: string | number | JSX.Element;
   valueStyles?: string;
   containerStyle?: string;
   trend: Trend;
@@ -21,7 +21,7 @@ interface StatRowProps {
 const StatRowWithTrend = ({
   text,
   value,
-  textStyles,
+  textStyles = "",
   valueStyles,
   containerStyle,
   trend,
@@ -32,32 +32,38 @@ const StatRowWithTrend = ({
   const trendMessageColor = isTrendGood ? "text-green-600" : "text-red-600";
 
   return (
-    <div>
-      <div className={`flex justify-between mb-0 ${containerStyle}`}>
+    <div className={`flex mb-0 gap-6 ${containerStyle}`}>
+      <div className="flex-1 min-w-0 flex">
         <Tooltip>
           <TooltipTrigger asChild>
-            <span className={`text-sm cursor-default ${textStyles}`}>
+            <span
+              className={`text-left text-sm break-words inline-block max-w-full whitespace-pre-line ${textStyles}`}
+            >
               {text}
             </span>
           </TooltipTrigger>
+
           {hint && (
             <TooltipContent sideOffset={-6}>
               <p>{hint}</p>
             </TooltipContent>
           )}
         </Tooltip>
+      </div>
 
+      <div className="flex flex-col">
         <div
-          className={`flex gap-2 items-center font-medium ${trendMessageColor}`}
+          className={`flex gap-2 items-center font-medium flex-shrink-0 whitespace-nowrap ${trendMessageColor}`}
         >
           {trend.isTrending && <TrendingUp className="w-5 h-5" />}
           {trend.message}
         </div>
-      </div>
-      <div className="flex justify-end">
-        <span className={`text-sm ${valueStyles}`}>{value}</span>
+        <div className="flex justify-end">
+          <span className={`text-sm ${valueStyles}`}>{value}</span>
+        </div>
       </div>
     </div>
   );
 };
+
 export default StatRowWithTrend;

--- a/kof-operator/webapp/collector/src/components/shared/UnhealthyAlert.tsx
+++ b/kof-operator/webapp/collector/src/components/shared/UnhealthyAlert.tsx
@@ -13,8 +13,10 @@ const UnhealthyAlert = ({ pod }: { pod: Pod }): JSX.Element => {
     return <></>;
   }
 
-  const alertMessage = pod.getStringMetric(METRICS.CONDITION_READY_MESSAGE.name);
-  const alertReason = pod.getStringMetric(METRICS.CONDITION_READY_REASON.name);
+  const alertMessage = pod.getMetric(METRICS.CONDITION_READY_MESSAGE.name)
+    ?.metricValues[0].value;
+  const alertReason = pod.getMetric(METRICS.CONDITION_READY_REASON.name)
+    ?.metricValues[0].value;
 
   return (
     <Alert variant="destructive">

--- a/kof-operator/webapp/collector/src/providers/DefaultProviderState.tsx
+++ b/kof-operator/webapp/collector/src/providers/DefaultProviderState.tsx
@@ -1,17 +1,14 @@
-import { CollectorMetricsRecordsManager } from "./collectors_metrics/CollectorsMetricsRecordManager";
-import {
-  Cluster,
-  CollectorMetricsSet,
-  Pod,
-} from "@/components/pages/collectorPage/models";
+
+import { MetricsRecordsManager } from "./collectors_metrics/CollectorsMetricsRecordManager";
+import { Cluster, ClustersSet, Pod } from "@/components/pages/collectorPage/models";
 
 export interface DefaultProviderState {
   error?: Error;
   isLoading: boolean;
-  data: CollectorMetricsSet | null;
+  data: ClustersSet | null;
   selectedCluster: Cluster | null;
   selectedPod: Pod | null;
-  metricsHistory: CollectorMetricsRecordsManager;
+  metricsHistory: MetricsRecordsManager;
   fetch: () => Promise<void>;
   setSelectedCluster: (name: string) => void;
   setSelectedPod: (name: string) => void;

--- a/kof-operator/webapp/collector/src/providers/collectors_metrics/CollectorsMetricsProvider.tsx
+++ b/kof-operator/webapp/collector/src/providers/collectors_metrics/CollectorsMetricsProvider.tsx
@@ -1,11 +1,11 @@
-import { CollectorMetricsSet } from "@/components/pages/collectorPage/models";
+import { ClustersSet } from "@/components/pages/collectorPage/models";
 import { create } from "zustand";
-import { CollectorMetricsRecordsManager } from "./CollectorsMetricsRecordManager";
 import { DefaultProviderState } from "../DefaultProviderState";
+import { MetricsRecordsService } from "../collectors_metrics/CollectorsMetricsRecordManager";
 
 export const useCollectorMetricsState = create<DefaultProviderState>()(
   (set, get) => {
-    const metricsHistory = new CollectorMetricsRecordsManager();
+    const metricsHistory = MetricsRecordsService;
 
     const fetchMetrics = async (): Promise<void> => {
       try {
@@ -22,8 +22,8 @@ export const useCollectorMetricsState = create<DefaultProviderState>()(
         }
 
         const json = await response.json();
-        const collectorsMetrics = new CollectorMetricsSet(json.clusters);
-        metricsHistory.add(collectorsMetrics);
+        const collectorsMetrics = new ClustersSet(json.clusters);
+        MetricsRecordsService.add(collectorsMetrics);
         set({ data: collectorsMetrics, isLoading: false, error: undefined });
       } catch (e) {
         set({ data: null, error: e as Error, isLoading: false });

--- a/kof-operator/webapp/collector/src/providers/victoria_metrics/VictoriaMetricsProvider.tsx
+++ b/kof-operator/webapp/collector/src/providers/victoria_metrics/VictoriaMetricsProvider.tsx
@@ -1,9 +1,6 @@
-import {
-  CollectorMetricsSet,
-  PodsMap,
-} from "@/components/pages/collectorPage/models";
+import { ClustersSet, PodsMap } from "@/components/pages/collectorPage/models";
 import { create } from "zustand";
-import { CollectorMetricsRecordsManager } from "../collectors_metrics/CollectorsMetricsRecordManager";
+import { MetricsRecordsService } from "../collectors_metrics/CollectorsMetricsRecordManager";
 import { DefaultProviderState } from "../DefaultProviderState";
 
 export interface Response {
@@ -12,7 +9,7 @@ export interface Response {
 
 export const useVictoriaMetricsState = create<DefaultProviderState>()(
   (set, get) => {
-    const metricsHistory = new CollectorMetricsRecordsManager();
+    const metricsHistory = MetricsRecordsService;
 
     const fetchMetrics = async (): Promise<void> => {
       try {
@@ -29,8 +26,8 @@ export const useVictoriaMetricsState = create<DefaultProviderState>()(
         }
 
         const json = (await response.json()) as Response;
-        const victoriaMetrics = new CollectorMetricsSet(json.clusters);
-        metricsHistory.add(victoriaMetrics);
+        const victoriaMetrics = new ClustersSet(json.clusters);
+        MetricsRecordsService.add(victoriaMetrics);
         set({ data: victoriaMetrics, isLoading: false, error: undefined });
       } catch (e) {
         set({ data: null, error: e as Error, isLoading: false });

--- a/kof-operator/webapp/collector/src/utils/metrics.ts
+++ b/kof-operator/webapp/collector/src/utils/metrics.ts
@@ -1,20 +1,20 @@
 import { Pod } from "@/components/pages/collectorPage/models";
 import {
-  CollectorMetricsRecordsManager,
+  MetricsRecordsManager,
   Trend,
 } from "@/providers/collectors_metrics/CollectorsMetricsRecordManager";
 import { TimePeriod } from "@/providers/collectors_metrics/TimePeriodState";
 
 export function getMetricTrendData(
   metricName: string,
-  history: CollectorMetricsRecordsManager,
+  history: MetricsRecordsManager,
   collector: Pod,
   timePeriod: TimePeriod
 ): {
   metricValue: number;
   metricTrend: Trend;
 } {
-  const metricValue = collector.getMetric(metricName);
+  const metricValue = collector.getMetric(metricName)?.totalValue ?? 0;
   const metricHistory = history.getMetricHistory(collector, metricName);
   const metricTrend = history.getMetricTrend(timePeriod, metricHistory);
 
@@ -26,7 +26,7 @@ export function getMetricTrendData(
 
 export function getAverageValue(
   metricName: string,
-  history: CollectorMetricsRecordsManager,
+  history: MetricsRecordsManager,
   collector: Pod,
   timePeriod: TimePeriod
 ): number {


### PR DESCRIPTION
This PR fixes an issue where metrics with multiple labels were not parsed and rendered correctly. The UI previously receive and used a single (last) label value instead of aggregating and exposing all labels and values. The Prometheus parser, backend response format, and UI rendering were updated so metrics now include distinct label entries and a value.

Examples Prometheus metric input:
```
vl_data_size_bytes{type="indexdb"} 199695
vl_data_size_bytes{type="storage"} 125139890
```

Before (incorrect) metrics were parsed into a single numeric value:
```json
"vl_data_size_bytes": 125139890
```

After (correct) backend now returns separated labels and values:
```json
{
  "vl_data_size_bytes": [
    {
      "labels": { "type": "indexdb" },
      "value": 199695
    },
    {
      "labels": { "type": "storage" },
      "value": 125139890
    }
  ]
}
```

<img width="1627" height="910" alt="image" src="https://github.com/user-attachments/assets/2e5a4b48-e1ce-4358-a23a-12f99d42ebb2" />

