### PR TITLE
ci: Using bigger GitHub runner

### DIFF
--- a/.github/workflows/build_charts.yml
+++ b/.github/workflows/build_charts.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build:
-    runs-on: ${{ github.repository_owner == 'k0rdent' && 'arc-runner-set-k0rdent' || 'ubuntu-latest' }}
+    runs-on: ${{ github.repository_owner == 'k0rdent' && 'self-hosted' || 'ubuntu-latest' }}
 
     permissions:
       contents: read

--- a/.github/workflows/build_images.yml
+++ b/.github/workflows/build_images.yml
@@ -13,7 +13,7 @@ jobs:
       group: build-${{ github.head_ref || github.run_id }}
       cancel-in-progress: true
     name: Build and Unit Test
-    runs-on: ${{ github.repository_owner == 'k0rdent' && 'arc-runner-set-k0rdent' || 'ubuntu-latest' }}
+    runs-on: ${{ github.repository_owner == 'k0rdent' && 'self-hosted' || 'ubuntu-latest' }}
     outputs:
       version: ${{ steps.vars.outputs.version }}
     permissions:

--- a/.github/workflows/helm-docs.yaml
+++ b/.github/workflows/helm-docs.yaml
@@ -3,7 +3,7 @@ on:
   - pull_request
 jobs:
   generate:
-    runs-on: ${{ github.repository_owner == 'k0rdent' && 'arc-runner-set-k0rdent' || 'ubuntu-latest' }}
+    runs-on: ${{ github.repository_owner == 'k0rdent' && 'self-hosted' || 'ubuntu-latest' }}
     # Don't use `permissions: contents: write` as it applies to base repo only.
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/pr_conventional_commit.yaml
+++ b/.github/workflows/pr_conventional_commit.yaml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   validate-pr-title:
-    runs-on: ${{ github.repository_owner == 'k0rdent' && 'arc-runner-set-k0rdent' || 'ubuntu-latest' }}
+    runs-on: ${{ github.repository_owner == 'k0rdent' && 'self-hosted' || 'ubuntu-latest' }}
     steps:
       - name: PR Conventional Commit Validation
         uses: ytanikin/pr-conventional-commits@1.4.1

--- a/.github/workflows/pr_test_adopted_upgrade.yml
+++ b/.github/workflows/pr_test_adopted_upgrade.yml
@@ -21,7 +21,7 @@ jobs:
       matrix:
         target: ["dev", "dev-istio"]
     name: Upgrade KOF
-    runs-on: ${{ github.repository_owner == 'k0rdent' && 'arc-runner-set-k0rdent' || 'ubuntu-latest' }}
+    runs-on: ${{ github.repository_owner == 'k0rdent' && 'self-hosted' || 'ubuntu-latest' }}
     steps:
       - id: kof_release
         uses: pozetroninc/github-action-get-latest-release@master

--- a/.github/workflows/pr_test_helm_chart.yml
+++ b/.github/workflows/pr_test_helm_chart.yml
@@ -18,7 +18,7 @@ on:
 jobs:
   test:
     name: Run Unit Tests
