### PR TITLE
feat: add journald receiver to daemon collector

### DIFF
--- a/.github/workflows/build_images.yml
+++ b/.github/workflows/build_images.yml
@@ -5,6 +5,7 @@ on:
       - main
     paths:
       - "kof-operator/**"
+      - "docker/opentelemetry-collector-contrib/**"
 
 jobs:
   build:
@@ -55,7 +56,8 @@ jobs:
           args: release --clean --verbose --snapshot
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          IMAGE_REPO: ghcr.io/${{ github.repository }}/kof-operator-controller
+          IMAGE_OPERATOR_REPO: ghcr.io/${{ github.repository }}/kof-operator-controller
+          IMAGE_OTEL_COLLECTOR_REPO: ghcr.io/${{ github.repository }}/kof-opentelemetry-collector-contrib
           GITHUB_OWNER: ${{ github.repository_owner }}
           GITHUB_REPO_NAME: ${{ github.event.repository.name }}
           VERSION: ${{ steps.vars.outputs.version }}

--- a/.github/workflows/release_images.yml
+++ b/.github/workflows/release_images.yml
@@ -1,10 +1,11 @@
-name: "Release Operator"
+name: "Release Docker Images"
 on:
   push:
     tags:
       - "*"
     paths:
       - "kof-operator/**"
+      - "docker/opentelemetry-collector-contrib/**"
 
 jobs:
   build:
