### PR TITLE
fix: `daemon-collector` crashes with `authenticator not found`

### DIFF
--- a/charts/kof-collectors/values.yaml
+++ b/charts/kof-collectors/values.yaml
@@ -691,6 +691,9 @@ opentelemetry-kube-stack:
             storage: file_storage/filelogk8sauditreceiver
         service:
           extensions:
+            - basicauth/metrics
+            - basicauth/logs
+            - basicauth/traces
             - k8s_observer
             - file_storage/filelogreceiver
             - file_storage/filelogsyslogreceiver


### PR DESCRIPTION
* Closes https://github.com/k0rdent/kof/issues/554
* See all details and tests in this issue above.