-    runs-on: ${{ github.repository_owner == 'k0rdent' && 'arc-runner-set-k0rdent' || 'ubuntu-latest' }}
+    runs-on: ${{ github.repository_owner == 'k0rdent' && 'self-hosted' || 'ubuntu-latest' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -34,7 +34,7 @@ jobs:
 
   lint-react:
     name: Run React Linter
-    runs-on: ${{ github.repository_owner == 'k0rdent' && 'arc-runner-set-k0rdent' || 'ubuntu-latest' }}
+    runs-on: ${{ github.repository_owner == 'k0rdent' && 'self-hosted' || 'ubuntu-latest' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -56,7 +56,7 @@ jobs:
 
   ui-tests:
     name: Run React Tests
-    runs-on: ${{ github.repository_owner == 'k0rdent' && 'arc-runner-set-k0rdent' || 'ubuntu-latest' }}
+    runs-on: ${{ github.repository_owner == 'k0rdent' && 'self-hosted' || 'ubuntu-latest' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -75,7 +75,7 @@ jobs:
 
   deploy:
     name: Deploy KOF & KCM
-    runs-on: ${{ github.repository_owner == 'k0rdent' && 'arc-runner-set-k0rdent' || 'ubuntu-latest' }}
+    runs-on: ${{ github.repository_owner == 'k0rdent' && 'self-hosted' || 'ubuntu-latest' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/pr_test_mgmt_upgrade.yml
+++ b/.github/workflows/pr_test_mgmt_upgrade.yml
@@ -17,7 +17,7 @@ on:
 jobs:
   deploy:
     name: Upgrade KOF
-    runs-on: ${{ github.repository_owner == 'k0rdent' && 'arc-runner-set-k0rdent' || 'ubuntu-latest' }}
+    runs-on: ${{ github.repository_owner == 'k0rdent' && 'self-hosted' || 'ubuntu-latest' }}
     steps:
       - id: kof_release
         uses: pozetroninc/github-action-get-latest-release@master

--- a/.github/workflows/release_charts.yml
+++ b/.github/workflows/release_charts.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   release:
-    runs-on: ${{ github.repository_owner == 'k0rdent' && 'arc-runner-set-k0rdent' || 'ubuntu-latest' }}
+    runs-on: ${{ github.repository_owner == 'k0rdent' && 'self-hosted' || 'ubuntu-latest' }}
 
     permissions:
       contents: read

--- a/.github/workflows/release_images.yml
+++ b/.github/workflows/release_images.yml
@@ -13,7 +13,7 @@ jobs:
       group: build-${{ github.head_ref || github.run_id }}
       cancel-in-progress: true
     name: Build and Unit Test
-    runs-on: ${{ github.repository_owner == 'k0rdent' && 'arc-runner-set-k0rdent' || 'ubuntu-latest' }}
+    runs-on: ${{ github.repository_owner == 'k0rdent' && 'self-hosted' || 'ubuntu-latest' }}
     outputs:
       version: ${{ steps.vars.outputs.version }}
     permissions:

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -10,7 +10,7 @@ jobs:
       issues: write
       pull-requests: write
 
-    runs-on: ${{ github.repository_owner == 'k0rdent' && 'arc-runner-set-k0rdent' || 'ubuntu-latest' }}
+    runs-on: ${{ github.repository_owner == 'k0rdent' && 'self-hosted' || 'ubuntu-latest' }}
     steps:
       - uses: actions/stale@v9
         with:

--- a/.github/workflows/triage.yaml
+++ b/.github/workflows/triage.yaml
@@ -10,7 +10,7 @@ jobs:
       contents: read
       issues: write
 
-    runs-on: ${{ github.repository_owner == 'k0rdent' && 'arc-runner-set-k0rdent' || 'ubuntu-latest' }}
+    runs-on: ${{ github.repository_owner == 'k0rdent' && 'self-hosted' || 'ubuntu-latest' }}
     steps:
       - name: Add needs-triage if not triage-ok
         uses: actions/github-script@v7


### PR DESCRIPTION
* Part of https://github.com/k0rdent/kof/issues/594
* Testing it on fork fails with:
  ```
  Requested labels: arc-runner-set-k0rdent
  Job defined at: denis-ryzhkov/kof/.github/workflows/pr_test_adopted_upgrade.yml@refs/heads/main
  Waiting for a runner to pick up this job...
  ```
  because this runner is available for https://github.com/k0rdent only.
* Testing on `kordent/kof` still [fails](https://github.com/k0rdent/kof/actions/runs/18379478952/job/52361957464?pr=581):
  ```
  Requested labels: arc-runner-set-k0rdent
  Job defined at: k0rdent/kof/.github/workflows/pr_conventional_commit.yaml@refs/pull/581/merge
  Waiting for a runner to pick up this job...
  ```
* Found later this worker is not available for `Public` repos.
* We've switched to our own `self-hosted` runner created by @gmlexx - thanks!