@@ -57,7 +58,8 @@ jobs:
           args: release --clean --verbose
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          IMAGE_REPO: ghcr.io/${{ github.repository }}/kof-operator-controller
+          IMAGE_OPERATOR_REPO: ghcr.io/${{ github.repository }}/kof-operator-controller
+          IMAGE_OTEL_COLLECTOR_REPO: ghcr.io/${{ github.repository }}/kof-opentelemetry-collector-contrib
           GITHUB_OWNER: ${{ github.repository_owner }}
           GITHUB_REPO_NAME: ${{ github.event.repository.name }}
           VERSION: ${{ steps.vars.outputs.version }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -67,12 +67,12 @@ changelog:
     {{ if eq (index .Env "SKIP_SCM_RELEASE") "true" }}{{true}}{{ else }}{{false}}{{ end }}
 
 dockers:
-  - id: linux-amd64
+  - id: operator-linux-amd64
     goos: linux
     goarch: amd64
     image_templates:
-      - "{{ .Env.IMAGE_REPO }}:{{ .Env.VERSION }}-amd64"
-      - "{{ .Env.IMAGE_REPO }}:latest-amd64"
+      - "{{ .Env.IMAGE_OPERATOR_REPO }}:{{ .Env.VERSION }}-amd64"
+      - "{{ .Env.IMAGE_OPERATOR_REPO }}:latest-amd64"
     skip_push: false
     dockerfile: "./kof-operator/goreleaser.dockerfile"
     use: buildx
@@ -89,12 +89,12 @@ dockers:
       - --label=org.opencontainers.image.licenses=Apache-2.0
       - --platform=linux/amd64
 
-  - id: linux-arm64
+  - id: operator-linux-arm64
     goos: linux
     goarch: arm64
     image_templates:
-      - "{{ .Env.IMAGE_REPO }}:{{ .Env.VERSION }}-arm64"
-      - "{{ .Env.IMAGE_REPO }}:latest-arm64"
+      - "{{ .Env.IMAGE_OPERATOR_REPO }}:{{ .Env.VERSION }}-arm64"
+      - "{{ .Env.IMAGE_OPERATOR_REPO }}:latest-arm64"
     skip_push: false
     dockerfile: "./kof-operator/goreleaser.dockerfile"
     use: buildx
@@ -111,21 +111,77 @@ dockers:
       - --label=org.opencontainers.image.licenses=Apache-2.0
       - --platform=linux/arm64/v8
 
+  - id: otel-collector-linux-amd64
+    goos: linux
+    goarch: amd64
+    image_templates:
+      - "{{ .Env.IMAGE_OTEL_COLLECTOR_REPO }}:{{ .Env.VERSION }}-amd64"
+      - "{{ .Env.IMAGE_OTEL_COLLECTOR_REPO }}:latest-amd64"
+    skip_push: false
+    dockerfile: "./docker/opentelemetry-collector-contrib/Dockerfile"
+    use: buildx
+    ids:
+      - amd64
+    build_flag_templates:
+      - --label=org.opencontainers.image.title="kof-opentelemetry-collector-contrib"
+      - --label=org.opencontainers.image.description="opentelemetry-collector-contrib image with journalctl binary"
+      - --label=org.opencontainers.image.url=https://github.com/{{ .Env.GITHUB_OWNER }}/{{ .Env.GITHUB_REPO_NAME }}
+      - --label=org.opencontainers.image.source=https://github.com/{{ .Env.GITHUB_OWNER }}/{{ .Env.GITHUB_REPO_NAME }}
+      - --label=org.opencontainers.image.version={{ .Env.VERSION }}
+      - --label=org.opencontainers.image.created={{ time "2006-01-02T15:04:05Z07:00" }}
+      - --label=org.opencontainers.image.revision={{ .FullCommit }}
+      - --label=org.opencontainers.image.licenses=Apache-2.0
+      - --platform=linux/amd64
+
+  - id: otel-collector-linux-arm64
+    goos: linux
+    goarch: arm64
+    image_templates:
+      - "{{ .Env.IMAGE_OTEL_COLLECTOR_REPO }}:{{ .Env.VERSION }}-arm64"
+      - "{{ .Env.IMAGE_OTEL_COLLECTOR_REPO }}:latest-arm64"
+    skip_push: false
+    dockerfile: "./docker/opentelemetry-collector-contrib/Dockerfile"
+    use: buildx
+    ids:
+      - arm64
+    build_flag_templates:
+      - --label=org.opencontainers.image.title="kof-opentelemetry-collector-contrib"
+      - --label=org.opencontainers.image.description="opentelemetry-collector-contrib image with journalctl binary"
+      - --label=org.opencontainers.image.url=https://github.com/{{ .Env.GITHUB_OWNER }}/{{ .Env.GITHUB_REPO_NAME }}
+      - --label=org.opencontainers.image.source=https://github.com/{{ .Env.GITHUB_OWNER }}/{{ .Env.GITHUB_REPO_NAME }}
+      - --label=org.opencontainers.image.version={{ .Env.VERSION }}
+      - --label=org.opencontainers.image.created={{ time "2006-01-02T15:04:05Z07:00" }}
+      - --label=org.opencontainers.image.revision={{ .FullCommit }}
+      - --label=org.opencontainers.image.licenses=Apache-2.0
+      - --platform=linux/arm64/v8
 docker_manifests:
-  - name_template: "{{ .Env.IMAGE_REPO }}:{{ .Env.VERSION }}"
+  - name_template: "{{ .Env.IMAGE_OPERATOR_REPO }}:{{ .Env.VERSION }}"
     image_templates:
-      - "{{ .Env.IMAGE_REPO }}:{{ .Env.VERSION }}-amd64"
-      - "{{ .Env.IMAGE_REPO }}:{{ .Env.VERSION }}-arm64"
+      - "{{ .Env.IMAGE_OPERATOR_REPO }}:{{ .Env.VERSION }}-amd64"
+      - "{{ .Env.IMAGE_OPERATOR_REPO }}:{{ .Env.VERSION }}-arm64"
     skip_push: false
     use: docker
 
-  - name_template: "{{ .Env.IMAGE_REPO }}:latest"
+  - name_template: "{{ .Env.IMAGE_OPERATOR_REPO }}:latest"
     image_templates:
-      - "{{ .Env.IMAGE_REPO }}:latest-amd64"
-      - "{{ .Env.IMAGE_REPO }}:latest-arm64"
+      - "{{ .Env.IMAGE_OPERATOR_REPO }}:latest-amd64"
+      - "{{ .Env.IMAGE_OPERATOR_REPO }}:latest-arm64"
     skip_push: false
     use: docker
 
+  - name_template: "{{ .Env.IMAGE_OTEL_COLLECTOR_REPO }}:{{ .Env.VERSION }}"
+    image_templates:
+      - "{{ .Env.IMAGE_OTEL_COLLECTOR_REPO }}:{{ .Env.VERSION }}-amd64"
+      - "{{ .Env.IMAGE_OTEL_COLLECTOR_REPO }}:{{ .Env.VERSION }}-arm64"
+    skip_push: false
+    use: docker
+
+  - name_template: "{{ .Env.IMAGE_OTEL_COLLECTOR_REPO }}:latest"
+    image_templates:
+      - "{{ .Env.IMAGE_OTEL_COLLECTOR_REPO }}:latest-amd64"
+      - "{{ .Env.IMAGE_OTEL_COLLECTOR_REPO }}:latest-arm64"
+    skip_push: false
+    use: docker
 release:
   github:
     owner: "{{ .Env.GITHUB_OWNER }}"

--- a/Makefile
+++ b/Makefile
@@ -121,7 +121,9 @@ kof-operator-docker-build: ## Build kof-operator controller docker image
 	cd kof-operator && make docker-build
 	@kof_version=v$$($(YQ) .version $(TEMPLATES_DIR)/kof-mothership/Chart.yaml); \
 	$(CONTAINER_TOOL) tag kof-operator-controller kof-operator-controller:$$kof_version; \
-	$(KIND) load docker-image kof-operator-controller:$$kof_version --name $(KIND_CLUSTER_NAME)
+	$(KIND) load docker-image kof-operator-controller:$$kof_version --name $(KIND_CLUSTER_NAME); \
+	$(CONTAINER_TOOL) tag kof-opentelemetry-collector-contrib ghcr.io/k0rdent/kof/kof-opentelemetry-collector-contrib:$$kof_version; \
+	$(KIND) load docker-image ghcr.io/k0rdent/kof/kof-opentelemetry-collector-contrib:$$kof_version --name $(KIND_CLUSTER_NAME)
 
 .PHONY: dev-operators-deploy
 dev-operators-deploy: dev ## Deploy kof-operators helm chart to the K8s cluster specified in ~/.kube/config
@@ -163,6 +165,8 @@ dev-adopted-deploy: dev kind envsubst ## Create adopted cluster deployment
 	KIND_CLUSTER_NAME=$(KIND_CLUSTER_NAME) \
 	$(ENVSUBST) -no-unset -i demo/creds/adopted-credentials.yaml \
 	| $(KUBECTL) apply -f -
+	@kof_version=v$$($(YQ) .version $(TEMPLATES_DIR)/kof-mothership/Chart.yaml); \
+	$(KIND) load docker-image ghcr.io/k0rdent/kof/kof-opentelemetry-collector-contrib:$$kof_version --name $(KIND_CLUSTER_NAME)
 
 .PHONY: dev-storage-deploy
 dev-storage-deploy: dev ## Deploy kof-storage helm chart to the K8s cluster specified in ~/.kube/config

--- a/charts/kof-child/values.yaml
+++ b/charts/kof-child/values.yaml
@@ -30,6 +30,7 @@ collectors:
               - file_storage/filelogreceiver
               - file_storage/filelogsyslogreceiver
               - file_storage/filelogk8sauditreceiver
+              - file_storage/journaldreceiver
             telemetry:
               metrics:
                 address: ${env:OTEL_K8S_NODE_IP}:8888

--- a/charts/kof-collectors/values.yaml
+++ b/charts/kof-collectors/values.yaml
@@ -208,6 +208,9 @@ opentelemetry-kube-stack:
           key: node-role.kubernetes.io/master
           operator: Exists
     daemon:
+      image:
+        repository: ghcr.io/k0rdent/kof/kof-opentelemetry-collector-contrib
+        tag: v1.4.0
       config:
         extensions:
           k8s_observer:
@@ -218,6 +221,8 @@ opentelemetry-kube-stack:
             directory: /var/lib/otelcol/file_storage/filelogsyslogreceiver
           file_storage/filelogk8sauditreceiver:
             directory: /var/lib/otelcol/file_storage/filelogk8sauditreceiver
+          file_storage/journaldreceiver:
+            directory: /var/lib/otelcol/file_storage/journaldreceiver
         processors:
           batch:
             send_batch_max_size: 1500
@@ -689,12 +694,16 @@ opentelemetry-kube-stack:
                 field: attributes.log_type
                 value: k8s_audit
             storage: file_storage/filelogk8sauditreceiver
+          journald:
+            storage: file_storage/journaldreceiver
+            dmesg: true
         service:
           extensions:
             - k8s_observer
             - file_storage/filelogreceiver
             - file_storage/filelogsyslogreceiver
             - file_storage/filelogk8sauditreceiver
+            - file_storage/journaldreceiver
           pipelines:
             logs:
               processors:
@@ -709,6 +718,7 @@ opentelemetry-kube-stack:
                 - receiver_creator
                 - filelog/syslog
                 - filelog/k8s_audit
+                - journald
               exporters: null
             metrics:
               processors:
@@ -767,6 +777,9 @@ opentelemetry-kube-stack:
         - name: varlogpods
           hostPath:
             path: /var/log/pods
+        - name: varrunjournald
+          hostPath:
+            path: /run/log/journal
         - name: fs-filelogreceiver
           hostPath:
             path: /var/lib/otelcol/file_storage/filelogreceiver
@@ -779,12 +792,18 @@ opentelemetry-kube-stack:
           hostPath:
             path: /var/lib/otelcol/file_storage/filelogk8sauditreceiver
             type: DirectoryOrCreate
+        - name: fs-filelogjournaldreceiver
+          hostPath:
+            path: /var/lib/otelcol/file_storage/journaldreceiver
+            type: DirectoryOrCreate
         - name: varlibdockercontainers
           hostPath:
             path: /var/lib/docker/containers
       volumeMounts:
         - name: varlogaudit
           mountPath: /var/log/kubernetes
+        - name: varrunjournald
+          mountPath: /run/log/journal
         - name: varlogpods
           mountPath: /var/log/pods
           readOnly: true
@@ -797,6 +816,8 @@ opentelemetry-kube-stack:
           mountPath: /var/lib/otelcol/file_storage/filelogsyslogreceiver
         - name: fs-filelogk8sauditreceiver
           mountPath: /var/lib/otelcol/file_storage/filelogk8sauditreceiver
+        - name: fs-filelogjournaldreceiver
+          mountPath: /var/lib/otelcol/file_storage/journaldreceiver
     controller-k0s:
       config:
         processors:

--- a/charts/kof-istio/values.yaml
+++ b/charts/kof-istio/values.yaml
@@ -88,3 +88,4 @@ collectors:
               - file_storage/filelogreceiver
               - file_storage/filelogsyslogreceiver
               - file_storage/filelogk8sauditreceiver
+              - file_storage/journaldreceiver

--- a/charts/kof-regional/values.yaml
+++ b/charts/kof-regional/values.yaml
@@ -17,6 +17,7 @@ collectors:
               - file_storage/filelogreceiver
               - file_storage/filelogsyslogreceiver
               - file_storage/filelogk8sauditreceiver
+              - file_storage/journaldreceiver
 storage:
   kof-dashboards:
     kcm:

--- a/docker/opentelemetry-collector-contrib/Dockerfile
+++ b/docker/opentelemetry-collector-contrib/Dockerfile
@@ -1,0 +1,15 @@
+FROM otel/opentelemetry-collector-contrib:0.123.0 AS orig
+
+FROM linuxcontainers/debian-slim:latest
+RUN apt-get -y update && apt-get -y install systemd ca-certificates && apt-get clean && rm -rf /var/lib/apt/lists/*
+ARG USER_UID=10001
+ARG USER_GID=10001
+RUN groupadd --gid ${USER_GID} oteluser && \
+    useradd --uid ${USER_UID} --gid ${USER_GID} oteluser && \
+    usermod -aG systemd-journal oteluser
+USER ${USER_UID}:${USER_GID}
+COPY --from=orig /otelcol-contrib /
+COPY --from=orig /etc/otelcol-contrib/config.yaml /etc/otelcol-contrib/config.yaml
+EXPOSE 4317 55680 55679
+ENTRYPOINT ["/otelcol-contrib"]
+CMD ["--config", "/etc/otelcol-contrib/config.yaml"]

--- a/docs/release.md
+++ b/docs/release.md
@@ -43,4 +43,5 @@
   * The same for dependency `kof-dashboards` in `kof-mothership` and `kof-storage`.
   * Run: `make helm-push`
   * In `Makefile`, find `svctmpls` - to e.g. `1-5-0`
+  * In `charts/kof-collectors/values.yaml` change opentelemetry-kube-stack.collectors.daemon.image.tag
 * Get this to `main` branch using PR as usual.

--- a/kof-operator/Makefile
+++ b/kof-operator/Makefile
@@ -159,22 +159,19 @@ docker-build: dev yq build-web-app goreleaser ## Build docker image with the man
 	cp -f ../.goreleaser.yml dev/.goreleaser.yml; \
 	ARCH=$$(uname -m); \
 	if [ "$$ARCH" = "arm64" ]; then \
-		$(YQ) eval -i 'del(.builds[0])' dev/.goreleaser.yml; \
-		$(YQ) eval -i 'del(.dockers[0])' dev/.goreleaser.yml; \
-		$(YQ) eval -i '.builds[0].dir = "."' dev/.goreleaser.yml; \
-		$(YQ) eval -i '.dockers[0].skip_push = "true"' dev/.goreleaser.yml; \
-		$(YQ) eval -i '.dockers[0].dockerfile = "./goreleaser.dockerfile"' dev/.goreleaser.yml; \
-		$(YQ) eval -i '.dockers[0].image_templates[1] = "kof-operator-controller:latest"' dev/.goreleaser.yml; \
+		$(YQ) eval -i 'del(.builds[] | select(.goarch | contains(["arm64"]) | not))' dev/.goreleaser.yml; \
+		$(YQ) eval -i 'del(.dockers[] | select(.goarch != "arm64"))' dev/.goreleaser.yml; \
 	elif [ "$$ARCH" = "x86_64" ]; then \
-		$(YQ) eval -i 'del(.builds[1])' dev/.goreleaser.yml; \
-		$(YQ) eval -i 'del(.dockers[1])' dev/.goreleaser.yml; \
-		$(YQ) eval -i '.builds[0].dir = "."' dev/.goreleaser.yml; \
-		$(YQ) eval -i '.dockers[0].skip_push = "true"' dev/.goreleaser.yml; \
-		$(YQ) eval -i '.dockers[0].dockerfile = "./goreleaser.dockerfile"' dev/.goreleaser.yml; \
-		$(YQ) eval -i '.dockers[0].image_templates[1] = "kof-operator-controller:latest"' dev/.goreleaser.yml; \
+		$(YQ) eval -i 'del(.builds[] | select(.goarch | contains(["amd64"]) | not))' dev/.goreleaser.yml; \
+		$(YQ) eval -i 'del(.dockers[] | select(.goarch != "amd64"))' dev/.goreleaser.yml; \
 	fi; \
-	IMAGE_REPO=kof-operator-controller GITHUB_OWNER=k0rdent GITHUB_REPO_NAME=kof VERSION=latest $(GORELEASER) release --snapshot --clean -f dev/.goreleaser.yml
-			
+	$(YQ) eval -i 'with(.builds[]; .dir = ".")' dev/.goreleaser.yml; \
+	$(YQ) eval -i 'with(.dockers[]; .skip_push = "true")' dev/.goreleaser.yml; \
+	$(YQ) eval -i '.dockers[0].dockerfile = "./goreleaser.dockerfile"' dev/.goreleaser.yml; \
+	$(YQ) eval -i '.dockers[0].image_templates[1] = "kof-operator-controller:latest"' dev/.goreleaser.yml;
+	$(YQ) eval -i '.dockers[1].dockerfile = "../docker/opentelemetry-collector-contrib/Dockerfile"' dev/.goreleaser.yml; \
+	$(YQ) eval -i '.dockers[1].image_templates[1] = "kof-opentelemetry-collector-contrib:latest"' dev/.goreleaser.yml;
+	IMAGE_OPERATOR_REPO=kof-operator-controller IMAGE_OTEL_COLLECTOR_REPO=kof-opentelemetry-collector-contrib GITHUB_OWNER=k0rdent GITHUB_REPO_NAME=kof VERSION=latest $(GORELEASER) release --snapshot --clean -f dev/.goreleaser.yml
 
 .PHONY: build-installer
 build-installer: manifests generate kustomize ## Generate a consolidated YAML with CRDs and deployment.


### PR DESCRIPTION
Closes https://github.com/k0rdent/kof/issues/371

Enables [journaldreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/journaldreceiver) for daemon collector.

As the receiver requires journalctl binary a custom collector docker image is created with systemd package installed.