### PR TITLE
fix: flatten event fields for better filtering

### DIFF
--- a/charts/kof-collectors/values.yaml
+++ b/charts/kof-collectors/values.yaml
@@ -56,6 +56,9 @@ opentelemetry-kube-stack:
                 conditions:
                   - IsMatch(attributes["k8s.resource.name"], "events")
                 statements:
+                  - delete_key(body["object"]["metadata"], "managedFields") where IsMap(body)
+                  - delete_key(body["object"], "eventTime") where IsMap(body)
+                  - flatten(body["object"], prefix="event", resolveConflicts=true) where IsMap(body)
                   - merge_maps(attributes, body["object"], "upsert") where IsMap(body)
           transform/k8scluster:
             metric_statements:
@@ -77,8 +80,8 @@ opentelemetry-kube-stack:
                   - merge_maps(datapoint.attributes, datapoint.cache["attrs"], "insert")
           resourcedetection:
             detectors:
-            - env
-            - kubeadm
+              - env
+              - kubeadm
             override: false
             timeout: 2s
         receivers:
@@ -100,21 +103,21 @@ opentelemetry-kube-stack:
             logs:
               exporters: null
               processors:
-              - resourcedetection
-              - resource/k8sclustername
-              - transform/events
-              - batch
+                - resourcedetection
+                - resource/k8sclustername
+                - transform/events
+                - batch
               receivers:
-              - k8sobjects
+                - k8sobjects
             metrics:
               exporters: null
               processors:
-              - resourcedetection            
-              - transform/k8scluster
-              - resource/k8sclustername
-              - batch
+                - resourcedetection
+                - transform/k8scluster
+                - resource/k8sclustername
+                - batch
               receivers:
-              - k8s_cluster
+                - k8s_cluster
       enabled: true
       labels:
         k0rdent.mirantis.com/kof-collector-metrics: "collector"
@@ -157,8 +160,8 @@ opentelemetry-kube-stack:
             timeout: 1s
           resourcedetection:
             detectors:
-            - env
-            - system
+              - env
+              - system
             override: false
             timeout: 2s
         receivers:
@@ -202,9 +205,9 @@ opentelemetry-kube-stack:
           memory: 500Mi
       suffix: ta-daemon
       tolerations:
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/master
-        operator: Exists
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/master
+          operator: Exists
     daemon:
       config:
         extensions:
@@ -260,13 +263,13 @@ opentelemetry-kube-stack:
                   - set(datapoint.attributes["nodename"], resource.attributes["k8s.node.name"])
           resourcedetection:
             detectors:
-            - env
-            - system
-            - ec2
-            - gcp
-            - azure
-            - k8snode
-            - kubeadm
+              - env
+              - system
+              - ec2
+              - gcp
+              - azure
+              - k8snode
+              - kubeadm
             override: false
             timeout: 2s
         receivers:
@@ -284,10 +287,14 @@ opentelemetry-kube-stack:
                         - role: pod
                           field: "spec.nodeName=${env:OTEL_K8S_NODE_NAME}"
                   relabel_configs:
-                    - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
+                    - source_labels:
+                        [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
                       action: keep
                       regex: true
-                    - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape_slow]
+                    - source_labels:
+                        [
+                          __meta_kubernetes_pod_annotation_prometheus_io_scrape_slow,
+                        ]
                       action: drop
                       regex: true
                     - source_labels: [__meta_kubernetes_pod_label_k8s_app]
@@ -300,19 +307,25 @@ opentelemetry-kube-stack:
                       regex: (?:[^:]+):(\d+)?;(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})
                       replacement: $$2:$$1
                       source_labels:
-                      - __address__
-                      - __meta_kubernetes_pod_annotation_prometheus_io_ip4
+                        - __address__
+                        - __meta_kubernetes_pod_annotation_prometheus_io_ip4
                       target_label: __address__
-                    - source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
+                    - source_labels:
+                        [
+                          __address__,
+                          __meta_kubernetes_pod_annotation_prometheus_io_port,
+                        ]
                       action: replace
                       regex: ([^:]+)(?::\d+)?;(\d+)
                       replacement: $$1:$$2
                       target_label: __address__
-                    - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scheme]
+                    - source_labels:
+                        [__meta_kubernetes_pod_annotation_prometheus_io_scheme]
                       action: replace
                       regex: (https?)
                       target_label: __scheme__
-                    - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_path]
+                    - source_labels:
+                        [__meta_kubernetes_pod_annotation_prometheus_io_path]
                       action: replace
                       target_label: __metrics_path__
                       regex: (.+)
@@ -335,7 +348,8 @@ opentelemetry-kube-stack:
                       regex: Pending|Succeeded|Failed|Completed
                       action: drop
                     - action: replace
-                      source_labels: [__meta_kubernetes_pod_label_app_kubernetes_io_name]
+                      source_labels:
+                        [__meta_kubernetes_pod_label_app_kubernetes_io_name]
                       target_label: job
                     - action: replace
                       regex: "^$$;(.+)"
@@ -361,43 +375,43 @@ opentelemetry-kube-stack:
                         - role: node
                           field: "metadata.name=${env:OTEL_K8S_NODE_NAME}"
                   metric_relabel_configs:
-                #    - action: drop
-                #      regex: container_cpu_(load_average_10s|system_seconds_total|user_seconds_total)
-                #      replacement: "$$1"
-                #      separator: ";"
-                #      source_labels:
-                #        - __name__
-                #    - action: drop
-                #      regex: container_fs_(io_current|reads_merged_total|sector_reads_total|sector_writes_total|writes_merged_total)
-                #      replacement: "$$1"
-                #      separator: ";"
-                #      source_labels:
-                #        - __name__
-                #    - action: drop
-                #      regex: container_memory_(mapped_file|swap)
-                #      replacement: "$$1"
-                #      separator: ";"
-                #      source_labels:
-                #        - __name__
-                #    - action: drop
-                #      regex: container_(file_descriptors|tasks_state|threads_max)
-                #      replacement: "$$1"
-                #      separator: ";"
-                #      source_labels:
-                #        - __name__
-                #    - action: drop
-                #      regex: container_spec.*
-                #      replacement: "$$1"
-                #      separator: ";"
-                #      source_labels:
-                #        - __name__
-                #    - action: drop
-                #      regex: ".+;"
-                #      replacement: "$$1"
-                #      separator: ";"
-                #      source_labels:
-                #        - id
-                #        - pod
+                  #    - action: drop
+                  #      regex: container_cpu_(load_average_10s|system_seconds_total|user_seconds_total)
+                  #      replacement: "$$1"
+                  #      separator: ";"
+                  #      source_labels:
+                  #        - __name__
+                  #    - action: drop
+                  #      regex: container_fs_(io_current|reads_merged_total|sector_reads_total|sector_writes_total|writes_merged_total)
+                  #      replacement: "$$1"
+                  #      separator: ";"
+                  #      source_labels:
+                  #        - __name__
+                  #    - action: drop
+                  #      regex: container_memory_(mapped_file|swap)
+                  #      replacement: "$$1"
+                  #      separator: ";"
+                  #      source_labels:
+                  #        - __name__
+                  #    - action: drop
+                  #      regex: container_(file_descriptors|tasks_state|threads_max)
+                  #      replacement: "$$1"
+                  #      separator: ";"
+                  #      source_labels:
+                  #        - __name__
+                  #    - action: drop
+                  #      regex: container_spec.*
+                  #      replacement: "$$1"
+                  #      separator: ";"
+                  #      source_labels:
+                  #        - __name__
+                  #    - action: drop
+                  #      regex: ".+;"
+                  #      replacement: "$$1"
+                  #      separator: ";"
+                  #      source_labels:
+                  #        - id
+                  #        - pod
                   metrics_path: "/metrics/cadvisor"
                   relabel_configs:
                     - action: replace
@@ -601,93 +615,93 @@ opentelemetry-kube-stack:
                   tls_config:
                     ca_file: "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
           filelog/containers:
-  #          storage: file_storage
+            #          storage: file_storage
             exclude: []
             include:
-            - /var/log/pods/*/*/*.log
+              - /var/log/pods/*/*/*.log
             include_file_name: false
             include_file_path: true
             operators:
