### PR TITLE
fix: prevent duplicate metric collection

### DIFF
--- a/charts/kof-collectors/values.yaml
+++ b/charts/kof-collectors/values.yaml
@@ -290,6 +290,12 @@ opentelemetry-kube-stack:
                     - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape_slow]
                       action: drop
                       regex: true
+                    - source_labels: [__meta_kubernetes_pod_label_k8s_app]
+                      action: drop
+                      regex: ^(kube-proxy|kube-dns)$
+                    - source_labels: [__meta_kubernetes_pod_label_app]
+                      action: drop
+                      regex: ^(helm-controller|source-controller)$
                     - action: replace
                       regex: (?:[^:]+):(\d+)?;(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})
                       replacement: $$2:$$1
@@ -341,21 +347,6 @@ opentelemetry-kube-stack:
                       source_labels: [job]
                       replacement: "kubernetes-pods"
                       target_label: job
-                - job_name: node-exporter
-                  scrape_interval: 30s
-                  relabel_configs:
-                    - action: labelmap
-                      regex: __meta_kubernetes_node_label_(.+)
-                    - action: replace
-                      regex: "(.*)"
-                      replacement: "$$1"
-                      separator: ";"
-                      source_labels:
-                        - job
-                      target_label: __tmp_prometheus_job_name
-                  static_configs:
-                    - targets:
-                        - ${env:OTEL_K8S_NODE_IP}:9100
                 - authorization:
                     credentials_file: "/var/run/secrets/kubernetes.io/serviceaccount/token"
                     type: Bearer
@@ -1511,7 +1502,19 @@ opentelemetry-kube-stack:
         labelValueLengthLimit: 0
         metricRelabelings: []
         proxyUrl: ""
-        relabelings: []
+        relabelings:
+        - sourceLabels: [__meta_kubernetes_pod_node_name]
+          separator: ;
+          regex: ^(.*)$
+          targetLabel: nodename
+          replacement: $1
+          action: replace
+        - sourceLabels: [__meta_kubernetes_pod_node_name]
+          separator: ;
+          regex: ^(.*)$
+          targetLabel: node
+          replacement: $1
+          action: replace
         sampleLimit: 0
         scrapeTimeout: ""
         targetLimit: 0

--- a/kof-operator/webapp/collector/src/components/features/SearchBar.tsx
+++ b/kof-operator/webapp/collector/src/components/features/SearchBar.tsx
@@ -50,20 +50,20 @@ export const SearchFilter = (value: string): FilterFunction => {
   return (clusters: Cluster[]) => {
     if (!value) return clusters;
 
-    value = value.toLocaleLowerCase()
+    value = value.toLocaleLowerCase();
 
     const targetFilterFn = (target: Target): boolean => {
       const includeInLabels = Object.values(target.labels).some((val) =>
-        val.includes(value)
+        val.toLocaleLowerCase().includes(value)
       );
 
       const includeInDiscoveredLabels = Object.values(
         target.discoveredLabels
-      ).some((val) => val.includes(value));
+      ).some((val) => val.toLocaleLowerCase().includes(value));
 
       return (
-        target.scrapeUrl.includes(value) ||
-        target.scrapePool.includes(value) ||
+        target.scrapeUrl.toLocaleLowerCase().includes(value) ||
+        target.scrapePool.toLocaleLowerCase().includes(value) ||
         includeInLabels ||
         includeInDiscoveredLabels
       );


### PR DESCRIPTION
Closes #411 

- Removed the `node-exporter` job from the daemon collector scrape config
- Added `node` and `nodename` labels to the `prometheus-node-exporter` ServiceMonitor so Grafana dashboards continue to render correctly.
- Dashboards related to Node Exporter metrics rendered correctly (tested on a regional cluster):
  - Node Exporter Full
  - KPS / Kubernetes / Compute Resources / Cluster
  - KPS / Kubernetes / Compute Resources / Multi-Cluster
  - KPS / Node Exporter / USE Method / Cluster
  - KPS / Node Exporter / USE Method / Node
  - KPS / Node Exporter / AIX
  - KPS / Node Exporter / Nodes

- Dropped scraping of `kube-proxy` and `kube-dns` pods in the collector daemon scrape config (`kubernetes-pods` job) to prevent duplicate metrics on regional and child clusters.
- Dashboards related to `Kube-dns` and `Kube-proxy` metrics rendered correctly (tested on a regional cluster):
  - KPS / Kubernetes / Proxy
  - KPS / CoreDNS

