### PR TITLE
fix: Fix of warnings on helm install/upgrade of kof-collectors

### DIFF
--- a/charts/kof-collectors/templates/opentelemetry/clusterroles/ta-daemon.yaml
+++ b/charts/kof-collectors/templates/opentelemetry/clusterroles/ta-daemon.yaml
@@ -34,5 +34,5 @@ rules:
     resources:
     - ingresses
     verbs: ["get", "list", "watch"]
-  - nonResourceURLs: ["/metrics"]
+  - nonResourceURLs: ["/metrics", "/api", "/api/*", "/apis", "/apis/*"]
     verbs: ["get"]


### PR DESCRIPTION
* One of [Storing KOF data](https://docs.k0rdent.io/v1.3.0/admin/kof/kof-storing/) steps is:
  ```
  helm upgrade -i --reset-values --wait -n kof kof-collectors \
    -f collectors-values.yaml \
    oci://ghcr.io/k0rdent/kof/charts/kof-collectors --version 1.3.0
  ```
* It shows warnings:
  ```
  I0829 17:49:23.779836   19681 warnings.go:110] "Warning:
  missing the following rules for
  system:serviceaccount:kof:kof-collectors-ta-daemon-targetallocator
  - nonResourceURL: /api: [get]"
  - nonResourceURL: /api/*: [get]"
  - nonResourceURL: /apis: [get]"
  - nonResourceURL: /apis/*: [get]"
  ```
* This KOF PR replicates [this upstream change](https://github.com/open-telemetry/opentelemetry-operator/commit/ef60b5746a3868e1e26691fac8dfb9681e1fe5d8#diff-a87f83d050226c1136ce9517d76837c61877a6219b2fec3182854c73bd940ac3R40-R44) in `opentelemetry-operator`.
* Tested, the only warning left is the old known one, @aglarendil believes it will be auto-fixed on upgrade of `opentelemetry-operator` in future:
  ```
  I0902 15:57:44.051055   49465 warnings.go:110] "Warning:
  unknown field \"spec.targetAllocator.allocationFallbackStrategy\""
  ```
