### PR TITLE
fix: Auto-upgrade KOF CRD PromxyServerGroup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -196,9 +196,8 @@ dev-ms-deploy: dev kof-operator-docker-build ## Deploy `kof-mothership` helm cha
 	$(KUBECTL) apply -f ./kof-operator/config/crd/bases/k0rdent.mirantis.com_servicetemplates.yaml
 	$(KUBECTL) apply -f ./kof-operator/config/crd/bases/k0rdent.mirantis.com_multiclusterservices.yaml
 	$(KUBECTL) apply -f ./kof-operator/config/crd/bases/k0rdent.mirantis.com_clusterdeployments.yaml
-	$(KUBECTL) apply -f ./charts/kof-mothership/crds/kof.k0rdent.mirantis.com_promxyservergroups.yaml
 	$(KUBECTL) delete deployment kof-mothership-promxy -n kof --ignore-not-found=true
-	$(HELM_UPGRADE) -n kof kof-mothership ./charts/kof-mothership -f dev/mothership-values.yaml
+	$(HELM_UPGRADE) --take-ownership -n kof kof-mothership ./charts/kof-mothership -f dev/mothership-values.yaml
 	$(KUBECTL) rollout restart -n kof deployment/kof-mothership-kof-operator
 	@svctmpls='cert-manager-v1-16-4|ingress-nginx-4-12-1|kof-collectors-1-3-0|kof-operators-1-3-0|kof-storage-1-3-0'; \
 	for attempt in $$(seq 1 10); do \

--- a/charts/kof-mothership/templates/promxy/promxyservergroup-crd.yaml
+++ b/charts/kof-mothership/templates/promxy/promxyservergroup-crd.yaml
@@ -1,9 +1,11 @@
+# All versions of ../../../../kof-operator/config/crd/bases/kof.k0rdent.mirantis.com_promxyservergroups.yaml
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.16.1
+    helm.sh/resource-policy: keep
   name: promxyservergroups.kof.k0rdent.mirantis.com
 spec:
   group: kof.k0rdent.mirantis.com


### PR DESCRIPTION
* Closes https://github.com/k0rdent/kof/issues/545
* The `--take-ownership` is required on upgrade to this version to avoid
  `exists and cannot be imported into the current release: invalid ownership metadata`
* Will add it to release notes of KOF 1.4.0.
* Test:
  ```
  kubectl get crd promxyservergroups.kof.k0rdent.mirantis.com -o yaml | yq .metadata

    annotations:
      controller-gen.kubebuilder.io/version: v0.16.1
      helm.sh/resource-policy: keep
      meta.helm.sh/release-name: kof-mothership
      meta.helm.sh/release-namespace: kof
    labels:
      app.kubernetes.io/managed-by: Helm
    ...
  ```
