### PR TITLE
chore: fix ci to re-apply adopted clusters configs

### DIFF
--- a/.github/workflows/pr_test_adopted_upgrade.yml
+++ b/.github/workflows/pr_test_adopted_upgrade.yml
@@ -166,6 +166,12 @@ jobs:
         run: |
           make dev-operators-deploy
           make dev-ms-deploy
+      - name: "[PR] Run KIND kof Regional cluster"
+        run: |
+          make dev-adopted-deploy KIND_CLUSTER_NAME=regional-adopted KIND_CONFIG_PATH=$PWD/config/kind.yaml
+      - name: "[PR] Run KIND kof Child cluster"
+        run: |
+          make dev-adopted-deploy KIND_CLUSTER_NAME=child-adopted KIND_CONFIG_PATH=$PWD/config/kind.yaml
       - name: "[PR] Deploy KOF components on adopted Regional cluster"
         run: |
           make ${{ matrix.target }}-regional-deploy-adopted


### PR DESCRIPTION
Fix CI that cannot find latest custom collector image