### PR TITLE
feat: add cluster deployment monitoring page to KOF UI

### DIFF
--- a/kof-operator/cmd/main.go
+++ b/kof-operator/cmd/main.go
@@ -156,6 +156,7 @@ func main() {
 	httpServer.Router.GET("/api/targets", handlers.PrometheusHandler)
 	httpServer.Router.GET("/api/collectors/metrics", handlers.CollectorHandler)
 	httpServer.Router.GET("/api/victoria/metrics", handlers.VictoriaHandler)
+	httpServer.Router.GET("/api/cluster-deployments", handlers.ClusterDeploymentHandler)
 	httpServer.Router.NotFound(handlers.NotFoundHandler)
 	setupLog.Info(fmt.Sprintf("Starting http server on :%s", httpServerPort))
 	var wg sync.WaitGroup

--- a/kof-operator/internal/server/handlers/cluster_deployments_handler.go
+++ b/kof-operator/internal/server/handlers/cluster_deployments_handler.go
@@ -1,0 +1,63 @@
+package handlers
+
+import (
+	"net/http"
+
+	kcmv1beta1 "github.com/K0rdent/kcm/api/v1beta1"
+	"github.com/k0rdent/kof/kof-operator/internal/k8s"
+	"github.com/k0rdent/kof/kof-operator/internal/server"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type ClusterDeploymentDTO struct {
+	Name              string                              `json:"name"`
+	Namespace         string                              `json:"namespace"`
+	Generation        int64                               `json:"generation"`
+	Labels            map[string]string                   `json:"labels"`
+	Annotations       map[string]string                   `json:"annotations"`
+	Spec              *kcmv1beta1.ClusterDeploymentSpec   `json:"spec"`
+	Status            *kcmv1beta1.ClusterDeploymentStatus `json:"status"`
+	CreationTimestamp *metav1.Time                        `json:"creation_time"`
+	DeletionTimestamp *metav1.Time                        `json:"deletion_time"`
+}
+
+type response struct {
+	ClusterDeployments map[string]*ClusterDeploymentDTO `json:"cluster_deployments"`
+}
+
+func ClusterDeploymentHandler(res *server.Response, req *http.Request) {
+	ctx := req.Context()
+
+	kubeClient, err := k8s.NewClient()
+	if err != nil {
+		res.Logger.Error(err, "Failed to create kube client")
+		res.Fail(server.BasicInternalErrorMessage, http.StatusInternalServerError)
+		return
+	}
+
+	cds, err := k8s.GetClusterDeployments(ctx, kubeClient.Client)
+	if err != nil {
+		res.Logger.Error(err, "Failed to get cluster deployments")
+		res.Fail(server.BasicInternalErrorMessage, http.StatusInternalServerError)
+		return
+	}
+
+	cdsMap := make(map[string]*ClusterDeploymentDTO, len(cds.Items))
+	for _, cd := range cds.Items {
+		cdsMap[cd.Name] = &ClusterDeploymentDTO{
+			Name:              cd.Name,
+			Namespace:         cd.Namespace,
+			Generation:        cd.Generation,
+			Labels:            cd.GetLabels(),
+			Annotations:       cd.GetAnnotations(),
+			Spec:              &cd.Spec,
+			Status:            &cd.Status,
+			CreationTimestamp: &cd.CreationTimestamp,
+			DeletionTimestamp: cd.DeletionTimestamp,
+		}
+	}
+
+	res.Send(&response{
+		ClusterDeployments: cdsMap,
+	}, http.StatusOK)
+}

--- a/kof-operator/webapp/collector/.env.ci
+++ b/kof-operator/webapp/collector/.env.ci
@@ -1,3 +1,4 @@
 VITE_TARGET_URL = "/api/targets"
 VITE_COLLECTOR_METRICS_URL = "/api/collectors/metrics"
 VITE_VICTORIA_METRICS_URL = "/api/victoria/metrics"
+VITE_CLUSTER_DEPLOYMENTS_URL = "/api/cluster-deployments"

--- a/kof-operator/webapp/collector/.env.development
+++ b/kof-operator/webapp/collector/.env.development
@@ -1,3 +1,4 @@
 VITE_TARGET_URL = "http://localhost:9090/api/targets"
 VITE_COLLECTOR_METRICS_URL = "http://localhost:9090/api/collectors/metrics"
 VITE_VICTORIA_METRICS_URL = "http://localhost:9090/api/victoria/metrics"
+VITE_CLUSTER_DEPLOYMENTS_URL = "http://localhost:9090/api/cluster-deployments"

--- a/kof-operator/webapp/collector/.env.production
+++ b/kof-operator/webapp/collector/.env.production
@@ -1,3 +1,4 @@
 VITE_TARGET_URL = "/api/targets"
 VITE_COLLECTOR_METRICS_URL = "/api/collectors/metrics"
 VITE_VICTORIA_METRICS_URL = "/api/victoria/metrics"
+VITE_CLUSTER_DEPLOYMENTS_URL = "/api/cluster-deployments"

--- a/kof-operator/webapp/collector/src/App.tsx
+++ b/kof-operator/webapp/collector/src/App.tsx
@@ -13,6 +13,9 @@ import CollectorContent from "./components/pages/collectorPage/components/collec
 import VictoriaPage from "./components/pages/victoriaPage/VictoriaPage";
 import { useVictoriaMetricsState } from "./providers/victoria_metrics/VictoriaMetricsProvider";
 import VictoriaDetailsPage from "./components/pages/victoriaPage/victoria-details/VictoriaDetailsPage";
+import ClusterDeploymentLayout from "./components/pages/clusterDeploymentsPage/ClusterDeploymentLayout";
+import ClusterDeploymentDetails from "./components/pages/clusterDeploymentsPage/components/details/ClusterDeploymentDetails";
+import ClusterDeploymentsList from "./components/pages/clusterDeploymentsPage/components/list/ClusterDeploymentList";
 
 function App() {
   const { fetch: fetchCollector, isLoading: collectorIsLoading } =
@@ -55,6 +58,18 @@ function App() {
               path="victoria/:cluster/:pod"
               element={<VictoriaDetailsPage />}
             />
+
+            <Route
+              path="cluster-deployments"
+              element={<ClusterDeploymentLayout />}
+            >
+              <Route index element={<ClusterDeploymentsList />} />
+              <Route
+                path=":clusterName"
+                element={<ClusterDeploymentDetails />}
+              />
+            </Route>
+
             <Route path="*" element={<NoPage />} />
           </Routes>
         </main>

--- a/kof-operator/webapp/collector/src/components/features/AppSidebar.tsx
+++ b/kof-operator/webapp/collector/src/components/features/AppSidebar.tsx
@@ -1,5 +1,12 @@
-import { JSX } from "react";
-import { Target, Funnel, Database } from "lucide-react";
+import { ForwardRefExoticComponent, JSX, RefAttributes } from "react";
+import {
+  Target,
+  Funnel,
+  Database,
+  Server,
+  TriangleAlert,
+  LucideProps,
+} from "lucide-react";
 import {
   Sidebar,
   SidebarContent,
@@ -11,26 +18,44 @@ import {
   SidebarMenuItem,
 } from "@/components/generated/ui/sidebar";
 import { Link } from "react-router-dom";
+import { useClusterDeploymentsProvider } from "@/providers/cluster_deployments/ClusterDeploymentsProvider";
 
-const items = [
-  {
-    title: "Prometheus Targets",
-    url: "/",
-    icon: Target,
-  },
-  {
-    title: "Collectors Metrics",
-    url: "collectors",
-    icon: Funnel,
-  },
-  {
-    title: "VictoriaMetrics/Logs",
-    url: "victoria",
-    icon: Database
-  }
-];
+interface SidebarItem {
+  title: string;
+  url: string;
+  icon: ForwardRefExoticComponent<
+    Omit<LucideProps, "ref"> & RefAttributes<SVGSVGElement>
+  >;
+  alert?: boolean;
+}
 
 const AppSidebar = (): JSX.Element => {
+  const { data, isLoading, error } = useClusterDeploymentsProvider();
+
+  const items: SidebarItem[] = [
+    {
+      title: "Prometheus Targets",
+      url: "/",
+      icon: Target,
+    },
+    {
+      title: "Collectors Metrics",
+      url: "collectors",
+      icon: Funnel,
+    },
+    {
+      title: "VictoriaMetrics/Logs",
+      url: "victoria",
+      icon: Database,
+    },
+    {
+      title: "Cluster Deployments",
+      url: "cluster-deployments",
+      icon: Server,
+      alert: data ? !isLoading && !error && !data.isHealthy : false,
+    },
+  ];
+
   return (
     <Sidebar>
       <SidebarHeader>
@@ -43,9 +68,17 @@ const AppSidebar = (): JSX.Element => {
               {items.map((item) => (
                 <SidebarMenuItem key={item.title}>
                   <SidebarMenuButton asChild>
-                    <Link to={item.url}>
-                      <item.icon />
-                      <span>{item.title}</span>
+                    <Link
+                      to={item.url}
+                      className="flex w-full items-center justify-between"
+                    >
+                      <div className="flex items-center gap-2">
+                        <item.icon className="h-4 w-4" />
+                        <span>{item.title}</span>
+                      </div>
+                      {item.alert && (
+                        <TriangleAlert className="text-orange-600 w-4 h-4" />
+                      )}
                     </Link>
                   </SidebarMenuButton>
                 </SidebarMenuItem>

--- a/kof-operator/webapp/collector/src/components/pages/clusterDeploymentsPage/ClusterDeploymentLayout.tsx
+++ b/kof-operator/webapp/collector/src/components/pages/clusterDeploymentsPage/ClusterDeploymentLayout.tsx
@@ -1,0 +1,43 @@
+import { JSX } from "react";
+import { Outlet } from "react-router-dom";
+import { Separator } from "@/components/generated/ui/separator";
+import { useClusterDeploymentsProvider } from "@/providers/cluster_deployments/ClusterDeploymentsProvider";
+import Loader from "@/components/shared/Loader";
+import { Button } from "@/components/generated/ui/button";
+
+const ClusterDeploymentLayout = (): JSX.Element => {
+  const { data: clusters, isLoading, error } = useClusterDeploymentsProvider();
+
+  return (
+    <div className="flex flex-col w-full h-full p-5 space-y-8">
+      <h1 className="font-bold text-3xl">Cluster Deployments</h1>
+      <Separator />
+      {isLoading ? <Loader />
+        : error ? <FetchError />
+        : !clusters || !clusters.length ? <EmptyState />
+        : <Outlet />}
+    </div>
+  );
+};
+
+export default ClusterDeploymentLayout;
+
+const FetchError = (): JSX.Element => {
+  const { fetch } = useClusterDeploymentsProvider();
+  return (
+    <div className="flex flex-col justify-center items-center mt-[15%]">
+      <span className="mb-3">
+        Failed to fetch cluster deployments. Click "Reload" button to try again.
+      </span>
+      <Button className="cursor-pointer" onClick={() => fetch()}>
+        Reload
+      </Button>
+    </div>
+  );
+};
+
+const EmptyState = (): JSX.Element => (
+  <div className="flex w-full h-full justify-center items-center">
+    No cluster deployments found
+  </div>
+);

--- a/kof-operator/webapp/collector/src/components/pages/clusterDeploymentsPage/components/details/ClusterDeploymentConfigTab.tsx
+++ b/kof-operator/webapp/collector/src/components/pages/clusterDeploymentsPage/components/details/ClusterDeploymentConfigTab.tsx
@@ -1,0 +1,57 @@
+import { TabsContent } from "@/components/generated/ui/tabs";
+import { MetricRow, MetricsCard } from "@/components/shared/MetricsCard";
+import StatRow from "@/components/shared/StatRow";
+import { useClusterDeploymentsProvider } from "@/providers/cluster_deployments/ClusterDeploymentsProvider";
+import { Cpu, FileSliders } from "lucide-react";
+import { JSX } from "react";
+
+const ClusterDeploymentConfigurationTab = (): JSX.Element => {
+  return (
+    <TabsContent value="configuration" className="flex flex-col gap-5">
+      <div className="grid gap-6 md:grid-cols-2">
+        <InfrastructureCard />
+        <ClusterConfigurationCard />
+      </div>
+    </TabsContent>
+  );
+};
+
+export default ClusterDeploymentConfigurationTab;
+
+const ClusterConfigurationCard = (): JSX.Element => {
+  const { selectedCluster } = useClusterDeploymentsProvider();
+  const rows: MetricRow[] = [
+    { title: "Template", value: selectedCluster?.spec.template },
+    { title: "Credential", value: selectedCluster?.spec.credential },
+  ];
+
+  return (
+    <MetricsCard rows={rows} icon={FileSliders} title="Cluster Configuration" />
+  );
+};
+
+const InfrastructureCard = (): JSX.Element => {
+  const { selectedCluster } = useClusterDeploymentsProvider();
+  const rows: MetricRow[] = [
+    { title: "Cloud Provider", value: selectedCluster?.spec.provider },
+    { title: "Region", value: selectedCluster?.spec.config.region },
+    {
+      title: "Control Plane",
+      customRow: ({ title }) => {
+        const nodesNumber = selectedCluster?.spec.config.controlPlaneNumber;
+        const type = selectedCluster?.spec.config.controlPlane.instanceType;
+        return <StatRow text={title} value={`${nodesNumber} x ${type}`} />;
+      },
+    },
+    {
+      title: "Workers",
+      customRow: ({ title }) => {
+        const nodesNumber = selectedCluster?.spec.config.workersNumber;
+        const type = selectedCluster?.spec.config.worker.instanceType;
+        return <StatRow text={title} value={`${nodesNumber} x ${type}`} />;
+      },
+    },
+  ];
+
+  return <MetricsCard rows={rows} icon={Cpu} title="Infrastructure" />;
+};

--- a/kof-operator/webapp/collector/src/components/pages/clusterDeploymentsPage/components/details/ClusterDeploymentDetails.tsx
+++ b/kof-operator/webapp/collector/src/components/pages/clusterDeploymentsPage/components/details/ClusterDeploymentDetails.tsx
@@ -1,0 +1,89 @@
+import { Button } from "@/components/generated/ui/button";
+import { Tabs, TabsList, TabsTrigger } from "@/components/generated/ui/tabs";
+import { useClusterDeploymentsProvider } from "@/providers/cluster_deployments/ClusterDeploymentsProvider";
+import { HardDrive, MoveLeft } from "lucide-react";
+import { JSX, useEffect } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import ClusterDeploymentMetadataTab from "./ClusterDeploymentMetadataTab";
+import HealthBadge from "@/components/shared/HealthBadge";
+import ClusterDeploymentStatusTab from "./ClusterDeploymentStatusTab";
+import ClusterDeploymentConfigurationTab from "./ClusterDeploymentConfigTab";
+
+const ClusterDeploymentDetails = (): JSX.Element => {
+  const { data, setSelectedCluster, selectedCluster, isLoading } =
+    useClusterDeploymentsProvider();
+
+  const navigate = useNavigate();
+  const { clusterName } = useParams();
+
+  useEffect(() => {
+    if (!isLoading && data && clusterName) {
+      setSelectedCluster(clusterName);
+    }
+  }, [clusterName, data, isLoading, setSelectedCluster]);
+
+  if (data && !selectedCluster) {
+    return (
+      <div className="flex flex-col w-full h-full p-5 space-y-8">
+        <div className="flex flex-col w-full h-full justify-center items-center space-y-4">
+          <span className="font-bold text-2xl">
+            Cluster deployments not found
+          </span>
+          <Button
+            variant="outline"
+            className="cursor-pointer"
+            onClick={() => {
+              navigate("/cluster-deployments");
+            }}
+          >
+            <MoveLeft />
+            <span>Back to Table</span>
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-5">
+      <DetailsHeader />
+      <Tabs defaultValue="status" className="space-y-6">
+        <TabsList className="flex w-full">
+          <TabsTrigger value="status">Status</TabsTrigger>
+          <TabsTrigger value="configuration">Configuration</TabsTrigger>
+          <TabsTrigger value="metadata">Metadata</TabsTrigger>
+        </TabsList>
+        <ClusterDeploymentStatusTab />
+        <ClusterDeploymentConfigurationTab />
+        <ClusterDeploymentMetadataTab />
+      </Tabs>
+    </div>
+  );
+};
+
+export default ClusterDeploymentDetails;
+
+const DetailsHeader = (): JSX.Element => {
+  const { selectedCluster: cluster } = useClusterDeploymentsProvider();
+  const navigate = useNavigate();
+
+  return (
+    <div className="space-y-6">
+      <Button
+        variant="outline"
+        className="cursor-pointer"
+        onClick={() => {
+          navigate("/cluster-deployments");
+        }}
+      >
+        <MoveLeft />
+        <span>Back to Table</span>
+      </Button>
+      <div className="flex gap-4 items-center mb-2">
+        <HardDrive />
+        <span className="font-bold text-xl">{cluster?.name}</span>
+        <HealthBadge isHealthy={cluster?.isHealthy ?? false} />
+      </div>
+    </div>
+  );
+};

--- a/kof-operator/webapp/collector/src/components/pages/clusterDeploymentsPage/components/details/ClusterDeploymentMetadataTab.tsx
+++ b/kof-operator/webapp/collector/src/components/pages/clusterDeploymentsPage/components/details/ClusterDeploymentMetadataTab.tsx
@@ -1,0 +1,99 @@
+import { TabsContent } from "@/components/generated/ui/tabs";
+import { MetricRow, MetricsCard } from "@/components/shared/MetricsCard";
+import { useClusterDeploymentsProvider } from "@/providers/cluster_deployments/ClusterDeploymentsProvider";
+import JsonView from "@uiw/react-json-view";
+import {
+  Clock,
+  Database,
+  FileText,
+  LucideProps,
+  Tag,
+  Tags,
+} from "lucide-react";
+import { ForwardRefExoticComponent, JSX, RefAttributes } from "react";
+
+const ClusterDeploymentMetadataTab = (): JSX.Element => {
+  const { selectedCluster: cluster } = useClusterDeploymentsProvider();
+
+  return (
+    <TabsContent value="metadata" className="max-w-full flex flex-col gap-5">
+      <div className="grid gap-6 md:grid-cols-1 lg:grid-cols-2">
+        <BasicInfoCard />
+        <TimelineCard />
+      </div>
+
+      <JsonMetricsCard title="Labels" icon={Tag} data={cluster?.labels ?? {}} />
+      <JsonMetricsCard
+        title="Cluster Annotations"
+        icon={FileText}
+        data={cluster?.spec.config.clusterAnnotations ?? {}}
+      />
+      <JsonMetricsCard
+        title="Annotations"
+        icon={Tags}
+        data={cluster?.annotations ?? {}}
+      />
+    </TabsContent>
+  );
+};
+
+export default ClusterDeploymentMetadataTab;
+
+const BasicInfoCard = (): JSX.Element => {
+  const { selectedCluster: cluster } = useClusterDeploymentsProvider();
+
+  const rows: MetricRow[] = [
+    { title: "Name", value: cluster?.name },
+    { title: "Namespace", value: cluster?.namespace },
+    { title: "Generation", value: String(cluster?.generation) },
+  ];
+
+  return (
+    <MetricsCard rows={rows} icon={Database} title={"Basic Information"} />
+  );
+};
+
+const TimelineCard = (): JSX.Element => {
+  const { selectedCluster: cluster } = useClusterDeploymentsProvider();
+
+  const rows: MetricRow[] = [
+    { title: "Created", value: cluster?.creationTime.toLocaleString() },
+    {
+      title: "Deletion Started",
+      value: cluster?.deletionTime?.toLocaleString() ?? "Not Deleted",
+    },
+  ];
+
+  return <MetricsCard rows={rows} icon={Clock} title={"Timeline"} />;
+};
+
+interface JsonMetricsCardProps {
+  title: string;
+  icon: ForwardRefExoticComponent<
+    Omit<LucideProps, "ref"> & RefAttributes<SVGSVGElement>
+  >;
+  data: Record<string, string>;
+}
+
+const JsonMetricsCard = ({
+  title,
+  icon,
+  data,
+}: JsonMetricsCardProps): JSX.Element => {
+  const rows: MetricRow[] = [
+    {
+      title: "",
+      customRow: () => (
+        <div className="flex flex-col gap-2 w-full">
+          <JsonView
+            value={data}
+            displayDataTypes={false}
+            className="w-full whitespace-normal break-words"
+          />
+        </div>
+      ),
+    },
+  ];
+
+  return <MetricsCard rows={rows} icon={icon} title={title} />;
+};

--- a/kof-operator/webapp/collector/src/components/pages/clusterDeploymentsPage/components/details/ClusterDeploymentStatusTab.tsx
+++ b/kof-operator/webapp/collector/src/components/pages/clusterDeploymentsPage/components/details/ClusterDeploymentStatusTab.tsx
@@ -1,0 +1,99 @@
+import { TabsContent } from "@/components/generated/ui/tabs";
+import { useClusterDeploymentsProvider } from "@/providers/cluster_deployments/ClusterDeploymentsProvider";
+import { JSX, useMemo } from "react";
+import { ClusterCondition } from "../../models";
+import { Card, CardContent, CardHeader } from "@/components/generated/ui/card";
+import { CircleAlert, CircleCheckBig } from "lucide-react";
+import { Badge } from "@/components/generated/ui/badge";
+
+const ClusterDeploymentStatusTab = (): JSX.Element => {
+  const { selectedCluster } = useClusterDeploymentsProvider();
+
+  const sortedConditions: ClusterCondition[] = useMemo(() => {
+    return (
+      selectedCluster?.status.conditions.sort(
+        (a, b) => Number(!b.isHealthy) - Number(!a.isHealthy)
+      ) ?? []
+    );
+  }, [selectedCluster?.status.conditions]);
+
+  return (
+    <TabsContent value="status" className="flex flex-col gap-5">
+      <ConditionHeader />
+      {sortedConditions.map((c) => (
+        <ConditionRow key={c.type} condition={c} />
+      ))}
+    </TabsContent>
+  );
+};
+
+export default ClusterDeploymentStatusTab;
+
+const ConditionRow = ({ condition }: ConditionRowProps): JSX.Element => {
+  const isHealthy: boolean = condition.isHealthy;
+
+  return (
+    <Card className="gap-2">
+      <CardHeader className="flex flex-row justify-between items-center">
+        <div className="flex gap-4">
+          {isHealthy ? (
+            <CircleCheckBig className="text-green-600 w-5 h-5" />
+          ) : (
+            <CircleAlert className="text-red-600 w-5 h-5" />
+          )}
+          <span className="font-medium">{condition.type}</span>
+          {isHealthy ? (
+            <Badge
+              variant="default"
+              className="bg-green-600 text-primary-foreground"
+            >
+              Ready
+            </Badge>
+          ) : (
+            <Badge variant="destructive">Failed</Badge>
+          )}
+        </div>
+        <div className="text-muted-foreground text-sm">
+          {condition.lastTransitionTimeDate.toLocaleString()}
+        </div>
+      </CardHeader>
+
+      <CardContent>
+        {condition.reason && (
+          <div className="flex gap-2">
+            <span>Reason: </span>
+            <span>{condition.reason}</span>
+          </div>
+        )}
+        {condition.message && (
+          <div className="flex gap-2">
+            <span>Message: </span>
+            <span>{condition.message}</span>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+};
+
+const ConditionHeader = (): JSX.Element => {
+  const { selectedCluster } = useClusterDeploymentsProvider();
+
+  return (
+    <div className="flex gap-2 text-sm font-medium">
+      <div>{selectedCluster?.totalStatusCount} conditions</div>
+      <span>•</span>
+      <div className="text-green-600">
+        {selectedCluster?.healthyStatusCount} healthy
+      </div>
+      <span>•</span>
+      <div className="text-red-600">
+        {selectedCluster?.unhealthyStatusCount} unhealthy
+      </div>
+    </div>
+  );
+};
+
+interface ConditionRowProps {
+  condition: ClusterCondition;
+}

--- a/kof-operator/webapp/collector/src/components/pages/clusterDeploymentsPage/components/list/ClusterDeploymentList.tsx
+++ b/kof-operator/webapp/collector/src/components/pages/clusterDeploymentsPage/components/list/ClusterDeploymentList.tsx
@@ -1,0 +1,103 @@
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/generated/ui/card";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHeader,
+  TableRow,
+} from "@/components/generated/ui/table";
+import { Server } from "lucide-react";
+import { JSX } from "react";
+import CustomizedTableHead from "../../../collectorPage/components/collector-list/CollectorTableHead";
+import HealthBadge from "@/components/shared/HealthBadge";
+import { useClusterDeploymentsProvider } from "@/providers/cluster_deployments/ClusterDeploymentsProvider";
+import { useNavigate } from "react-router-dom";
+import { capitalizeFirstLetter, formatTime } from "@/utils/formatter";
+
+const ClusterDeploymentsList = (): JSX.Element => {
+  return (
+    <Card className="w-full gap-3">
+      <ListHeader />
+      <ListContent />
+    </Card>
+  );
+};
+
+export default ClusterDeploymentsList;
+
+const ListHeader = (): JSX.Element => {
+  const { data: clusters } = useClusterDeploymentsProvider();
+  return (
+    <CardHeader>
+      <CardTitle>
+        <div className="flex gap-4 items-center w-full h-full">
+          <Server className="w-5 h-5" />
+          <div className="flex gap-3 w-full items-center">
+            <span>{clusters?.length} Total</span>
+            <span>•</span>
+            <span className="text-green-600">
+              {clusters?.healthyCount} Healthy
+            </span>
+            <span>•</span>
+            <span className="text-red-600">
+              {clusters?.unhealthyCount} Unhealthy
+            </span>
+          </div>
+        </div>
+      </CardTitle>
+    </CardHeader>
+  );
+};
+
+const ListContent = (): JSX.Element => {
+  const { data: clusters } = useClusterDeploymentsProvider();
+  const navigate = useNavigate();
+
+  return (
+    <CardContent>
+      <Table className="w-full table-fixed">
+        <TableHeader>
+          <TableRow className="font-bold">
+            <CustomizedTableHead text={"Namespace"} width={110} />
+            <CustomizedTableHead text={"Name"} width={200} />
+            <CustomizedTableHead text={"Status"} width={110} />
+            <CustomizedTableHead text={"Role"} width={100} />
+            <CustomizedTableHead text={"Template"} width={180} />
+            <CustomizedTableHead text={"Age"} width={120} />
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {clusters?.deployments.map((cluster) => (
+            <TableRow
+              onClick={() => navigate(cluster.name)}
+              key={`${cluster.namespace}-${cluster.name}`}
+              className="cursor-pointer"
+            >
+              <TableCell className="font-medium">{cluster.namespace}</TableCell>
+              <TableCell className="font-medium truncate">
+                {cluster.name}
+              </TableCell>
+              <TableCell className="font-medium">
+                <HealthBadge isHealthy={cluster.isHealthy} />
+              </TableCell>
+              <TableCell className="font-medium">
+                {capitalizeFirstLetter(cluster.role ?? "N/A")}
+              </TableCell>
+              <TableCell className="font-medium">
+                {cluster.spec.template}
+              </TableCell>
+              <TableCell className="font-medium">
+                {formatTime(cluster.ageInSeconds)}
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </CardContent>
+  );
+};

--- a/kof-operator/webapp/collector/src/components/pages/clusterDeploymentsPage/models.ts
+++ b/kof-operator/webapp/collector/src/components/pages/clusterDeploymentsPage/models.ts
@@ -1,0 +1,383 @@
+const CLUSTER_ROLE_LABEL = "k0rdent.mirantis.com/kof-cluster-role";
+
+export type ClusterRole = "child" | "regional";
+
+export class ClusterDeploymentSet {
+  private _deploymentsMap: Record<string, ClusterDeployment>;
+  private _deploymentsArray: ClusterDeployment[];
+  private _healthyCount: number;
+  private _unhealthyCount: number;
+
+  constructor(data: Record<string, ClusterDeploymentData>) {
+    this._deploymentsMap = Object.entries(data).reduce((acc, [name, value]) => {
+      acc[name] = new ClusterDeployment(value);
+      return acc;
+    }, {} as Record<string, ClusterDeployment>);
+
+    this._deploymentsArray = Object.values(this._deploymentsMap);
+
+    this._healthyCount = this._deploymentsArray.filter(
+      (c) => c.isHealthy
+    ).length;
+
+    this._unhealthyCount = this._deploymentsArray.length - this._healthyCount;
+  }
+
+  public get length(): number {
+    return this._deploymentsArray.length;
+  }
+
+  public get healthyCount(): number {
+    return this._healthyCount;
+  }
+
+  public get unhealthyCount(): number {
+    return this._unhealthyCount;
+  }
+
+  public get isHealthy(): boolean {
+    console.log(this._unhealthyCount === 0)
+    return this._unhealthyCount === 0;
+  }
+
+  public get deployments(): ClusterDeployment[] {
+    return this._deploymentsArray;
+  }
+
+  public getCluster(name: string): ClusterDeployment | null {
+    return this._deploymentsMap[name] ?? null;
+  }
+}
+
+export class ClusterDeployment {
+  private _name: string;
+  private _namespace: string;
+  private _labels: Record<string, string>;
+  private _annotations: Record<string, string>;
+  private _spec: ClusterSpec;
+  private _status: ClusterStatus;
+  private _creation_time: string;
+  private _deletion_time?: string;
+  private _generation: number;
+
+  constructor(data: ClusterDeploymentData) {
+    this._name = data.name;
+    this._namespace = data.namespace;
+    this._labels = data.labels;
+    this._annotations = data.annotations;
+    this._creation_time = data.creation_time;
+    this._deletion_time = data.deletion_time;
+    this._generation = data.generation;
+    this._status = new ClusterStatus(data.status);
+    this._spec = new ClusterSpec(data.spec);
+  }
+
+  public get name(): string {
+    return this._name;
+  }
+
+  public get namespace(): string {
+    return this._namespace;
+  }
+
+  public get generation(): number {
+    return this._generation;
+  }
+
+  public get labels(): Record<string, string> {
+    return this._labels;
+  }
+
+  public get annotations(): Record<string, string> {
+    return this._annotations;
+  }
+
+  public get spec(): ClusterSpec {
+    return this._spec;
+  }
+
+  public get status(): ClusterStatus {
+    return this._status;
+  }
+
+  public get role(): ClusterRole | undefined {
+    const role: string = this._labels[CLUSTER_ROLE_LABEL];
+    if (role === "child" || role === "regional") {
+      return role;
+    }
+    return undefined;
+  }
+
+  public get isReady(): boolean {
+    return this.status.conditions.some(
+      (c) => c.type === "Ready" && c.status === "True"
+    );
+  }
+
+  public get totalStatusCount(): number {
+    return this._status.conditions.length;
+  }
+
+  public get healthyStatusCount(): number {
+    return this._status.conditions.filter((c) => c.status === "True").length;
+  }
+
+  public get unhealthyStatusCount(): number {
+    return this.totalStatusCount - this.healthyStatusCount;
+  }
+
+  public get isHealthy(): boolean {
+    return this.healthyStatusCount === this._status.conditions.length;
+  }
+
+  public get creationTime(): Date {
+    return new Date(this._creation_time);
+  }
+
+  public get deletionTime(): Date | null {
+    return this._deletion_time ? new Date(this._deletion_time) : null;
+  }
+
+  public get totalNodes(): number {
+    return (
+      this._spec.config.controlPlaneNumber + this._spec.config.workersNumber
+    );
+  }
+
+  public get ageInSeconds(): number {
+    const timeNow: number = Date.now();
+    const creationTime: number = this.creationTime.getTime();
+    return (timeNow - creationTime) / 1000;
+  }
+}
+
+export class ClusterSpec implements ClusterSpecData {
+  private _config: ClusterConfig;
+  private _template: string;
+  private _credential: string;
+  private _ipamClaim?: Record<string, unknown> | undefined;
+  private _serviceSpec?: ServiceSpecData | undefined;
+  private _propagateCredentials?: boolean | undefined;
+
+  constructor(data: ClusterSpecData) {
+    this._template = data.template;
+    this._credential = data.credential;
+    this._ipamClaim = data.ipamClaim;
+    this._serviceSpec = data.serviceSpec;
+    this._propagateCredentials = data.propagateCredentials;
+    this._config = new ClusterConfig(data.config);
+  }
+
+  public get config(): ClusterConfig {
+    return this._config;
+  }
+
+  public get template(): string {
+    return this._template;
+  }
+
+  public get credential(): string {
+    return this._credential;
+  }
+
+  public get ipamClaim(): Record<string, unknown> | undefined {
+    return this._ipamClaim;
+  }
+
+  public get serviceSpec(): ServiceSpecData | undefined {
+    return this._serviceSpec;
+  }
+
+  public get propagateCredentials(): boolean | undefined {
+    return this._propagateCredentials;
+  }
+
+  public get provider(): string {
+    return this._template.split("-")[0];
+  }
+}
+
+export class ClusterConfig implements ClusterConfigData {
+  private _clusterAnnotation?: Record<string, string>;
+  private _clusterIdentity: ClusterIdentityData;
+  private _controlPlane: ControlPlaneData;
+  private _controlPlaneNumber: number;
+  private _region: string;
+  private _worker: WorkerSpecData;
+  private _workersNumber: number;
+
+  constructor(data: ClusterConfigData) {
+    this._clusterAnnotation = data.clusterAnnotations;
+    this._clusterIdentity = data.clusterIdentity;
+    this._controlPlane = data.controlPlane;
+    this._controlPlaneNumber = data.controlPlaneNumber;
+    this._region = data.region;
+    this._worker = data.worker;
+    this._workersNumber = data.workersNumber;
+  }
+
+  public get clusterAnnotations(): Record<string, string> | undefined {
+    return this._clusterAnnotation;
+  }
+
+  public get clusterAnnotationsArray(): [string, string][] {
+    if (!this._clusterAnnotation) return [];
+    return Object.entries(this._clusterAnnotation);
+  }
+
+  public get clusterIdentity(): ClusterIdentityData {
+    return this._clusterIdentity;
+  }
+
+  public get controlPlane(): ControlPlaneData {
+    return this._controlPlane;
+  }
+
+  public get controlPlaneNumber(): number {
+    return this._controlPlaneNumber;
+  }
+
+  public get region(): string {
+    return this._region;
+  }
+
+  public get worker(): WorkerSpecData {
+    return this._worker;
+  }
+
+  public get workersNumber(): number {
+    return this._workersNumber;
+  }
+}
+
+export class ClusterStatus implements ClusterStatusData {
+  private _conditions: ClusterCondition[];
+  private _observedGeneration: number;
+
+  constructor(data: ClusterStatusData) {
+    this._conditions = data.conditions.map((c) => new ClusterCondition(c));
+    this._observedGeneration = data.observedGeneration;
+  }
+
+  public get conditions(): ClusterCondition[] {
+    return this._conditions;
+  }
+
+  public get observedGeneration(): number {
+    return this._observedGeneration;
+  }
+}
+
+export class ClusterCondition implements ClusterConditionData {
+  private _type: string;
+  private _status: string;
+  private _observedGeneration?: number | undefined;
+  private _lastTransitionTime: string;
+  private _lastTransitionTimeDate: Date;
+  private _reason: string;
+  private _message: string;
+
+  constructor(data: ClusterConditionData) {
+    this._lastTransitionTime = data.lastTransitionTime;
+    this._type = data.type;
+    this._status = data.status;
+    this._reason = data.reason;
+    this._message = data.message;
+    this._lastTransitionTimeDate = new Date(data.lastTransitionTime);
+  }
+
+  public get type(): string {
+    return this._type;
+  }
+
+  public get status(): string {
+    return this._status;
+  }
+
+  public get observedGeneration(): number | undefined {
+    return this._observedGeneration;
+  }
+
+  public get lastTransitionTime(): string {
+    return this._lastTransitionTime;
+  }
+
+  public get reason(): string {
+    return this._reason;
+  }
+
+  public get message(): string {
+    return this._message;
+  }
+
+  public get lastTransitionTimeDate(): Date {
+    return this._lastTransitionTimeDate;
+  }
+
+  public get isHealthy(): boolean {
+    return this._status === "True";
+  }
+}
+
+export interface ClusterDeploymentData {
+  name: string;
+  namespace: string;
+  labels: Record<string, string>;
+  annotations: Record<string, string>;
+  spec: ClusterSpecData;
+  status: ClusterStatusData;
+  generation: number;
+  creation_time: string;
+  deletion_time?: string;
+}
+
+export interface ClusterSpecData {
+  config: ClusterConfigData;
+  template: string;
+  credential: string;
+  ipamClaim?: Record<string, unknown>;
+  serviceSpec?: ServiceSpecData;
+  propagateCredentials?: boolean;
+}
+
+export interface ClusterConfigData {
+  clusterAnnotations?: Record<string, string>;
+  clusterIdentity: ClusterIdentityData;
+  controlPlane: ControlPlaneData;
+  controlPlaneNumber: number;
+  region: string;
+  worker: WorkerSpecData;
+  workersNumber: number;
+}
+
+export interface ClusterIdentityData {
+  name: string;
+  namespace: string;
+}
+
+export interface ControlPlaneData {
+  instanceType: string;
+}
+
+export interface WorkerSpecData {
+  instanceType: string;
+}
+
+export interface ServiceSpecData {
+  syncMode: string;
+  priority: number;
+}
+
+export interface ClusterStatusData {
+  conditions: ClusterConditionData[];
+  observedGeneration: number;
+}
+
+export interface ClusterConditionData {
+  type: string;
+  status: string;
+  observedGeneration?: number;
+  lastTransitionTime: string;
+  reason: string;
+  message: string;
+}

--- a/kof-operator/webapp/collector/src/components/shared/Loader.tsx
+++ b/kof-operator/webapp/collector/src/components/shared/Loader.tsx
@@ -1,0 +1,12 @@
+import { Loader as LoaderIcon } from "lucide-react";
+import { JSX } from "react";
+
+const Loader = (): JSX.Element => {
+  return (
+    <div className="flex w-full h-full justify-center items-center">
+      <LoaderIcon className="animate-spin w-8 h-8" />
+    </div>
+  );
+};
+
+export default Loader;

--- a/kof-operator/webapp/collector/src/providers/cluster_deployments/ClusterDeploymentsProvider.tsx
+++ b/kof-operator/webapp/collector/src/providers/cluster_deployments/ClusterDeploymentsProvider.tsx
@@ -1,0 +1,61 @@
+import { create } from "zustand";
+import {
+  ClusterDeployment,
+  ClusterDeploymentData,
+  ClusterDeploymentSet,
+} from "@/components/pages/clusterDeploymentsPage/models";
+
+interface ClusterDeploymentProviderState {
+  error?: Error;
+  isLoading: boolean;
+  data: ClusterDeploymentSet | null;
+  selectedCluster: ClusterDeployment | null;
+  fetch: () => Promise<void>;
+  setSelectedCluster: (name: string) => void;
+}
+
+interface ApiResponse {
+  cluster_deployments: Record<string, ClusterDeploymentData>;
+}
+
+export const useClusterDeploymentsProvider =
+  create<ClusterDeploymentProviderState>()((set, get) => {
+    const fetchClusters = async (): Promise<void> => {
+      try {
+        set({ isLoading: true, error: undefined });
+        const response = await fetch(
+          import.meta.env.VITE_CLUSTER_DEPLOYMENTS_URL,
+          {
+            method: "GET",
+          }
+        );
+
+        if (!response.ok) {
+          throw new Error(`Response status ${response.status}`);
+        }
+
+        const json = (await response.json()) as ApiResponse;
+        const map = new ClusterDeploymentSet(json.cluster_deployments);
+        set({ data: map, isLoading: false, error: undefined });
+      } catch (e) {
+        set({ data: null, error: e as Error, isLoading: false });
+      }
+    };
+
+    const setSelectedCluster = (name: string): void => {
+      const data = get().data;
+      if (data) {
+        set({ selectedCluster: data.getCluster(name) });
+      }
+    };
+
+    fetchClusters();
+
+    return {
+      isLoading: true,
+      data: null,
+      selectedCluster: null,
+      fetch: fetchClusters,
+      setSelectedCluster,
+    };
+  });

--- a/kof-operator/webapp/collector/src/utils/formatter.ts
+++ b/kof-operator/webapp/collector/src/utils/formatter.ts
@@ -27,3 +27,11 @@ export function formatTime(seconds: number): string {
   const minutes = duration.minutes();
   return `${days}d ${hours}h ${minutes}m`;
 }
+
+export function capitalizeFirstLetter(str: string): string {
+  return str.charAt(0).toUpperCase() + str.slice(1);
+}
+
+export function formatMetric(value: number, formatFn?: (value: number) => string): string {
+  return formatFn ? formatFn(value) : value.toString();
+}


### PR DESCRIPTION
Part of #76 

This PR adds a page to the KOF UI that allows monitoring the health and configuration of cluster deployments.

<img width="1327" height="382" alt="image" src="https://github.com/user-attachments/assets/6d1b4fd8-1c77-4ae6-9121-ac0c2bfcfc59" />

<img width="1311" height="791" alt="image" src="https://github.com/user-attachments/assets/44bb6443-ebcd-45aa-aeb3-2878cc27b25a" />

<img width="1322" height="603" alt="image" src="https://github.com/user-attachments/assets/d23ae273-3b36-4e4e-9f71-795cafc1bca8" />

<img width="1309" height="791" alt="image" src="https://github.com/user-attachments/assets/e8f32573-024e-4cbd-abfc-737a4eb17b06" />


