### PR TITLE
ci: fix docker pull rate limit issue

### DIFF
--- a/.github/actions/kind-config-patch/action.yaml
+++ b/.github/actions/kind-config-patch/action.yaml
@@ -1,0 +1,33 @@
+name: Patch kind config
+description: Patch kind config to add registry mirror with authentication.
+inputs:
+  kind_config_path:
+    description: 'Path to the kind config file'
+    required: false
+    default: $PWD/config/kind.yaml
+  registry-username:
+    description: Username for registry
+    required: true
+  registry-password:
+    description: Password for registry
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Patch kind config for registry mirror
+      shell: bash
+      run: |
+        KIND_CONFIG_PATH="${{ inputs.kind_config_path }}"
+        cat <<EOF > patches.yaml
+        containerdConfigPatches:
+          - |-
+            [plugins."io.containerd.grpc.v1.cri".registry.mirrors."docker.io"]
+              endpoint = ["https://registry.ci.mirantis.com/v2/dockerhub"]
+          - |-
+            [plugins."io.containerd.grpc.v1.cri".registry.configs."registry.ci.mirantis.com".auth]
+              username = "${{ inputs.registry-username }}"
+              password = "${{ inputs.registry-password }}"
+        EOF
+        sed -i '/apiVersion: kind.x-k8s.io\/v1alpha4/r patches.yaml' ${KIND_CONFIG_PATH}
+        rm patches.yaml

--- a/.github/workflows/pr_test_adopted_upgrade.yml
+++ b/.github/workflows/pr_test_adopted_upgrade.yml
@@ -78,6 +78,13 @@ jobs:
         with:
           path: kcm-repo/bin
           key: kcm-cli-${{ runner.os }}-${{ steps.kcm_release.outputs.release }}-${{ github.run_id }}
+      - name: Patch Kind Config
+        if: github.repository_owner == 'k0rdent'
+        uses: ./.github/actions/kind-config-patch
+        with:
+          registry-username: ${{ secrets.REGISTRY_CI_USERNAME }}
+          registry-password: ${{ secrets.REGISTRY_CI_PASSWORD }}
+
       - name: "[Latest release] Create KIND kcm cluster"
         run: |
           export KIND_CONFIG_PATH=$PWD/config/kind.yaml

--- a/.github/workflows/pr_test_helm_chart.yml
+++ b/.github/workflows/pr_test_helm_chart.yml
@@ -110,6 +110,12 @@ jobs:
         with:
           path: kcm-repo/bin
           key: kcm-cli-${{ runner.os }}-${{ github.sha }}-${{ github.run_id }}
+      - name: Patch Kind Config
+        if: github.repository_owner == 'k0rdent'
+        uses: ./.github/actions/kind-config-patch
+        with:
+          registry-username: ${{ secrets.REGISTRY_CI_USERNAME }}
+          registry-password: ${{ secrets.REGISTRY_CI_PASSWORD }}
       - name: Apply KCM Dev Configuration
         run: |
           export KIND_CONFIG_PATH=$PWD/config/kind.yaml

--- a/.github/workflows/pr_test_kof_installation.yaml
+++ b/.github/workflows/pr_test_kof_installation.yaml
@@ -44,6 +44,12 @@ jobs:
       - name: "[Main Branch] Install KCM CLI"
         run: |
           make -C kcm-repo cli-install
+      - name: Patch Kind Config
+        if: github.repository_owner == 'k0rdent'
+        uses: ./.github/actions/kind-config-patch
+        with:
+          registry-username: ${{ secrets.REGISTRY_CI_USERNAME }}
+          registry-password: ${{ secrets.REGISTRY_CI_PASSWORD }}
       - name: "[Main Branch] Create KIND kcm cluster"
         run: |
           make kcm-dev-apply KCM_REPO_PATH="kcm-repo" KIND_CONFIG_PATH="$PWD/config/kind.yaml"

--- a/.github/workflows/pr_test_mgmt_upgrade.yml
+++ b/.github/workflows/pr_test_mgmt_upgrade.yml
@@ -72,6 +72,12 @@ jobs:
         with:
           path: kcm-repo/bin
           key: kcm-cli-${{ runner.os }}-${{ steps.kcm_release.outputs.release }}-${{ github.run_id }}
+      - name: Patch Kind Config
+        if: github.repository_owner == 'k0rdent'
+        uses: ./.github/actions/kind-config-patch
+        with:
+          registry-username: ${{ secrets.REGISTRY_CI_USERNAME }}
+          registry-password: ${{ secrets.REGISTRY_CI_PASSWORD }}
       - name: "[Latest release] Create KIND kcm cluster"
         run: |
           export KIND_CONFIG_PATH=$PWD/config/kind.yaml


### PR DESCRIPTION
Part of https://github.com/k0rdent/2a-internal/issues/276

This PR fixes the Docker pull rate limit issue in CI by configuring the kind cluster to use the Mirantis registry