### PR TITLE
fix: prevent OOM crash in promxy on large queries

### DIFF
--- a/charts/kof-mothership/README.md
+++ b/charts/kof-mothership/README.md
@@ -104,8 +104,8 @@ A Helm chart that deploys Grafana, Promxy, and VictoriaMetrics.
 | promxy<br>.image | object | `{"pullPolicy":"IfNotPresent",`<br>`"registry":"quay.io",`<br>`"repository":"jacksontj/promxy",`<br>`"tag":"v0.0.93"}` | Promxy image to use. |
 | promxy<br>.ingress | object | `{"annotations":{},`<br>`"enabled":false,`<br>`"extraLabels":{},`<br>`"hosts":["example.com"],`<br>`"ingressClassName":"nginx",`<br>`"path":"/",`<br>`"pathType":"Prefix",`<br>`"tls":[]}` | Config of `kof-mothership-promxy` [Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/). |
 | promxy<br>.replicaCount | int | `1` | Number of replicated promxy pods. |
-| promxy<br>.resources<br>.limits | object | `{"cpu":"100m",`<br>`"memory":"256Mi"}` | Maximum resources available for the `promxy` container in the pods of `kof-mothership-promxy` deployment. |
-| promxy<br>.resources<br>.requests | object | `{"cpu":"100m",`<br>`"memory":"256Mi"}` | Minimum resources required for the `promxy` container in the pods of `kof-mothership-promxy` deployment. |
+| promxy<br>.resources<br>.limits | object | `{"cpu":"100m",`<br>`"memory":"512Mi"}` | Maximum resources available for the `promxy` container in the pods of `kof-mothership-promxy` deployment. |
+| promxy<br>.resources<br>.requests | object | `{"cpu":"100m",`<br>`"memory":"512Mi"}` | Minimum resources required for the `promxy` container in the pods of `kof-mothership-promxy` deployment. |
 | promxy<br>.service | object | `{"annotations":{},`<br>`"clusterIP":"",`<br>`"enabled":true,`<br>`"externalIPs":[],`<br>`"extraLabels":{},`<br>`"loadBalancerIP":"",`<br>`"loadBalancerSourceRanges":[],`<br>`"servicePort":8082,`<br>`"type":"ClusterIP"}` | Config of `kof-mothership-promxy` [Service](https://kubernetes.io/docs/concepts/services-networking/service/). |
 | promxy<br>.serviceAccount<br>.annotations | object | `{}` | Annotations for the service account of promxy. |
 | promxy<br>.serviceAccount<br>.create | bool | `true` | Creates a service account for promxy. |

--- a/charts/kof-mothership/values.yaml
+++ b/charts/kof-mothership/values.yaml
@@ -457,13 +457,13 @@ promxy:
     # in the pods of `kof-mothership-promxy` deployment.
     requests:
       cpu: 100m
-      memory: 256Mi
+      memory: 512Mi
 
     # -- Maximum resources available for the `promxy` container
     # in the pods of `kof-mothership-promxy` deployment.
     limits:
       cpu: 100m
-      memory: 256Mi
+      memory: 512Mi
 
   # -- Extra command line arguments passed as `--key=value` to the `/bin/promxy`.
   extraArgs:

--- a/docs/system-requirements.md
+++ b/docs/system-requirements.md
@@ -52,6 +52,27 @@ Each node has a dedicated `vmselect-cachedir` PVC for caching in VMSelect.
 * **grafana-vm-pvc**: 1Gi
 Used for regional components such as Grafana.
 
+## Promxy Requirements
+
+By default, Promxy uses the following resource configuration:
+
+```yaml
+resources:
+    requests:
+        cpu: 100m
+        memory: 512Mi
+
+    limits:
+        cpu: 100m
+        memory: 512Mi
+```
+
+However, this may not be sufficient for large queries.
+If Grafana displays errors such as `connection refused`, `EOF` or `timeout awaiting response headers`, it could be caused by an OOM (Out of Memory) error in Kubernetes Promxy pod.
+
+You should adjust the resource requests and limits according to your workload.
+The more clusters you connect, the more memory will be required for large queries.
+
 ## Recommendations for Cluster Scaling
 
 To ensure optimal performance of your cluster under high load, it is recommended to:


### PR DESCRIPTION
- Increase memory `requests` and `limits` from 256Mi to 512Mi
- Update `System Requirements` docs to mention Promxy resource configuration
- Matching the correct memory resources is impossible due to varying queries and cluster counts