-            - id: container-parser
-              max_log_size: 102400
-              type: container
-            - id: extract_metadata_from_filepath
-              on_error: drop_quiet
-              parse_from: attributes["log.file.path"]
-              regex: ^.*\/(?P<namespace>[^_]+)_(?P<pod_name>[^_]+)_(?P<uid>[a-f0-9\-]{36})\/(?P<container_name>[^\._]+)\/(?P<restart_count>\d+)\.log$
-              type: regex_parser
-            - from: attributes.container_name
-              to: resource["k8s.container.name"]
-              type: move
-            - from: attributes.namespace
-              to: resource["k8s.namespace.name"]
-              type: move
-            - from: attributes.pod_name
-              to: resource["k8s.pod.name"]
-              type: move
-            - from: attributes.restart_count
-              to: resource["k8s.container.restart_count"]
-              type: move
-            - from: attributes.uid
-              to: resource["k8s.pod.uid"]
-              type: move
-            - id: extract_log_level
-              on_error: send_quiet
-              parse_from: body
-              regex: (?i)(?P<log_level>(panic|fatal|crit|alert|emerg|err(?:or)?|warn(?:ing)?|info|debug|notice|trace|(?-i:[EFDWI]\d{4}\s+)))
-              type: regex_parser
-            - id: extract_short_letter
-              if: ("log_level" in attributes)
-              on_error: send_quiet
-              parse_from: attributes["log_level"]
-              regex: (?i)(?P<log_level>[EFDWI])\d{4}
-              type: regex_parser
-            - field: attributes.log_level
-              if: '!("log_level" in attributes)'
-              type: add
-              value: info
-            - mapping:
-                debug:
-                - debug
-                - D
-                error:
-                - error
-                - err
-                - failed
-                - E
-                fatal:
-                - fatal
-                - crit
-                - alert
-                - emerg
-                - panic
-                - F
-                info:
-                - info
-                - notice
-                - trace
-                - I
-                warn:
-                - warn
-                - warning
-                - W
-              overwrite_text: true
-              parse_from: attributes.log_level
-              preset: none
-              type: severity_parser
-            - cache:
-                size: 128
-              field: attributes.log_level
-              type: remove
+              - id: container-parser
+                max_log_size: 102400
+                type: container
+              - id: extract_metadata_from_filepath
+                on_error: drop_quiet
+                parse_from: attributes["log.file.path"]
+                regex: ^.*\/(?P<namespace>[^_]+)_(?P<pod_name>[^_]+)_(?P<uid>[a-f0-9\-]{36})\/(?P<container_name>[^\._]+)\/(?P<restart_count>\d+)\.log$
+                type: regex_parser
+              - from: attributes.container_name
+                to: resource["k8s.container.name"]
+                type: move
+              - from: attributes.namespace
+                to: resource["k8s.namespace.name"]
+                type: move
+              - from: attributes.pod_name
+                to: resource["k8s.pod.name"]
+                type: move
+              - from: attributes.restart_count
+                to: resource["k8s.container.restart_count"]
+                type: move
+              - from: attributes.uid
+                to: resource["k8s.pod.uid"]
+                type: move
+              - id: extract_log_level
+                on_error: send_quiet
+                parse_from: body
+                regex: (?i)(?P<log_level>(panic|fatal|crit|alert|emerg|err(?:or)?|warn(?:ing)?|info|debug|notice|trace|(?-i:[EFDWI]\d{4}\s+)))
+                type: regex_parser
+              - id: extract_short_letter
+                if: ("log_level" in attributes)
+                on_error: send_quiet
+                parse_from: attributes["log_level"]
+                regex: (?i)(?P<log_level>[EFDWI])\d{4}
+                type: regex_parser
+              - field: attributes.log_level
+                if: '!("log_level" in attributes)'
+                type: add
+                value: info
+              - mapping:
+                  debug:
+                    - debug
+                    - D
+                  error:
+                    - error
+                    - err
+                    - failed
+                    - E
+                  fatal:
+                    - fatal
+                    - crit
+                    - alert
+                    - emerg
+                    - panic
+                    - F
+                  info:
+                    - info
+                    - notice
+                    - trace
+                    - I
+                  warn:
+                    - warn
+                    - warning
+                    - W
+                overwrite_text: true
+                parse_from: attributes.log_level
+                preset: none
+                type: severity_parser
+              - cache:
+                  size: 128
+                field: attributes.log_level
+                type: remove
             retry_on_failure:
               enabled: true
             start_at: end
-  
+
           filelog/syslog:
-  #          storage: file_storage
+            #          storage: file_storage
             exclude: []
             include:
-            - /hostfs/var/log/syslog
+              - /hostfs/var/log/syslog
             include_file_name: false
             include_file_path: true
             retry_on_failure:
@@ -697,31 +711,31 @@ opentelemetry-kube-stack:
           pipelines:
             logs:
               processors:
-              - resource/k8sclustername
-              - resourcedetection
-              - transform/syslog
-              - batch
+                - resource/k8sclustername
+                - resourcedetection
+                - transform/syslog
+                - batch
               receivers:
-              - otlp
-              - filelog/containers
-              - filelog/syslog
+                - otlp
+                - filelog/containers
+                - filelog/syslog
               exporters: null
             metrics:
               processors:
-              - resourcedetection
-              - transform/kubeletstats
-              - transform/hostmetrics
-              - transform/k8snode
-              - batch
+                - resourcedetection
+                - transform/kubeletstats
+                - transform/hostmetrics
+                - transform/k8snode
+                - batch
               receivers: null
               exporters: null
             traces:
               exporters: null
               processors:
-              - resourcedetection
-              - batch
+                - resourcedetection
+                - batch
               receivers:
-              - otlp
+                - otlp
       enabled: true
       labels:
         k0rdent.mirantis.com/kof-collector-metrics: "collector"
@@ -753,9 +767,9 @@ opentelemetry-kube-stack:
       scrape_configs_file: ""
       suffix: daemon
       tolerations:
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/master
-        operator: Exists
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/master
+          operator: Exists
       volumes:
         - name: varlogpods
           hostPath:
@@ -807,11 +821,11 @@ opentelemetry-kube-stack:
                   - set(datapoint.attributes["nodename"], resource.attributes["k8s.node.name"])
           resourcedetection:
             detectors:
-            - env
-            - system
-            - ec2
-            - gcp
-            - azure
+              - env
+              - system
+              - ec2
+              - gcp
+              - azure
             override: false
             timeout: 2s
         receivers:
@@ -891,15 +905,15 @@ opentelemetry-kube-stack:
             collection_interval: 10s
             endpoint: https://${env:OTEL_K8S_NODE_IP}:10250
             extra_metadata_labels:
-            - container.id
-            - k8s.volume.type
+              - container.id
+              - k8s.volume.type
             k8s_api_config:
               auth_type: serviceAccount
             metric_groups:
-            - node
-            - pod
-            - volume
-            - container
+              - node
+              - pod
+              - volume
+              - container
           otlp:
             protocols:
               grpc:
@@ -910,18 +924,18 @@ opentelemetry-kube-stack:
           pipelines:
             metrics:
               processors:
-              - resourcedetection
-              - transform/kubeletstats
-              - transform/hostmetrics
-              - transform/k8snode
-              - batch
+                - resourcedetection
+                - transform/kubeletstats
+                - transform/hostmetrics
+                - transform/k8snode
+                - batch
               receivers:
-              - prometheus
+                - prometheus
             logs:
               receivers:
-               - nop
+                - nop
               exporters:
-               - nop
+                - nop
             traces:
               receivers:
                 - nop
@@ -950,12 +964,12 @@ opentelemetry-kube-stack:
         prometheus.io/ip4: ${env:OTEL_K8S_NODE_IP}
         prometheus.io/port: "18888"
       ports:
-      - name: metrics
-        port: 18888
-        protocol: TCP
-      - name: api-server
-        port: 19090
-        protocol: TCP
+        - name: metrics
+          port: 18888
+          protocol: TCP
+        - name: api-server
+          port: 19090
+          protocol: TCP
       presets:
         hostMetrics:
           enabled: false
@@ -976,9 +990,9 @@ opentelemetry-kube-stack:
         node-role.kubernetes.io/control-plane: "true"
       suffix: controller-k0s-daemon
       tolerations:
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/master
-        operator: Exists
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/master
+          operator: Exists
       volumes:
         - name: hostfs
           hostPath:
@@ -1030,7 +1044,7 @@ opentelemetry-kube-stack:
         otlphttp/traces:
           endpoint: http://kof-storage-jaeger-collector:4318
         otlphttp/logs:
-          logs_endpoint: http://kof-storage-victoria-logs-cluster-vlinsert:9481/insert/opentelemetry/v1/logs 
+          logs_endpoint: http://kof-storage-victoria-logs-cluster-vlinsert:9481/insert/opentelemetry/v1/logs
       receivers:
         nop: {}
         otlp:
@@ -1042,10 +1056,10 @@ opentelemetry-kube-stack:
         prometheus:
           config:
             scrape_configs:
-            - job_name: dummy
-              scrape_interval: 600s
-              static_configs:
-                - targets: []
+              - job_name: dummy
+                scrape_interval: 600s
+                static_configs:
+                  - targets: []
           api_server:
             enabled: true
             server_config:
@@ -1064,21 +1078,21 @@ opentelemetry-kube-stack:
         pipelines:
           logs:
             exporters:
-            - otlphttp/logs
-            - debug
+              - otlphttp/logs
+              - debug
           metrics:
             exporters:
-            - prometheusremotewrite
-            - debug
+              - prometheusremotewrite
+              - debug
             receivers:
-            - prometheus
-            - otlp
+              - prometheus
+              - otlp
           traces:
             exporters:
-            - otlphttp/traces
-            - debug
+              - otlphttp/traces
+              - debug
             receivers:
-            - otlp
+              - otlp
     configmaps: []
     enabled: false
     env: []
@@ -1166,13 +1180,13 @@ opentelemetry-kube-stack:
     nginx: {}
     nodejs: {}
     propagators:
-    - tracecontext
-    - baggage
-    - b3
-    - b3multi
-    - jaeger
-    - xray
-    - ottrace
+      - tracecontext
+      - baggage
+      - b3
+      - b3multi
+      - jaeger
+      - xray
+      - ottrace
     python: {}
     resource:
       addK8sUIDAttributes: true
@@ -1181,38 +1195,38 @@ opentelemetry-kube-stack:
   kube-state-metrics:
     initContainers:
       - command:
-        - /bin/sh
-        - -c
-        - |
-          cat << EOF > "/etc/config/crd-metrics-config.yaml"
-          kind: CustomResourceStateMetrics
-          spec:
-            resources: []
-          EOF
+          - /bin/sh
+          - -c
+          - |
+            cat << EOF > "/etc/config/crd-metrics-config.yaml"
+            kind: CustomResourceStateMetrics
+            spec:
+              resources: []
+            EOF
         image: kiwigrid/k8s-sidecar:latest
         name: init-crd-config
         volumeMounts:
-        - mountPath: /etc/config
-          name: config-volume
+          - mountPath: /etc/config
+            name: config-volume
     containers:
       - env:
-        - name: LABEL
-          value: kube-state-metrics/custom-resource
-        - name: FOLDER
-          value: /tmp
-        - name: RESOURCE
-          value: configmap
-        - name: NAMESPACE
-          value: kof 
-        - name: SCRIPT
-          value: /script/compile.sh
+          - name: LABEL
+            value: kube-state-metrics/custom-resource
+          - name: FOLDER
+            value: /tmp
+          - name: RESOURCE
+            value: configmap
+          - name: NAMESPACE
+            value: kof
+          - name: SCRIPT
+            value: /script/compile.sh
         image: kiwigrid/k8s-sidecar:latest
         name: crd-sidecar
         volumeMounts:
-        - mountPath: /etc/config
-          name: config-volume
-        - mountPath: /script
-          name: compile-script
+          - mountPath: /etc/config
+            name: config-volume
+          - mountPath: /script
+            name: compile-script
     extraArgs:
       - --custom-resource-state-config-file=/etc/config/crd-metrics-config.yaml
     namespaceOverride: ""
@@ -1234,13 +1248,13 @@ opentelemetry-kube-stack:
       create: true
       extraRules:
         - apiGroups:
-          - apiextensions.k8s.io
+            - apiextensions.k8s.io
           resources:
-          - customresourcedefinitions
+            - customresourcedefinitions
           verbs:
-          - get
-          - list
-          - watch
+            - get
+            - list
+            - watch
     releaseLabel: true
     selfMonitor:
       enabled: true
@@ -1264,11 +1278,11 @@ opentelemetry-kube-stack:
       labelNameLengthLimit: 0
       labelValueLengthLimit: 0
       metricRelabelings:
-      - action: drop
-        regex: apiserver_request_duration_seconds_bucket;(0.15|0.2|0.3|0.35|0.4|0.45|0.6|0.7|0.8|0.9|1.25|1.5|1.75|2|3|3.5|4|4.5|6|7|8|9|15|25|40|50)
-        sourceLabels:
-        - __name__
-        - le
+        - action: drop
+          regex: apiserver_request_duration_seconds_bucket;(0.15|0.2|0.3|0.35|0.4|0.45|0.6|0.7|0.8|0.9|1.25|1.5|1.75|2|3|3.5|4|4.5|6|7|8|9|15|25|40|50)
+          sourceLabels:
+            - __name__
+            - le
       proxyUrl: ""
       relabelings: []
       sampleLimit: 0
@@ -1487,8 +1501,8 @@ opentelemetry-kube-stack:
         repository: otel/opentelemetry-collector-k8s
   prometheus-node-exporter:
     extraArgs:
-    - --collector.filesystem.mount-points-exclude=^/(dev|proc|sys|var/lib/docker/.+|var/lib/kubelet/.+)($|/)
-    - --collector.filesystem.fs-types-exclude=^(autofs|binfmt_misc|bpf|cgroup2?|configfs|debugfs|devpts|devtmpfs|fusectl|hugetlbfs|iso9660|mqueue|nsfs|overlay|proc|procfs|pstore|rpc_pipefs|securityfs|selinuxfs|squashfs|sysfs|tracefs)$
+      - --collector.filesystem.mount-points-exclude=^/(dev|proc|sys|var/lib/docker/.+|var/lib/kubelet/.+)($|/)
+      - --collector.filesystem.fs-types-exclude=^(autofs|binfmt_misc|bpf|cgroup2?|configfs|debugfs|devpts|devtmpfs|fusectl|hugetlbfs|iso9660|mqueue|nsfs|overlay|proc|procfs|pstore|rpc_pipefs|securityfs|selinuxfs|squashfs|sysfs|tracefs)$
     namespaceOverride: ""
     podLabels:
       jobLabel: node-exporter
@@ -1503,18 +1517,18 @@ opentelemetry-kube-stack:
         metricRelabelings: []
         proxyUrl: ""
         relabelings:
-        - sourceLabels: [__meta_kubernetes_pod_node_name]
-          separator: ;
-          regex: ^(.*)$
-          targetLabel: nodename
-          replacement: $1
-          action: replace
-        - sourceLabels: [__meta_kubernetes_pod_node_name]
-          separator: ;
-          regex: ^(.*)$
-          targetLabel: node
-          replacement: $1
-          action: replace
+          - sourceLabels: [__meta_kubernetes_pod_node_name]
+            separator: ;
+            regex: ^(.*)$
+            targetLabel: nodename
+            replacement: $1
+            action: replace
+          - sourceLabels: [__meta_kubernetes_pod_node_name]
+            separator: ;
+            regex: ^(.*)$
+            targetLabel: node
+            replacement: $1
+            action: replace
         sampleLimit: 0
         scrapeTimeout: ""
         targetLimit: 0

--- a/charts/kof-dashboards/files/dashboards/kubernetes-events/kubernetes-events-dashboard.yaml
+++ b/charts/kof-dashboards/files/dashboards/kubernetes-events/kubernetes-events-dashboard.yaml
@@ -6,7 +6,7 @@ annotations:
         uid: grafana
       enable: true
       hide: true
-      iconColor: 'rgba(0, 211, 255, 1)'
+      iconColor: "rgba(0, 211, 255, 1)"
       name: Annotations & Alerts
       target:
         limit: 100
@@ -28,14 +28,14 @@ panels:
       h: 1
       w: 24
       x: 0
-      'y': 0
+      "y": 0
     id: 34
     panels: []
     title: Kubernetes Events - Details
     type: row
   - datasource:
       type: victoriametrics-logs-datasource
-      uid: '${datasource}'
+      uid: "${datasource}"
     fieldConfig:
       defaults:
         color:
@@ -108,10 +108,10 @@ panels:
               value: 101
         - matcher:
             id: byName
-            options: Involved Object
+            options: Note
           properties:
             - id: custom.width
-              value: 164
+              value: 434
         - matcher:
             id: byName
             options: Source
@@ -138,12 +138,6 @@ panels:
               value: 131
         - matcher:
             id: byName
-            options: Involved Object
-          properties:
-            - id: custom.width
-              value: 217
-        - matcher:
-            id: byName
             options: Count
           properties:
             - id: custom.width
@@ -166,18 +160,24 @@ panels:
           properties:
             - id: custom.width
               value: 105
