### PR TITLE
ci: Fix of `invalid semantic version` in `build_charts` CI

### DIFF
--- a/.github/workflows/build_charts.yml
+++ b/.github/workflows/build_charts.yml
@@ -18,8 +18,8 @@ jobs:
       - name: Checkout git repo
         uses: actions/checkout@v5
         with:
+          # Required for `git describe --tags`:
           fetch-depth: 0
-            # Required for `git describe --tags` below.
 
       - uses: ./.github/actions/shared-setup
       - uses: ./.github/actions/setup-yq

--- a/.github/workflows/build_images.yml
+++ b/.github/workflows/build_images.yml
@@ -22,8 +22,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v5
         with:
+          # Required for `git describe --tags`:
           fetch-depth: 0
-            # Required for `git describe --tags` below.
 
       - uses: ./.github/actions/shared-setup
       - name: Setup Go

--- a/.github/workflows/release_images.yml
+++ b/.github/workflows/release_images.yml
@@ -23,8 +23,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v5
         with:
+          # Required for `git describe --tags`:
           fetch-depth: 0
-            # Required for `git describe --tags` below.
 
       - uses: ./.github/actions/shared-setup
       - name: Setup Go


### PR DESCRIPTION
* Part of https://github.com/k0rdent/kof/issues/603
* Found `build_charts` CI workflow on push to `main` started [failing](https://github.com/k0rdent/kof/actions/workflows/build_charts.yml) after the recent PR https://github.com/k0rdent/kof/pull/584
* [Debugged](https://github.com/k0rdent/kof/commit/5279505ddfb2f207f8acb8b72e2e0c48ab5dd243) directly in the `main` branch.
* Got [better error](https://github.com/k0rdent/kof/actions/runs/18946000985/job/54097305490#step:6:36):
  ```
  helm package charts/kof-child --version bd383eb --app-version bd383eb
  Error: invalid semantic version
  ```
* Fixed with `fetch-depth: 0` in the `actions/checkout` to fetch all tags as required for `git describe --tags`.
* Deleted the debug commands.
