### PR TITLE
fix: prevent SANs checking error

### DIFF
--- a/charts/kof-mothership/README.md
+++ b/charts/kof-mothership/README.md
@@ -115,7 +115,7 @@ KOF Helm chart for KOF Management cluster
 | promxy<br>.serviceAccount<br>.name | string | `nil` | Name for the service account of promxy. If not set, it is generated as `kof-mothership-promxy`. |
 | sveltos<br>.grafanaDashboard | bool | `true` | Adds Sveltos dashboard to Grafana. |
 | sveltos<br>.serviceMonitors | bool | `true` | Creates `ServiceMonitor`-s for Sveltos `sc-manager` and `addon-controller`. |
-| victoria-metrics-operator | object | `{"crds":{"cleanup":{"enabled":false},`<br>`"plain":true},`<br>`"enabled":true,`<br>`"operator":{"disable_prometheus_converter":true},`<br>`"serviceMonitor":{"enabled":true,`<br>`"vm":false}}` | [Docs](https://github.com/VictoriaMetrics/helm-charts/tree/master/charts/victoria-metrics-operator#parameters) |
+| victoria-metrics-operator | object | `{"crds":{"cleanup":{"enabled":false},`<br>`"plain":true},`<br>`"enabled":true,`<br>`"global":{"cluster":{"dnsDomain":"cluster.local"}},`<br>`"operator":{"disable_prometheus_converter":true},`<br>`"serviceMonitor":{"enabled":true,`<br>`"vm":false}}` | [Docs](https://github.com/VictoriaMetrics/helm-charts/tree/master/charts/victoria-metrics-operator#parameters) |
 | victoriametrics<br>.enabled | bool | `true` | Enables VictoriaMetrics. |
 | victoriametrics<br>.vmalert<br>.enabled | bool | `true` | Enables VMAlertManager only, as VMAlert is replaced with promxy in kof-mothership. |
 | victoriametrics<br>.vmalert<br>.manager<br>.spec | object | `{"configReloaderImageTag":"jimmidyson/configmap-reload:v0.3.0",`<br>`"image":{"repository":"prom/alertmanager",`<br>`"tag":"v0.27.0"},`<br>`"port":"9093"}` | [VMAlertmanagerSpec](https://docs.victoriametrics.com/operator/api/#vmalertmanagerspec). |

--- a/charts/kof-mothership/values.yaml
+++ b/charts/kof-mothership/values.yaml
@@ -374,6 +374,9 @@ dex:
 # -- [Docs](https://github.com/VictoriaMetrics/helm-charts/tree/master/charts/victoria-metrics-operator#parameters)
 victoria-metrics-operator:
   enabled: true
+  global:
+    cluster:
+      dnsDomain: cluster.local
   serviceMonitor:
     enabled: true
     vm: false


### PR DESCRIPTION
The default dnsDomain has the trailing dot which is [not working correctly with some go versions](https://github.com/golang/go/issues/75828)