+        - matcher:
+            id: byType
+            options: string
+          properties:
+            - id: filterable
+              value: true
     gridPos:
       h: 13
       w: 24
       x: 0
-      'y': 1
+      "y": 1
     id: 36
     options:
       cellHeight: sm
       footer:
         countRows: false
         enablePagination: true
-        fields: ''
+        fields: ""
         reducer:
           - sum
         show: false
@@ -189,7 +189,7 @@ panels:
     targets:
       - datasource:
           type: loki
-          uid: '${datasource}'
+          uid: "${datasource}"
         editorMode: code
         expr: |-
           k8s.namespace.name:~"$namespace"
@@ -202,40 +202,24 @@ panels:
         options:
           format: kvp
           source: labels
-      - id: extractFields
-        options:
-          format: json
-          jsonPaths:
-            - alias: Kind
-              path: kind
-            - alias: Source
-              path: name
-          source: regarding
-      - id: extractFields
-        options:
-          format: json
-          jsonPaths:
-            - alias: Created
-              path: creationTimestamp
-          source: metadata
       - id: organize
         options:
           excludeByName:
-            '0': true
-            '1': true
-            '2': true
-            '3': true
-            '4': true
-            '5': true
-            '6': true
-            '7': true
-            '8': true
-            '9': true
-            '10': true
-            '11': true
-            '12': true
-            '13': true
-            '14': true
+            "0": true
+            "1": true
+            "2": true
+            "3": true
+            "4": true
+            "5": true
+            "6": true
+            "7": true
+            "8": true
+            "9": true
+            "10": true
+            "11": true
+            "12": true
+            "13": true
+            "14": true
             Line: true
             Time: false
             _stream_id: true
@@ -243,8 +227,28 @@ panels:
             deprecatedFirstTimestamp: true
             deprecatedLastTimestamp: true
             deprecatedSource: true
+            event.apiVersion: true
+            event.deprecatedFirstTimestamp: true
+            event.deprecatedLastTimestamp: true
+            event.deprecatedSource.component: true
+            event.deprecatedSource.host: true
             event.domain: true
+            event.kind: true
+            event.metadata.creationTimestamp: true
+            event.metadata.name: true
+            event.metadata.namespace: true
+            event.metadata.resourceVersion: true
+            event.metadata.uid: true
+            event.metadata.annotations.generation: true
+            event.name: true
+            event.regarding.apiVersion: true
+            event.regarding.resourceVersion: true
+            event.regarding.uid: true
+            event.regarding.fieldPath: true
+            event.reportingController: true
+            event.reportingInstance: true
             k8s.event.uid: true
+            k8s.namespace.name: true
             k8s.node.name: true
             k8s.object.api_version: true
             k8s.object.fieldpath: true
@@ -261,40 +265,58 @@ panels:
             severity: true
           includeByName: {}
           indexByName:
-            Created: 8
-            Kind: 4
-            Line: 23
-            Source: 6
-            Time: 9
-            _stream_id: 11
-            apiVersion: 13
-            deprecatedCount: 7
-            deprecatedFirstTimestamp: 14
-            deprecatedLastTimestamp: 15
-            deprecatedSource: 16
-            event.domain: 17
-            event.name: 5
-            k8s.namespace.name: 3
-            k8s.resource.name: 18
-            kind: 19
-            labels: 10
-            level: 12
-            metadata: 20
-            note: 1
-            reason: 2
-            regarding: 21
-            reportingController: 22
-            severity: 24
-            type: 0
+            Line: 9
+            Time: 0
+            _stream_id: 5
+            event.apiVersion: 11
+            event.deprecatedCount: 2
+            event.deprecatedFirstTimestamp: 12
+            event.deprecatedLastTimestamp: 13
+            event.deprecatedSource.component: 14
+            event.deprecatedSource.host: 33
+            event.domain: 7
+            event.kind: 15
+            event.metadata.creationTimestamp: 16
+            event.metadata.name: 17
+            event.metadata.namespace: 18
+            event.metadata.resourceVersion: 19
+            event.metadata.uid: 20
+            event.name: 3
+            event.note: 21
+            event.reason: 22
+            event.regarding.apiVersion: 23
+            event.regarding.fieldPath: 34
+            event.regarding.kind: 24
+            event.regarding.name: 25
+            event.regarding.namespace: 26
+            event.regarding.resourceVersion: 27
+            event.regarding.uid: 28
+            event.reportingController: 29
+            event.reportingInstance: 35
+            event.type: 30
+            k8s.cluster.name: 31
+            k8s.cluster.namespace: 32
+            k8s.namespace.name: 1
+            k8s.resource.name: 8
+            labels: 4
+            level: 6
+            severity: 10
           renameByName:
             Kind: Kind
-            Line: ''
+            Line: ""
             Time: Last Seen
             deprecatedCount: Count
-            event.name: Involved Object
+            event.deprecatedCount: Count
+            event.name: ""
+            event.note: Note
+            event.reason: Reason
+            event.regarding.kind: Kind
+            event.regarding.name: Object
+            event.regarding.namespace: Namespace
+            event.type: Type
             k8s.cluster.name: Cluster Name
+            k8s.cluster.namespace: Cluster Namespace
             k8s.event.count: Count
-            k8s.event.name: Involved Object
             k8s.event.reason: Reason
             k8s.event.start_time: Created
             k8s.namespace.name: Namespace
@@ -302,7 +324,7 @@ panels:
             k8s.object.name: Source
             note: Message
             reason: Reason
-            severity: ''
+            severity: ""
             type: Type
     type: table
   - collapsed: false
@@ -310,14 +332,14 @@ panels:
       h: 1
       w: 24
       x: 0
-      'y': 14
+      "y": 14
     id: 32
     panels: []
     title: Kubernetes Events - Stats
     type: row
   - datasource:
       type: victoriametrics-logs-datasource
-      uid: '${datasource}'
+      uid: "${datasource}"
     fieldConfig:
       defaults:
         color:
@@ -326,7 +348,7 @@ panels:
           axisBorderShow: false
           axisCenteredZero: false
           axisColorMode: text
-          axisLabel: ''
+          axisLabel: ""
           axisPlacement: left
           barAlignment: 0
           drawStyle: bars
@@ -348,7 +370,7 @@ panels:
             group: A
             mode: normal
           thresholdsStyle:
-            mode: 'off'
+            mode: "off"
         mappings: []
         thresholds:
           mode: absolute
@@ -362,7 +384,7 @@ panels:
       h: 8
       w: 12
       x: 0
-      'y': 15
+      "y": 15
     id: 2
     interval: 1m
     options:
@@ -377,7 +399,7 @@ panels:
     targets:
       - datasource:
           type: loki
-          uid: '${datasource}'
+          uid: "${datasource}"
         editorMode: code
         expr: |-
           k8s.namespace.name:~"$namespace"
@@ -386,12 +408,12 @@ panels:
         legendFormat: "{{`{{type}}`}}"
         queryType: statsRange
         refId: A
-        step: ''
+        step: ""
     title: Overview
     type: timeseries
   - datasource:
       type: victoriametrics-logs-datasource
-      uid: '${datasource}'
+      uid: "${datasource}"
     fieldConfig:
       defaults:
         color:
@@ -400,7 +422,7 @@ panels:
           axisBorderShow: false
           axisCenteredZero: false
           axisColorMode: text
-          axisLabel: ''
+          axisLabel: ""
           axisPlacement: auto
           barAlignment: 0
           drawStyle: line
@@ -422,7 +444,7 @@ panels:
             group: A
             mode: none
           thresholdsStyle:
-            mode: 'off'
+            mode: "off"
         mappings: []
         thresholds:
           mode: absolute
@@ -456,7 +478,7 @@ panels:
                   severity:="Warning"
 
                   | stats count()
-              prefix: 'All except:'
+              prefix: "All except:"
               readOnly: true
           properties:
             - id: custom.hideFrom
@@ -468,7 +490,7 @@ panels:
       h: 8
       w: 12
       x: 12
-      'y': 15
+      "y": 15
     id: 4
     interval: 1m
     options:
@@ -484,7 +506,7 @@ panels:
     targets:
       - datasource:
           type: loki
-          uid: '${datasource}'
+          uid: "${datasource}"
         editorMode: code
         expr: |-
           k8s.namespace.name:~"$namespace"
@@ -500,13 +522,13 @@ panels:
     type: timeseries
   - datasource:
       type: victoriametrics-logs-datasource
-      uid: '${datasource}'
+      uid: "${datasource}"
     fieldConfig:
       defaults:
         color:
           mode: thresholds
         mappings: []
