### PR TITLE
ci: Fix of `go-version input was not specified`

### DIFF
--- a/.github/workflows/pr_test_helm_chart.yml
+++ b/.github/workflows/pr_test_helm_chart.yml
@@ -84,7 +84,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: "kof-operator/go.mod"
       - id: kcm_release
         uses: pozetroninc/github-action-get-latest-release@master
         with:


### PR DESCRIPTION
* Part of https://github.com/k0rdent/kof/issues/594
* https://github.com/k0rdent/kof/actions/runs/18529758983/job/52809162239?pr=583
  ```
  Setup go version spec 
  Warning: go-version input was not specified. The action will try to use pre-installed version.
  /bin/sh: 1: version: not found
  Error: Command failed:  version
  /bin/sh: 1: version: not found
  ```
* Caused by missing env var in `go-version: ${{ env.GO_VERSION }}`
* All other workflows were using `go-version-file` already.
* Bug in this workflow was hidden due to env var present in the old runner.