### PR TITLE
fix: Make global values compatible with new collectors

### DIFF
--- a/charts/kof-child/templates/child-multi-cluster-service.yaml
+++ b/charts/kof-child/templates/child-multi-cluster-service.yaml
@@ -1,5 +1,5 @@
 {{- $global := .Values.global | default dict }}
-{{- $globalValues := .Values.globalValues }}
+{{- $globalValues := .Values.globalValues | fromYaml }}
 {{- $customRegistry := or $global.registry $globalValues.registry "" }}
 {{- if eq $customRegistry "docker.io" }}{{ $customRegistry = "" }}{{ end }}
 

--- a/charts/kof-child/values.yaml
+++ b/charts/kof-child/values.yaml
@@ -2,7 +2,9 @@ cert-manager:
   enabled: true
   template: cert-manager-v1-16-4
 
-globalValues: {}
+# --set-file globalValues=global-values.yaml
+globalValues: "{}"
+
 collectors: {}
 operators:
   grafana-operator:

--- a/charts/kof-regional/templates/regional-multi-cluster-service.yaml
+++ b/charts/kof-regional/templates/regional-multi-cluster-service.yaml
@@ -1,5 +1,5 @@
 {{- $global := .Values.global | default dict }}
-{{- $globalValues := .Values.globalValues }}
+{{- $globalValues := .Values.globalValues | fromYaml }}
 {{- $customRegistry := or $global.registry $globalValues.registry "" }}
 {{- if eq $customRegistry "docker.io" }}{{ $customRegistry = "" }}{{ end }}
 

--- a/charts/kof-regional/values.yaml
+++ b/charts/kof-regional/values.yaml
@@ -6,7 +6,9 @@ ingress-nginx:
   enabled: true
   template: ingress-nginx-4-12-1
 
-globalValues: {}
+# --set-file globalValues=global-values.yaml
+globalValues: "{}"
+
 collectors: {}
 storage: {}
 operators: {}


### PR DESCRIPTION
* Making global values DRY and simple by:
  * deleting the duplicates hardcoded in MCS-es,
  * passing `-f global-values.yaml` on direct helm install,
  * passing `--set-file globalValues=global-values.yaml` on helm install via MCS-es.
* Tested:
```
helm template kof-regional ./charts/kof-regional \
  --set-file globalValues=global-values.yaml > kof-regional-rendered.yaml

helm template kof-child ./charts/kof-child \
  --set-file globalValues=global-values.yaml > kof-child-rendered.yaml
```
* Result:
  * [global-values.yaml](https://github.com/user-attachments/files/24041530/global-values.yaml)
  * [kof-child-rendered.yaml](https://github.com/user-attachments/files/24041531/kof-child-rendered.yaml)
  * [kof-regional-rendered.yaml](https://github.com/user-attachments/files/24041533/kof-regional-rendered.yaml)