-        noValue: '0'
+        noValue: "0"
         thresholds:
           mode: absolute
           steps:
@@ -519,7 +541,7 @@ panels:
       h: 5
       w: 3
       x: 0
-      'y': 23
+      "y": 23
     id: 6
     interval: 1m
     options:
@@ -530,7 +552,7 @@ panels:
       reduceOptions:
         calcs:
           - last
-        fields: ''
+        fields: ""
         values: false
       showPercentChange: false
       text: {}
@@ -540,14 +562,14 @@ panels:
     targets:
       - datasource:
           type: loki
-          uid: '${datasource}'
+          uid: "${datasource}"
         editorMode: code
         expr: |-
           k8s.namespace.name:~"$namespace"
           reason:="Failed"
           _msg:~"ImagePullBackOff"
           | stats count()
-        legendFormat: ''
+        legendFormat: ""
         queryType: stats
         range: true
         refId: A
@@ -555,13 +577,13 @@ panels:
     type: stat
   - datasource:
       type: victoriametrics-logs-datasource
-      uid: '${datasource}'
+      uid: "${datasource}"
     fieldConfig:
       defaults:
         color:
           mode: thresholds
         mappings: []
-        noValue: '0'
+        noValue: "0"
         thresholds:
           mode: absolute
           steps:
@@ -574,7 +596,7 @@ panels:
       h: 5
       w: 3
       x: 3
-      'y': 23
+      "y": 23
     id: 14
     interval: 1m
     options:
@@ -585,7 +607,7 @@ panels:
       reduceOptions:
         calcs:
           - last
-        fields: ''
+        fields: ""
         values: false
       showPercentChange: false
       text: {}
@@ -595,7 +617,7 @@ panels:
     targets:
       - datasource:
           type: loki
-          uid: '${datasource}'
+          uid: "${datasource}"
         editorMode: code
         expr: |-
           k8s.namespace.name:~"$namespace"
@@ -609,13 +631,13 @@ panels:
     type: stat
   - datasource:
       type: victoriametrics-logs-datasource
-      uid: '${datasource}'
+      uid: "${datasource}"
     fieldConfig:
       defaults:
         color:
           mode: thresholds
         mappings: []
-        noValue: '0'
+        noValue: "0"
         thresholds:
           mode: absolute
           steps:
@@ -628,7 +650,7 @@ panels:
       h: 5
       w: 3
       x: 6
-      'y': 23
+      "y": 23
     id: 41
     interval: 1m
     options:
@@ -639,7 +661,7 @@ panels:
       reduceOptions:
         calcs:
           - last
-        fields: ''
+        fields: ""
         values: false
       showPercentChange: false
       text: {}
@@ -649,7 +671,7 @@ panels:
     targets:
       - datasource:
           type: loki
-          uid: '${datasource}'
+          uid: "${datasource}"
         editorMode: code
         expr: |-
           k8s.namespace.name:~"$namespace"
@@ -662,13 +684,13 @@ panels:
     type: stat
   - datasource:
       type: victoriametrics-logs-datasource
-      uid: '${datasource}'
+      uid: "${datasource}"
     fieldConfig:
       defaults:
         color:
           mode: thresholds
         mappings: []
-        noValue: '0'
+        noValue: "0"
         thresholds:
           mode: absolute
           steps:
@@ -681,7 +703,7 @@ panels:
       h: 5
       w: 3
       x: 9
-      'y': 23
+      "y": 23
     id: 16
     interval: 1m
     options:
@@ -692,7 +714,7 @@ panels:
       reduceOptions:
         calcs:
           - last
-        fields: ''
+        fields: ""
         values: false
       showPercentChange: false
       text:
@@ -703,7 +725,7 @@ panels:
     targets:
       - datasource:
           type: loki
-          uid: '${datasource}'
+          uid: "${datasource}"
         editorMode: code
         expr: |-
           k8s.namespace.name:~"$namespace"
@@ -716,13 +738,13 @@ panels:
     type: stat
   - datasource:
       type: victoriametrics-logs-datasource
-      uid: '${datasource}'
+      uid: "${datasource}"
     fieldConfig:
       defaults:
         color:
           mode: thresholds
         mappings: []
-        noValue: '0'
+        noValue: "0"
         thresholds:
           mode: absolute
           steps:
@@ -735,7 +757,7 @@ panels:
       h: 5
       w: 3
       x: 12
-      'y': 23
+      "y": 23
     id: 10
     interval: 1m
     options:
@@ -746,7 +768,7 @@ panels:
       reduceOptions:
         calcs:
           - last
-        fields: ''
+        fields: ""
         values: false
       showPercentChange: false
       text: {}
@@ -756,7 +778,7 @@ panels:
     targets:
       - datasource:
           type: loki
-          uid: '${datasource}'
+          uid: "${datasource}"
         editorMode: code
         expr: |-
           k8s.namespace.name:~"$namespace"
@@ -769,11 +791,11 @@ panels:
     type: stat
   - datasource:
       type: victoriametrics-logs-datasource
-      uid: '${datasource}'
+      uid: "${datasource}"
     fieldConfig:
       defaults:
         mappings: []
-        noValue: '0'
+        noValue: "0"
         thresholds:
           mode: absolute
           steps:
@@ -787,7 +809,7 @@ panels:
       h: 5
       w: 3
       x: 15
-      'y': 23
+      "y": 23
     id: 12
     interval: 1m
     options:
@@ -798,7 +820,7 @@ panels:
       reduceOptions:
         calcs:
           - last
-        fields: ''
+        fields: ""
         values: false
       showPercentChange: false
       textMode: auto
@@ -807,7 +829,7 @@ panels:
     targets:
       - datasource:
           type: loki
-          uid: '${datasource}'
+          uid: "${datasource}"
         editorMode: code
         expr: |
           k8s.namespace.name:~"$namespace"
@@ -820,13 +842,13 @@ panels:
     type: stat
   - datasource:
       type: victoriametrics-logs-datasource
-      uid: '${datasource}'
+      uid: "${datasource}"
     fieldConfig:
       defaults:
         color:
           mode: thresholds
         mappings: []
-        noValue: '0'
+        noValue: "0"
         thresholds:
           mode: absolute
           steps:
@@ -839,7 +861,7 @@ panels:
       h: 5
       w: 3
       x: 18
-      'y': 23
+      "y": 23
     id: 18
     interval: 1m
     options:
@@ -850,7 +872,7 @@ panels:
       reduceOptions:
         calcs:
           - last
-        fields: ''
+        fields: ""
         values: false
       showPercentChange: false
       text: {}
@@ -860,7 +882,7 @@ panels:
     targets:
       - datasource:
           type: loki
-          uid: '${datasource}'
+          uid: "${datasource}"
         editorMode: code
         expr: |-
           k8s.namespace.name:~"$namespace"
@@ -874,11 +896,11 @@ panels:
     type: stat
   - datasource:
       type: victoriametrics-logs-datasource
-      uid: '${datasource}'
+      uid: "${datasource}"
     fieldConfig:
       defaults:
         mappings: []
-        noValue: '0'
+        noValue: "0"
         thresholds:
           mode: absolute
           steps:
@@ -892,7 +914,7 @@ panels:
       h: 5
       w: 3
       x: 21
-      'y': 23
+      "y": 23
     id: 40
     interval: 1m
     options:
@@ -903,7 +925,7 @@ panels:
       reduceOptions:
         calcs:
           - last
-        fields: ''
+        fields: ""
         values: false
       showPercentChange: false
       textMode: auto
@@ -912,7 +934,7 @@ panels:
     targets:
       - datasource:
           type: loki
-          uid: '${datasource}'
+          uid: "${datasource}"
         editorMode: code
         expr: |-
           k8s.namespace.name:~"$namespace"
@@ -928,15 +950,15 @@ panels:
       h: 1
       w: 24
       x: 0
-      'y': 28
+      "y": 28
     id: 30
     panels: []
     title: Kubernetes Events - Distribution
     type: row
   - datasource:
       type: victoriametrics-logs-datasource
-      uid: '${datasource}'
-    description: ''
+      uid: "${datasource}"
+    description: ""
     fieldConfig:
       defaults:
         color:
@@ -959,7 +981,7 @@ panels:
               value: Reason
             - id: color
               value:
-                fixedColor: '#eab839'
+                fixedColor: "#eab839"
                 mode: fixed
         - matcher:
             id: byName
@@ -999,7 +1021,7 @@ panels:
                   _time:[1743485797, 1743489397] k8s.namespace.name:~".*"
                   | stats by (k8s.event.reason) count()
                 - Info
