### PR TITLE
fix: Crash of OTelCol without extensions required for storing KOF data of Management cluster

### DIFF
--- a/charts/kof-collectors/values.yaml
+++ b/charts/kof-collectors/values.yaml
@@ -690,6 +690,11 @@ opentelemetry-kube-stack:
                 value: k8s_audit
             storage: file_storage/filelogk8sauditreceiver
         service:
+          extensions:
+            - k8s_observer
+            - file_storage/filelogreceiver
+            - file_storage/filelogsyslogreceiver
+            - file_storage/filelogk8sauditreceiver
           pipelines:
             logs:
               processors:


### PR DESCRIPTION
* Part of https://github.com/k0rdent/kof/issues/554
* Fixes OpenTelemetryCollector extensions deleted in https://github.com/k0rdent/kof/pull/558
* Without them [storing KOF data of Management cluster](https://docs.k0rdent.io/v1.3.1/admin/kof/kof-storing/) failed with
  `kof-collectors-daemon-collector` crashing with:
  ```
  Error: cannot start pipelines: failed to start "filelog/syslog" receiver:
  storage client: storage extension 'file_storage/filelogsyslogreceiver' not found
  ```
  or
  ```
  Error: cannot start pipelines: failed to start "receiver_creator" receiver:
  failed to find observer "k8s_observer" in the extensions list
  ```
