### PR TITLE
fix: Typo `grafana-operator.enables/enabled`, dedup of this subchart, updated descriptions

### DIFF
--- a/charts/kof-child/Chart.yaml
+++ b/charts/kof-child/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: kof-child
-description: A Helm chart that installs multi cluster service template for kof child clusters
+description: KOF Helm chart with MultiClusterService template for KOF Child clusters
 version: "1.3.0"
 appVersion: "1.3.0"

--- a/charts/kof-collectors/Chart.yaml
+++ b/charts/kof-collectors/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: kof-collectors
-description: A Helm chart that deploys OpenTelemetryCollector resources
+description: KOF Helm chart with OpenTelemetryCollectors and OpenCost
 version: "1.3.0"
 appVersion: "1.3.0"
 dependencies:

--- a/charts/kof-dashboards/Chart.yaml
+++ b/charts/kof-dashboards/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: kof-dashboards
-description: A Helm chart that deploys Grafana Dashboards
+description: KOF Helm chart with collection of Grafana Dashboards
 version: "1.3.0"
 appVersion: "1.3.0"

--- a/charts/kof-istio/Chart.yaml
+++ b/charts/kof-istio/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: kof-istio
-description: A Helm chart that deploys Istio with multicluster multinetwork setup
+description: KOF Helm chart that deploys Istio with multicluster multinetwork setup
 version: "1.3.0"
 appVersion: "1.3.0"
 dependencies:

--- a/charts/kof-mothership/Chart.yaml
+++ b/charts/kof-mothership/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: kof-mothership
-description: A Helm chart that deploys Grafana, Promxy, and VictoriaMetrics.
+description: KOF Helm chart for KOF Management cluster
 version: "1.3.0"
 appVersion: "1.3.0"
 dependencies:

--- a/charts/kof-mothership/README.md
+++ b/charts/kof-mothership/README.md
@@ -2,7 +2,7 @@
 
 ![Version: 1.3.0](https://img.shields.io/badge/Version-1.3.0-informational?style=flat-square) ![AppVersion: 1.3.0](https://img.shields.io/badge/AppVersion-1.3.0-informational?style=flat-square)
 
-A Helm chart that deploys Grafana, Promxy, and VictoriaMetrics.
+KOF Helm chart for KOF Management cluster
 
 ## Requirements
 

--- a/charts/kof-operators/Chart.yaml
+++ b/charts/kof-operators/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: kof-operators
-description: A Helm chart that deploys opentelemetry-operator and prometheus CRDs
+description: KOF Helm chart that deploys operators and CRDs required by other KOF charts
 version: "1.3.0"
 appVersion: "1.3.0"
 dependencies:

--- a/charts/kof-operators/values.yaml
+++ b/charts/kof-operators/values.yaml
@@ -23,7 +23,7 @@ opentelemetry-operator:
     image:
       repository: quay.io/brancz/kube-rbac-proxy
 grafana-operator:
-  enables: true
+  enabled: true
   image:
     # -- Custom `grafana-operator` image repository.
     repository: ghcr.io/grafana/grafana-operator

--- a/charts/kof-regional/Chart.yaml
+++ b/charts/kof-regional/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: kof-regional
-description: A Helm chart that installs multi cluster service template for kof regional clusters
+description: KOF Helm chart with MultiClusterService template for KOF Regional clusters
 version: "1.3.0"
 appVersion: "1.3.0"

--- a/charts/kof-storage/Chart.lock
+++ b/charts/kof-storage/Chart.lock
@@ -1,7 +1,4 @@
 dependencies:
-- name: grafana-operator
-  repository: oci://ghcr.io/grafana/helm-charts
-  version: v5.18.0
 - name: victoria-metrics-operator
   repository: https://victoriametrics.github.io/helm-charts/
   version: 0.43.1
@@ -20,5 +17,5 @@ dependencies:
 - name: kof-dashboards
   repository: file://../kof-dashboards/
   version: 1.3.0
-digest: sha256:4074c219245817e6b02b91146b2c109a177b18c04ffc8f9bb91b00a8bb27828d
-generated: "2025-08-25T18:50:55.553733+02:00"
+digest: sha256:1217335bf92d712a5b5ca68ae039249c56f2b3e3d1cb381eb1015f136ed46323
+generated: "2025-09-02T17:32:02.652911+02:00"

--- a/charts/kof-storage/Chart.yaml
+++ b/charts/kof-storage/Chart.yaml
@@ -1,13 +1,9 @@
 apiVersion: v2
 name: kof-storage
-description: A Helm chart that deploys Grafana, and VictoriaMetrics.
+description: KOF Helm chart with Jaeger and VictoriaMetrics storage
 version: "1.3.0"
 appVersion: "1.3.0"
 dependencies:
-  - name: grafana-operator
-    version: "v5.18.0"
-    repository: "oci://ghcr.io/grafana/helm-charts"
-    condition: grafana.enabled
   - name: victoria-metrics-operator
     version: "0.43.1"
     repository: "https://victoriametrics.github.io/helm-charts/"

--- a/charts/kof-storage/values.yaml
+++ b/charts/kof-storage/values.yaml
@@ -10,11 +10,6 @@ global:
   # https://kubernetes.io/docs/concepts/storage/storage-classes/#default-storageclass
   # storageClass: ebs-csi-default-sc
 
-grafana-operator:
-  image:
-    # -- Custom `grafana-operator` image repository.
-    repository: ghcr.io/grafana/grafana-operator
-
 cert-manager:
   enabled: true
   cluster-issuer:


### PR DESCRIPTION
* There is a typo `grafana-operator.enables` (ends with "s") in 1.3.0 [kof-operators/values.yaml](https://github.com/k0rdent/kof/blob/v1.3.0/charts/kof-operators/values.yaml#L26),
  while `grafana-operator.enabled` (ends with "d") is expected in [kof-operators/Chart.yaml](https://github.com/k0rdent/kof/blob/v1.3.0/charts/kof-operators/Chart.yaml#L10)
  to determine if `grafana-operator` subchart should be installed.
* Despite this typo and expectation that non-existing field is falsy,
  `grafana-operator` was still installed due to unexpected Helm docs [here](https://helm.sh/docs/topics/charts/#tags-and-condition-fields-in-dependencies:~:text=if%20no%20paths%20exist%20then%20the%20condition%20has%20no%20effect):
  > if no paths exist then the condition has no effect.
* This PR fixes the typo anyway.
* It also deletes `grafana-operator` from `kof-storage`,
  because if `kof-storage` is installed,
  then `kof-operators` is installed too in all cases (but not vice versa),
  so the duplication of `grafana-operator` does not make sense.
* Tested `kof-storage` still works in management and regional clusters.
* Also updated charts descriptions as we've moved, added and deleted subcharts recently.