-              prefix: 'All except:'
+              prefix: "All except:"
               readOnly: true
           properties:
             - id: custom.hideFrom
@@ -1011,7 +1033,7 @@ panels:
       h: 14
       w: 6
       x: 0
-      'y': 29
+      "y": 29
     id: 26
     interval: 1m
     options:
@@ -1023,7 +1045,7 @@ panels:
       reduceOptions:
         calcs:
           - sum
-        fields: ''
+        fields: ""
         values: false
       tooltip:
         mode: multi
@@ -1032,7 +1054,7 @@ panels:
     targets:
       - datasource:
           type: loki
-          uid: '${datasource}'
+          uid: "${datasource}"
         editorMode: code
         expr: |-
           k8s.namespace.name:~"$namespace"
@@ -1047,7 +1069,7 @@ panels:
     type: piechart
   - datasource:
       type: victoriametrics-logs-datasource
-      uid: '${datasource}'
+      uid: "${datasource}"
     fieldConfig:
       defaults:
         color:
@@ -1063,7 +1085,7 @@ panels:
       h: 14
       w: 6
       x: 6
-      'y': 29
+      "y": 29
     id: 28
     interval: 1m
     options:
@@ -1076,7 +1098,7 @@ panels:
       reduceOptions:
         calcs:
           - sum
-        fields: ''
+        fields: ""
         values: false
       tooltip:
         mode: multi
@@ -1084,7 +1106,7 @@ panels:
     targets:
       - datasource:
           type: loki
-          uid: '${datasource}'
+          uid: "${datasource}"
         editorMode: code
         expr: |-
           k8s.namespace.name:~"$namespace"
@@ -1098,7 +1120,7 @@ panels:
     type: piechart
   - datasource:
       type: victoriametrics-logs-datasource
-      uid: '${datasource}'
+      uid: "${datasource}"
     fieldConfig:
       defaults:
         color:
@@ -1115,7 +1137,7 @@ panels:
       h: 14
       w: 6
       x: 12
-      'y': 29
+      "y": 29
     id: 42
     interval: 1m
     options:
@@ -1128,7 +1150,7 @@ panels:
       reduceOptions:
         calcs:
           - sum
-        fields: ''
+        fields: ""
         values: false
       tooltip:
         mode: multi
@@ -1136,7 +1158,7 @@ panels:
     targets:
       - datasource:
           type: loki
-          uid: '${datasource}'
+          uid: "${datasource}"
         editorMode: code
         expr: |-
           k8s.namespace.name:~"$namespace"
@@ -1151,7 +1173,7 @@ panels:
     type: piechart
   - datasource:
       type: victoriametrics-logs-datasource
-      uid: '${datasource}'
+      uid: "${datasource}"
     fieldConfig:
       defaults:
         color:
@@ -1168,7 +1190,7 @@ panels:
       h: 14
       w: 6
       x: 18
-      'y': 29
+      "y": 29
     id: 22
     interval: 1m
     options:
@@ -1181,7 +1203,7 @@ panels:
       reduceOptions:
         calcs:
           - sum
-        fields: ''
+        fields: ""
         values: false
       tooltip:
         mode: multi
@@ -1189,7 +1211,7 @@ panels:
     targets:
       - datasource:
           type: loki
-          uid: '${datasource}'
+          uid: "${datasource}"
         editorMode: code
         expr: |-
           k8s.namespace.name:~"$namespace"
@@ -1207,19 +1229,19 @@ panels:
       h: 1
       w: 24
       x: 0
-      'y': 43
+      "y": 43
     id: 38
     panels: []
     title: Kubernetes Events - Raw Logs
     type: row
   - datasource:
       type: victoriametrics-logs-datasource
-      uid: '${datasource}'
+      uid: "${datasource}"
     gridPos:
       h: 13
       w: 24
       x: 0
-      'y': 44
+      "y": 44
     id: 8
     options:
       dedupStrategy: none
@@ -1233,7 +1255,7 @@ panels:
     targets:
       - datasource:
           type: loki
-          uid: '${datasource}'
+          uid: "${datasource}"
         editorMode: code
         expr: |-
           k8s.namespace.name:~"$namespace"
@@ -1260,9 +1282,9 @@ templating:
       name: datasource
       options: []
       query: victoriametrics-logs-datasource
-      queryValue: ''
+      queryValue: ""
       refresh: 1
-      regex: ''
+      regex: ""
       skipUrlSync: false
       type: datasource
     - allValue: .*
@@ -1272,8 +1294,8 @@ templating:
         value: $__all
       datasource:
         type: victoriametrics-logs-datasource
-        uid: '${datasource}'
-      definition: ''
+        uid: "${datasource}"
+      definition: ""
       hide: 0
       includeAll: true
       label: namespace
@@ -1283,14 +1305,23 @@ templating:
       query:
         field: k8s.namespace.name
         limit: 0
-        query: ''
+        query: ""
         refId: VictoriaLogsVariableQueryEditor-VariableQuery
         type: fieldValue
       refresh: 1
-      regex: ''
+      regex: ""
       skipUrlSync: false
       sort: 0
       type: query
+    - baseFilters: []
+      datasource:
+        type: victoriametrics-logs-datasource
+        uid: "${datasource}"
+      filters: []
+      hide: 0
+      name: filter
+      skipUrlSync: false
+      type: adhoc
 time:
   from: now-1h
   to: now
@@ -1305,8 +1336,8 @@ timepicker:
     - 1h
     - 2h
     - 1d
-timezone: ''
+timezone: ""
 title: All Kubernetes Events
 uid: kubernetes-event-exporter
 version: 39
-weekStart: ''
+weekStart: ""

--- a/charts/kof-dashboards/files/dashboards/victoria-logs/victoria-logs.yaml
+++ b/charts/kof-dashboards/files/dashboards/victoria-logs/victoria-logs.yaml
@@ -3,27 +3,27 @@ annotations:
     - builtIn: 1
       datasource:
         type: grafana
-        uid: '-- Grafana --'
+        uid: "-- Grafana --"
       enable: true
       hide: true
-      iconColor: 'rgba(0, 211, 255, 1)'
+      iconColor: "rgba(0, 211, 255, 1)"
       name: Annotations & Alerts
       type: dashboard
 editable: true
 fiscalYearStartMonth: 0
 graphTooltip: 0
-id: 12
+id: 69
 links: []
 panels:
   - datasource:
       type: victoriametrics-logs-datasource
-      uid: '${datasource}'
+      uid: "${datasource}"
     fieldConfig:
       defaults:
         color:
           mode: thresholds
         mappings: []
-        noValue: '0'
+        noValue: "0"
         thresholds:
           mode: absolute
           steps:
@@ -37,7 +37,7 @@ panels:
       h: 5
       w: 4
       x: 0
-      'y': 0
+      "y": 0
     id: 1
     options:
       colorMode: value
@@ -47,7 +47,7 @@ panels:
       reduceOptions:
         calcs:
           - sum
-        fields: ''
+        fields: ""
         values: false
       showPercentChange: false
       textMode: auto
@@ -56,7 +56,7 @@ panels:
     targets:
       - datasource:
           type: victoriametrics-logs-datasource
-          uid: '${datasource}'
+          uid: "${datasource}"
         editorMode: code
         expr: |-
           k8s.cluster.name:in($cluster)
@@ -71,13 +71,13 @@ panels:
     type: stat
   - datasource:
       type: victoriametrics-logs-datasource
-      uid: '${datasource}'
+      uid: "${datasource}"
     fieldConfig:
       defaults:
         color:
           mode: thresholds
         mappings: []
-        noValue: '0'
+        noValue: "0"
         thresholds:
           mode: absolute
           steps:
@@ -91,7 +91,7 @@ panels:
       h: 5
       w: 4
       x: 4
-      'y': 0
+      "y": 0
     id: 11
     options:
       colorMode: value
@@ -101,7 +101,7 @@ panels:
       reduceOptions:
         calcs:
           - sum
-        fields: ''
+        fields: ""
         values: false
       showPercentChange: false
       textMode: auto
@@ -110,7 +110,7 @@ panels:
     targets:
       - datasource:
           type: victoriametrics-logs-datasource
-          uid: '${datasource}'
+          uid: "${datasource}"
         editorMode: code
         expr: |-
           k8s.cluster.name:in($cluster)
@@ -126,14 +126,14 @@ panels:
     type: stat
   - datasource:
       type: victoriametrics-logs-datasource
-      uid: '${datasource}'
-    description: ''
+      uid: "${datasource}"
+    description: ""
     fieldConfig:
       defaults:
         color:
           mode: thresholds
         mappings: []
