### PR TITLE
fix: change duplicated dashboard uid

### DIFF
--- a/charts/kof-dashboards/files/dashboards/kcm/kcm-controller-manager.yaml
+++ b/charts/kof-dashboards/files/dashboards/kcm/kcm-controller-manager.yaml
@@ -681,7 +681,7 @@ time:
 timepicker: {}
 timezone: UTC
 title: KCM Controller Manager
-uid: 72e0e05bef5099e5f049b05fdc429ed4
+uid: a3f8b2c14d5e6f7a8b9c0d1e2f3a4b5c
 version: 1
 weekStart: ''
 gnetId: 21010


### PR DESCRIPTION
Grafana operator hides one of the dashboard with the duplicated uid