### PR TITLE
fix: prevent grafana operator reconciliation issue due to missing creds

### DIFF
--- a/charts/kof-mothership/templates/grafana/secret.yaml
+++ b/charts/kof-mothership/templates/grafana/secret.yaml
@@ -12,6 +12,8 @@ apiVersion: v1
 metadata:
   name: {{ .Values.grafana.security.credentials_secret_name }}
   namespace: {{ .Release.Namespace }}
+  annotations:
+     helm.sh/resource-policy: keep # prevent grafana-operator from reconciliation issue due to missing credentials
 stringData:
   GF_SECURITY_ADMIN_USER: {{ $username | quote }} # Grafana username
   GF_SECURITY_ADMIN_PASSWORD: {{ $password | quote }} # Grafana password


### PR DESCRIPTION
Uninstallation via helm uninstall --wait --cascade foreground -n kof kof-mothership takes too much time due to grafana-operator reconciliation issue where despite the deletion of grafana CR the operator is still trying to create it but failed as the credentials secret already deleted.