-        noValue: '0'
+        noValue: "0"
         thresholds:
           mode: absolute
           steps:
@@ -147,7 +147,7 @@ panels:
       h: 5
       w: 4
       x: 8
-      'y': 0
+      "y": 0
     id: 2
     options:
       colorMode: value
@@ -157,7 +157,7 @@ panels:
       reduceOptions:
         calcs:
           - sum
-        fields: ''
+        fields: ""
         values: false
       showPercentChange: false
       textMode: auto
@@ -183,14 +183,14 @@ panels:
     type: stat
   - datasource:
       type: victoriametrics-logs-datasource
-      uid: '${datasource}'
-    description: ''
+      uid: "${datasource}"
+    description: ""
     fieldConfig:
       defaults:
         color:
           mode: thresholds
         mappings: []
-        noValue: '0'
+        noValue: "0"
         thresholds:
           mode: absolute
           steps:
@@ -204,7 +204,7 @@ panels:
       h: 5
       w: 4
       x: 12
-      'y': 0
+      "y": 0
     id: 3
     options:
       colorMode: value
@@ -214,7 +214,7 @@ panels:
       reduceOptions:
         calcs:
           - sum
-        fields: ''
+        fields: ""
         values: false
       showPercentChange: false
       textMode: auto
@@ -240,14 +240,14 @@ panels:
     type: stat
   - datasource:
       type: victoriametrics-logs-datasource
-      uid: '${datasource}'
-    description: ''
+      uid: "${datasource}"
+    description: ""
     fieldConfig:
       defaults:
         color:
           mode: thresholds
         mappings: []
-        noValue: '0'
+        noValue: "0"
         thresholds:
           mode: absolute
           steps:
@@ -261,7 +261,7 @@ panels:
       h: 5
       w: 4
       x: 16
-      'y': 0
+      "y": 0
     id: 4
     options:
       colorMode: value
@@ -271,7 +271,7 @@ panels:
       reduceOptions:
         calcs:
           - sum
-        fields: ''
+        fields: ""
         values: false
       showPercentChange: false
       textMode: auto
@@ -297,14 +297,14 @@ panels:
     type: stat
   - datasource:
       type: victoriametrics-logs-datasource
-      uid: '${datasource}'
-    description: ''
+      uid: "${datasource}"
+    description: ""
     fieldConfig:
       defaults:
         color:
           mode: thresholds
         mappings: []
-        noValue: '0'
+        noValue: "0"
         thresholds:
           mode: absolute
           steps:
@@ -318,7 +318,7 @@ panels:
       h: 5
       w: 4
       x: 20
-      'y': 0
+      "y": 0
     id: 5
     options:
       colorMode: value
@@ -328,7 +328,7 @@ panels:
       reduceOptions:
         calcs:
           - sum
-        fields: ''
+        fields: ""
         values: false
       showPercentChange: false
       textMode: auto
@@ -354,22 +354,60 @@ panels:
     type: stat
   - datasource:
       type: victoriametrics-logs-datasource
-      uid: '${datasource}'
+      uid: "${datasource}"
+    fieldConfig:
+      defaults:
+        custom:
+          align: auto
+          cellOptions:
+            type: auto
+          inspect: false
+        mappings: []
+        thresholds:
+          mode: absolute
+          steps:
+            - color: green
+              value: null
+            - color: red
+              value: 80
+      overrides:
+        - matcher:
+            id: byType
+            options: string
+          properties:
+            - id: filterable
+              value: true
     gridPos:
       h: 11
       w: 24
       x: 0
-      'y': 5
+      "y": 5
     id: 10
     options:
+      cellHeight: sm
       dedupStrategy: none
       enableLogDetails: true
+      footer:
+        countRows: false
+        fields: ""
+        reducer:
+          - sum
+        show: false
       prettifyLogMessage: false
       showCommonLabels: false
+      showHeader: true
       showLabels: false
       showTime: false
       sortOrder: Descending
       wrapLogMessage: false
+    overrides:
+      - matcher:
+          id: byType
+          options: string
+        properties:
+          - id: filterable
+            value: true
+    pluginVersion: 10.4.18+security-01
     targets:
       - datasource:
           type: victoriametrics-logs-datasource
@@ -387,12 +425,58 @@ panels:
         queryType: instant
         range: true
         refId: A
-        step: ''
-    title: 'Logs | Severity: $severity'
-    type: logs
+        step: ""
+    title: "Logs | Severity: $severity"
+    transformations:
+      - id: extractFields
+        options:
+          format: kvp
+          source: labels
+      - id: organize
+        options:
+          excludeByName:
+            Line: true
+            Time: false
+            _stream_id: true
+            apiVersion: true
+            labels: true
+            level: true
+          includeByName: {}
+          indexByName:
+            Line: 2
+            Time: 0
+            _stream_id: 5
+            container.image.name: 6
+            container.image.tag: 7
+            host.name: 8
+            k8s.app.instance: 9
+            k8s.cluster.name: 10
+            k8s.cluster.namespace: 11
+            k8s.cluster.uid: 12
+            k8s.container.name: 13
+            k8s.container.restart_count: 14
+            k8s.deployment.name: 15
+            k8s.namespace.name: 16
+            k8s.node.name: 17
+            k8s.node.uid: 18
+            k8s.pod.name: 19
+            k8s.pod.start_time: 20
+            k8s.pod.uid: 21
+            k8s.replicaset.name: 22
+            k8s.replicaset.uid: 23
+            labels: 3
+            level: 4
+            log.file.path: 24
+            log.iostream: 25
+            logtag: 26
+            os.type: 27
+            service.name: 28
+            severity: 1
+          renameByName: {}
+    type: table
   - datasource:
       type: victoriametrics-logs-datasource
-      uid: '${datasource}'
+      uid: "${datasource}"
     fieldConfig:
       defaults:
         color:
@@ -433,14 +517,14 @@ panels:
       h: 10
       w: 24
       x: 0
-      'y': 16
+      "y": 16
     id: 12
     options:
       cellHeight: sm
       footer:
         countRows: false
         enablePagination: false
-        fields: ''
+        fields: ""
         reducer:
           - sum
         show: false
@@ -464,7 +548,7 @@ panels:
         queryType: instant
         range: true
         refId: A
-    title: 'Pods Logs Severity Count | Severity: $severity'
+    title: "Pods Logs Severity Count | Severity: $severity"
     transformations:
       - id: extractFields
         options:
@@ -485,7 +569,7 @@ panels:
     type: table
   - datasource:
       type: victoriametrics-logs-datasource
-      uid: '${datasource}'
+      uid: "${datasource}"
     fieldConfig:
       defaults:
         color:
@@ -494,7 +578,7 @@ panels:
           axisBorderShow: false
           axisCenteredZero: false
           axisColorMode: text
-          axisLabel: ''
+          axisLabel: ""
           axisPlacement: auto
           fillOpacity: 80
           gradientMode: none
@@ -506,7 +590,7 @@ panels:
           scaleDistribution:
             type: linear
           thresholdsStyle:
-            mode: 'off'
+            mode: "off"
         mappings: []
         thresholds:
           mode: absolute
@@ -520,7 +604,7 @@ panels:
       h: 10
       w: 11
       x: 0
-      'y': 26
+      "y": 26
     id: 6
     options:
       barRadius: 0
@@ -543,7 +627,7 @@ panels:
     targets:
       - datasource:
           type: victoriametrics-logs-datasource
-          uid: '${datasource}'
+          uid: "${datasource}"
         editorMode: code
         expr: |-
           k8s.namespace.name:*
@@ -555,12 +639,12 @@ panels:
         legendFormat: '{{`{{k8s.namespace.name}}`}}'
         queryType: stats
         refId: A
-        step: ''
-    title: 'Logs by Namespace | Severity: $severity'
+        step: ""
+    title: "Logs by Namespace | Severity: $severity"
     type: barchart
   - datasource:
       type: victoriametrics-logs-datasource
-      uid: '${datasource}'
+      uid: "${datasource}"
     fieldConfig:
       defaults:
         color:
@@ -569,7 +653,7 @@ panels:
           axisBorderShow: false
           axisCenteredZero: false
           axisColorMode: text
-          axisLabel: ''
+          axisLabel: ""
           axisPlacement: auto
           barAlignment: 0
           drawStyle: line
@@ -591,7 +675,7 @@ panels:
             group: A
             mode: none
           thresholdsStyle:
-            mode: 'off'
+            mode: "off"
         mappings: []
         thresholds:
           mode: absolute
@@ -606,7 +690,7 @@ panels:
       h: 10
       w: 13
       x: 11
