### PR TITLE
fix: vmauth used vmalert image

### DIFF
--- a/charts/kof-storage/templates/victoria/vmauth.yaml
+++ b/charts/kof-storage/templates/victoria/vmauth.yaml
@@ -10,7 +10,7 @@ metadata:
 spec:
   {{- $spec := deepCopy .Values.victoriametrics.vmauth.spec }}
   {{- if $global.registry }}
-  {{- $_ := set $spec.image "repository" ( printf "%s/victoriametrics/vmalert" $global.registry) }}
+  {{- $_ := set $spec.image "repository" ( printf "%s/victoriametrics/vmauth" $global.registry) }}
   {{- end }}
   {{- if and $global.registry (ne $global.registry "docker.io") }}
   {{- $configReloaderImageTag := $spec.configReloaderImageTag | trimPrefix "quay.io/" }}


### PR DESCRIPTION
* History of `vmauth.yaml`: https://github.com/k0rdent/kof/commits/main/charts/kof-storage/templates/victoria/vmauth.yaml
* Here it was still using `vmauth` image: https://github.com/k0rdent/kof/pull/436/files
* Here it was accidentally replaced with `vmalert` image: https://github.com/k0rdent/kof/pull/478/files#diff-3c621100f39cb5cb5a1ea92f9e55e697b41530fd2dc3c8c93b49cc66c32d2633R13
