### PR TITLE
feat: add misconfiguration check for collector scrape in KOF UI

### DIFF
--- a/charts/kof-child/values.yaml
+++ b/charts/kof-child/values.yaml
@@ -11,6 +11,10 @@ collectors:
       daemon:
         config:
           receivers:
+            prometheus:
+              api_server:
+                server_config:
+                  endpoint: ${env:OTEL_K8S_NODE_IP}:9090
             otlp:
               protocols:
                 grpc:

--- a/charts/kof-collectors/values.yaml
+++ b/charts/kof-collectors/values.yaml
@@ -273,7 +273,7 @@ opentelemetry-kube-stack:
           prometheus:
             api_server:
               server_config:
-                endpoint: ${env:OTEL_K8S_NODE_IP}:9090
+                endpoint: 0.0.0.0:9090
             config:
               scrape_configs:
                 - job_name: kubernetes-pods

--- a/kof-operator/webapp/collector/src/components/features/DuplicateTargetsAlert.tsx
+++ b/kof-operator/webapp/collector/src/components/features/DuplicateTargetsAlert.tsx
@@ -1,0 +1,93 @@
+import { JSX, useEffect, useMemo } from "react";
+import { Target } from "@/models/PrometheusTarget";
+import { Cluster } from "@/models/Cluster";
+import { Alert, AlertDescription, AlertTitle } from "../generated/ui/alert";
+import { AlertCircleIcon } from "lucide-react";
+import { toast } from "sonner";
+import usePrometheusTarget from "@/providers/prometheus/PrometheusHook";
+
+const DuplicateTargetsAlert = ({
+  clusterName,
+}: {
+  clusterName: string;
+}): JSX.Element => {
+  const { data } = usePrometheusTarget();
+
+  const cluster: Cluster | undefined = useMemo(() => {
+    return data?.findCluster(clusterName);
+  }, [data, clusterName]);
+
+  const targetsMap = useMemo(() => {
+    const map: Record<string, Target[]> = {};
+    if (!cluster || !cluster.targets) return map;
+
+    cluster.targets.forEach((target) => {
+      map[target.scrapeUrl] = map[target.scrapeUrl] ?? [];
+      map[target.scrapeUrl].push(target);
+    });
+    return map;
+  }, [cluster]);
+
+  const duplicatedScrapeUrl = useMemo(
+    () =>
+      Object.entries(targetsMap)
+        .filter(([, targets]) => targets.length > 1)
+        .map(([key]) => key),
+    [targetsMap]
+  );
+
+  useEffect(() => {
+    if (cluster && duplicatedScrapeUrl.length !== 0) {
+      toast.error("Misconfiguration Found!", {
+        id: cluster.name,
+        description: `Check the '${cluster.name}' cluster for more details.`,
+      });
+    }
+  }, [cluster, duplicatedScrapeUrl]);
+
+  if (!cluster || duplicatedScrapeUrl.length === 0) return <></>;
+
+  return (
+    <Alert variant="destructive">
+      <AlertCircleIcon />
+      <AlertTitle>Misconfiguration Found!</AlertTitle>
+      <AlertDescription className="flex flex-col space-y-2">
+        <span>Some targets are duplicated and scraping the same URL</span>
+        {duplicatedScrapeUrl.map((scrapeUrl) => {
+          return (
+            <div key={scrapeUrl} className="border-l-2 border-red-500 pl-3">
+              <p className="font-semibold">Scrape URL: {scrapeUrl}</p>
+              <span>Scrape pools:</span>
+              <ul className="list-disc list-inside">
+                {targetsMap[scrapeUrl].map((target) => (
+                  <li key={`${cluster.name}-${target.scrapePool}`}>
+                    <button
+                      className="cursor-pointer"
+                      onClick={() => {
+                        const id: string = `${cluster.name}-${target.scrapePool}-${target.lastScrape}`;
+                        const el = document.getElementById(id);
+                        if (!el) return;
+                        highlightElement(el);
+                      }}
+                    >
+                      {target.scrapePool}
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          );
+        })}
+      </AlertDescription>
+    </Alert>
+  );
+};
+
+const highlightElement = (el: HTMLElement) => {
+  el.scrollIntoView({ behavior: "smooth", block: "center" });
+  el.focus({ preventScroll: true });
+  el.classList.add("transition-colors", "duration-500", "bg-red-100");
+  setTimeout(() => el.classList.remove("bg-red-100"), 2000);
+};
+
+export default DuplicateTargetsAlert;

--- a/kof-operator/webapp/collector/src/components/features/TargetsList.tsx
+++ b/kof-operator/webapp/collector/src/components/features/TargetsList.tsx
@@ -21,6 +21,7 @@ import { Target } from "@/models/PrometheusTarget";
 import JsonView from "@uiw/react-json-view";
 import { Loader } from "lucide-react";
 import { Button } from "@/components/generated/ui/button";
+import DuplicateTargetsAlert from "./DuplicateTargetsAlert";
 
 const TargetList = (): JSX.Element => {
   const { filteredData, loading, fetchPrometheusTargets, error } =
@@ -51,11 +52,12 @@ const TargetList = (): JSX.Element => {
   return (
     <>
       {filteredData?.map((cluster) => (
-        <div className="flex flex-col p-6" key={cluster.name}>
+        <div className="flex flex-col p-6 space-y-2.5" key={cluster.name}>
           <div className="flex justify-between">
             <h1 className="flex items-center text-2xl w-fit font-bold ml-2">{`${cluster.name}`}</h1>
             <TargetStats clusters={[cluster]}></TargetStats>
           </div>
+          <DuplicateTargetsAlert clusterName={cluster.name} />
           <Table className="w-full table-fixed">
             <TableHeader>
               <TableRow>
@@ -71,6 +73,7 @@ const TargetList = (): JSX.Element => {
               {cluster.targets.map((target, idx) => (
                 <Row
                   key={`${cluster.name}-${target.scrapeUrl}-${idx}`}
+                  id={`${cluster.name}-${target.scrapePool}-${target.lastScrape}`}
                   target={target}
                 />
               ))}
@@ -84,7 +87,7 @@ const TargetList = (): JSX.Element => {
 
 export default TargetList;
 
-const Row = ({ target }: { target: Target }) => {
+const Row = ({ target, id }: { target: Target; id: string }) => {
   const [open, setOpen] = useState(false);
   const prettyScrapeUrl = new URL(target.scrapeUrl);
   prettyScrapeUrl.host =
@@ -96,6 +99,7 @@ const Row = ({ target }: { target: Target }) => {
       <TableRow
         className="cursor-pointer hover:bg-muted transition-colors"
         onClick={() => setOpen((o) => !o)}
+        id={id}
       >
         <EndpointCell url={prettyScrapeUrl.toString()} />
         <StateCell state={target.health} />


### PR DESCRIPTION
Closes #227

- Add a check that detects duplicate Prometheus target scrape URLs
- Display misconfiguration error in the KOF UI

<img width="1411" height="585" alt="image" src="https://github.com/user-attachments/assets/776064d6-dff5-4a60-917b-dc3418387012" />