-      'y': 26
+      "y": 26
     id: 9
     options:
       legend:
@@ -639,11 +723,11 @@ panels:
         queryType: statsRange
         range: true
         refId: A
-    title: 'Logs Rate - $pod | Severity: $severity'
+    title: "Logs Rate - $pod | Severity: $severity"
     type: timeseries
   - datasource:
       type: victoriametrics-logs-datasource
-      uid: '${datasource}'
+      uid: "${datasource}"
     fieldConfig:
       defaults:
         color:
@@ -690,13 +774,13 @@ panels:
       h: 10
       w: 10
       x: 0
-      'y': 36
+      "y": 36
     id: 7
     options:
       cellHeight: sm
       footer:
         countRows: false
-        fields: ''
+        fields: ""
         reducer:
           - sum
         show: false
@@ -720,7 +804,7 @@ panels:
         queryType: instant
         range: true
         refId: A
-    title: 'Top Field-Value Pairs | Severity: $severity'
+    title: "Top Field-Value Pairs | Severity: $severity"
     transformations:
       - id: extractFields
         options:
@@ -730,7 +814,7 @@ panels:
     type: table
   - datasource:
       type: victoriametrics-logs-datasource
-      uid: '${datasource}'
+      uid: "${datasource}"
     fieldConfig:
       defaults:
         color:
@@ -771,13 +855,13 @@ panels:
       h: 10
       w: 14
       x: 10
-      'y': 36
+      "y": 36
     id: 8
     options:
       cellHeight: sm
       footer:
         countRows: false
-        fields: ''
+        fields: ""
         reducer:
           - sum
         show: false
@@ -801,7 +885,7 @@ panels:
         queryType: instant
         range: true
         refId: A
-    title: 'Top 10 Log Patterns | Severity: $severity'
+    title: "Top 10 Log Patterns | Severity: $severity"
     transformations:
       - id: extractFields
         options:
@@ -810,26 +894,28 @@ panels:
           replace: false
           source: labels
     type: table
-refresh: ''
+refresh: ""
 schemaVersion: 39
-tags:
-  - Kubernetes
-  - Logs
+tags: []
 templating:
   list:
-    - hide: 0
+    - current:
+        selected: false
+        text: logs
+        value: 9d266288-b035-49ab-bfac-16007adc13cd
+      hide: 0
       includeAll: false
       label: datasource
       multi: false
       name: datasource
       options: []
       query: victoriametrics-logs-datasource
-      queryValue: ''
+      queryValue: ""
       refresh: 1
-      regex: ''
+      regex: ""
       skipUrlSync: false
       type: datasource
-    - allValue: '*'
+    - allValue: "*"
       current:
         selected: true
         text:
@@ -838,8 +924,8 @@ templating:
           - $__all
       datasource:
         type: victoriametrics-logs-datasource
-        uid: '${datasource}'
-      definition: ''
+        uid: "${datasource}"
+      definition: ""
       hide: 0
       includeAll: true
       label: cluster
@@ -849,15 +935,15 @@ templating:
       query:
         field: k8s.cluster.name
         limit: 0
-        query: ''
+        query: ""
         refId: VictoriaLogsVariableQueryEditor-VariableQuery
         type: fieldValue
       refresh: 1
-      regex: ''
+      regex: ""
       skipUrlSync: false
       sort: 0
       type: query
-    - allValue: '*'
+    - allValue: "*"
       current:
         selected: true
         text:
@@ -866,8 +952,8 @@ templating:
           - $__all
       datasource:
         type: victoriametrics-logs-datasource
-        uid: '${datasource}'
-      definition: 'k8s.cluster.name:~$cluster'
+        uid: "${datasource}"
+      definition: "k8s.cluster.name:~$cluster"
       hide: 0
       includeAll: true
       label: node
@@ -877,15 +963,15 @@ templating:
       query:
         field: k8s.node.name
         limit: 0
-        query: 'k8s.cluster.name:~$cluster'
+        query: "k8s.cluster.name:~$cluster"
         refId: VictoriaLogsVariableQueryEditor-VariableQuery
         type: fieldValue
       refresh: 2
-      regex: ''
+      regex: ""
       skipUrlSync: false
       sort: 0
       type: query
-    - allValue: '*'
+    - allValue: "*"
       current:
         selected: true
         text:
@@ -894,8 +980,8 @@ templating:
           - $__all
       datasource:
         type: victoriametrics-logs-datasource
-        uid: '${datasource}'
-      definition: 'k8s.cluster.name:~$cluster k8s.node.name:~$node'
+        uid: "${datasource}"
+      definition: "k8s.cluster.name:~$cluster k8s.node.name:~$node"
       hide: 0
       includeAll: true
       label: namespace
@@ -905,15 +991,15 @@ templating:
       query:
         field: k8s.namespace.name
         limit: 0
-        query: 'k8s.cluster.name:~$cluster k8s.node.name:~$node'
+        query: "k8s.cluster.name:~$cluster k8s.node.name:~$node"
         refId: VictoriaLogsVariableQueryEditor-VariableQuery
         type: fieldValue
       refresh: 2
-      regex: ''
+      regex: ""
       skipUrlSync: false
       sort: 0
       type: query
-    - allValue: '*'
+    - allValue: "*"
       current:
         selected: true
         text:
@@ -922,7 +1008,7 @@ templating:
           - $__all
       datasource:
         type: victoriametrics-logs-datasource
-        uid: '${datasource}'
+        uid: "${datasource}"
       definition: >-
         k8s.cluster.name:~$cluster k8s.node.name:~$node
         k8s.namespace.name:~$namespace
@@ -941,11 +1027,11 @@ templating:
         refId: VictoriaLogsVariableQueryEditor-VariableQuery
         type: fieldValue
       refresh: 2
-      regex: ''
+      regex: ""
       skipUrlSync: false
       sort: 0
       type: query
-    - allValue: '*'
+    - allValue: "*"
       current:
         selected: true
         text:
@@ -954,7 +1040,7 @@ templating:
           - $__all
       datasource:
         type: victoriametrics-logs-datasource
-        uid: '${datasource}'
+        uid: "${datasource}"
       definition: >-
         k8s.cluster.name:~$cluster k8s.node.name:~$node
         k8s.namespace.name:~$namespace k8s.pod.name:~$pod
@@ -973,7 +1059,7 @@ templating:
         refId: VictoriaLogsVariableQueryEditor-VariableQuery
         type: fieldValue
       refresh: 2
-      regex: ''
+      regex: ""
       skipUrlSync: false
       sort: 0
       type: query
@@ -1008,14 +1094,14 @@ templating:
         - selected: false
           text: Fatal
           value: FATAL
-      query: 'Info : INFO,Debug : DEBUG,Warning : WARN,Error : ERROR,Fatal : FATAL'
-      queryValue: ''
+      query: "Info : INFO,Debug : DEBUG,Warning : WARN,Error : ERROR,Fatal : FATAL"
+      queryValue: ""
       skipUrlSync: false
       type: custom
     - current:
         selected: false
-        text: '100'
-        value: '100'
+        text: "100"
+        value: "100"
       hide: 0
       includeAll: false
       label: limit
@@ -1023,27 +1109,35 @@ templating:
       name: limit
       options:
         - selected: true
-          text: '100'
-          value: '100'
+          text: "100"
+          value: "100"
         - selected: false
-          text: '500'
-          value: '500'
+          text: "500"
+          value: "500"
         - selected: false
-          text: '1000'
-          value: '1000'
+          text: "1000"
+          value: "1000"
         - selected: false
-          text: '2000'
-          value: '2000'
-      query: '100, 500, 1000, 2000'
-      queryValue: ''
+          text: "2000"
+          value: "2000"
+      query: "100, 500, 1000, 2000"
+      queryValue: ""
       skipUrlSync: false
       type: custom
+    - datasource:
+        type: victoriametrics-logs-datasource
+        uid: "${datasource}"
+      filters: []
+      hide: 0
+      name: Filters
+      skipUrlSync: false
+      type: adhoc
 time:
-  from: now-3h
+  from: now-5m
   to: now
 timepicker: {}
 timezone: browser
 title: VictoriaLogs Dashboard
 uid: aeckkt1pio0sgc
-version: 25
-weekStart: ''
+version: 1
+weekStart: ""


### PR DESCRIPTION
Closes https://github.com/k0rdent/kof/issues/372 and https://github.com/k0rdent/kof/issues/501

Flattening event fields allows victoria logs work with adhoc filters by removing the unnecessary transformations of metadata and regarding json fields in event log record