### PR TITLE
chore: prevent kcm-controller OOM causing CI failure

### DIFF
--- a/.github/workflows/pr_test_helm_chart.yml
+++ b/.github/workflows/pr_test_helm_chart.yml
@@ -119,6 +119,7 @@ jobs:
       - name: Apply KCM Dev Configuration
         run: |
           make kcm-dev-apply KCM_REPO_PATH="kcm-repo" KIND_CONFIG_PATH="$PWD/config/kind.yaml"
+          kubectl patch mgmt/kcm --type='json' -p '[{"op": "replace", "path": "/spec/providers", "value":[{"name":"projectsveltos"}]}]'
       - name: Push KOF Helm Charts
         run: |
           make helm-push

--- a/.github/workflows/pr_test_kof_installation.yaml
+++ b/.github/workflows/pr_test_kof_installation.yaml
@@ -54,8 +54,6 @@ jobs:
         run: |
           make kcm-dev-apply KCM_REPO_PATH="kcm-repo" KIND_CONFIG_PATH="$PWD/config/kind.yaml"
           kubectl patch mgmt/kcm --type='json' -p '[{"op": "replace", "path": "/spec/providers", "value":[{"name":"projectsveltos"}]}]'
-          kubectl patch mgmt kcm --type=merge -p '{"spec":{"core":{"kcm":{"config":{"resources":{"limits":{"cpu":"500m","memory":"256Mi"},"requests":{"cpu":"10m","memory":"64Mi"}}}}}}}'
-          kubectl wait --for=condition=Ready mgmt/kcm --timeout=10m
       - name: "[Main Branch] Checkout Istio repository"
         if: ${{ matrix.target == 'dev-istio' }}
         uses: actions/checkout@v5

--- a/.github/workflows/pr_test_mgmt_upgrade.yml
+++ b/.github/workflows/pr_test_mgmt_upgrade.yml
@@ -91,6 +91,7 @@ jobs:
       - name: "[Latest release] Create KIND kcm cluster"
         run: |
           make kcm-dev-apply KCM_REPO_PATH="kcm-repo" KIND_CONFIG_PATH="$PWD/config/kind.yaml"
+          kubectl patch mgmt/kcm --type='json' -p '[{"op": "replace", "path": "/spec/providers", "value":[{"name":"projectsveltos"}]}]'
       - name: "[Latest Release] Deploy KOF local registry container"
         run: |
           make registry-deploy

--- a/Makefile
+++ b/Makefile
@@ -107,9 +107,9 @@ kcm-kind-deploy: dev
 
 .PHONY: kcm-dev-apply
 kcm-dev-apply: dev cli-install kcm-kind-deploy
+	$(YQ) eval -i '.resources.limits.memory = "512Mi"' $(KCM_REPO_PATH)/config/dev/kcm_values.yaml
 	make -C $(KCM_REPO_PATH) dev-apply
-	$(KUBECTL) wait --for create mgmt/kcm --timeout=1m
-	$(KUBECTL) patch mgmt kcm --type=merge -p '{"spec":{"core":{"kcm":{"config":{"resources":{"limits":{"cpu":"500m","memory":"256Mi"},"requests":{"cpu":"10m","memory":"64Mi"}}}}}}}'
+	$(KUBECTL) wait --for=condition=Ready mgmt/kcm --timeout=10m
 	$(KUBECTL) wait --for condition=available deployment/kcm-controller-manager --timeout=1m -n $(KCM_NAMESPACE)
 
 .PHONY: kind-deploy


### PR DESCRIPTION
The kcm-controller pod was being OOMKilled in CI:

```
    State: Terminated
    Reason: OOMKilled
    Restart Count: 2
    Limits:
      memory: 128Mi
```

This commit increases the memory limit from 128Mi (default limit) to 512Mi to prevent CrashLoopBackOff failures during CI runs.