### PR TITLE
fix: show log line field in dashboard

### DIFF
--- a/charts/kof-dashboards/files/dashboards/victoria-logs/victoria-logs.yaml
+++ b/charts/kof-dashboards/files/dashboards/victoria-logs/victoria-logs.yaml
@@ -435,7 +435,6 @@ panels:
       - id: organize
         options:
           excludeByName:
-            Line: true
             Time: false
             _stream_id: true
             apiVersion: true


### PR DESCRIPTION
This is the only field where we can see the log message, it shouldn't be hidden