### PR TITLE
fix: move PKI_PATH to defaultCR env

### DIFF
--- a/charts/kof-child/templates/child-multi-cluster-service.yaml
+++ b/charts/kof-child/templates/child-multi-cluster-service.yaml
@@ -167,17 +167,6 @@ spec:
                                   port: 8888
                     {{- end }}
             defaultCRConfig:
-              env:
-                - name: KOF_VM_USER
-                  valueFrom:
-                    secretKeyRef:
-                      key: username
-                      name: {vmuserSecretName}
-                - name: KOF_VM_PASSWORD
-                  valueFrom:
-                    secretKeyRef:
-                      key: password
-                      name: {vmuserSecretName}
               podAnnotations:
                 k0rdent.mirantis.com/kof-vmuser-secret-version: "{vmuserSecretVersion}"
               config:
@@ -254,7 +243,23 @@ spec:
           {{- else }} | replace "{tracesEndpoint}" $tracesEndpoint | replace "{logsEndpoint}" $logsEndpoint | replace "{writeMetricsEndpoint}" $writeMetricsEndpoint | replace "{readMetricsEndpoint}" $readMetricsEndpoint | replace "{vmuserSecretVersion}" $vmuserSecretVersion
           {{- end }} | fromYaml {{`}}`}}
           {{`{{`}} $globalValuesFromHelm := `{{ $globalValues | toYaml | nindent 10 }}` | fromYaml {{`}}`}}
-          {{`{{ mergeOverwrite (dict) $globalValuesFromHelm $collectorsValuesHere $collectorsValuesFromHelm $collectorsValuesFromAnnotation | toYaml | nindent 4 }}`}}
+          {{`{{ $mergedValues := mergeOverwrite (dict) $globalValuesFromHelm $collectorsValuesHere $collectorsValuesFromHelm $collectorsValuesFromAnnotation }}`}}
+          {{`{{ `}} $defaultCRConfigEnv := `
+          env:
+            - name: KOF_VM_USER
+              valueFrom:
+                secretKeyRef:
+                  key: username
+                  name: {vmuserSecretName}
+            - name: KOF_VM_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  key: password
+                  name: {vmuserSecretName}
+          `  | replace "{vmuserSecretName}" $vmuserSecretName | fromYaml {{`}}`}}
+          {{`{{ $env := concat (get $defaultCRConfigEnv "env") (dig "opentelemetry-kube-stack" "defaultCRConfig" "env" (list) $mergedValues) }}`}}
+          {{`{{ $mergedValues = mergeOverwrite $mergedValues (dict "opentelemetry-kube-stack" (dict "defaultCRConfig" (dict "env" $env)))  }}`}}
+          {{`{{ $mergedValues | toYaml | nindent 4 }}`}}
     templateResourceRefs:
     - identifier: ChildConfig
       resource:

--- a/charts/kof-collectors/values.yaml
+++ b/charts/kof-collectors/values.yaml
@@ -819,9 +819,6 @@ opentelemetry-kube-stack:
         - name: fs-filelogjournaldreceiver
           mountPath: /var/lib/otelcol/file_storage/journaldreceiver
     controller-k0s:
-      env:
-        - name: PKI_PATH
-          value: var/lib/k0s
       config:
         processors:
           batch:
@@ -1131,7 +1128,9 @@ opentelemetry-kube-stack:
               - otlp
     configmaps: []
     enabled: false
-    env: []
+    env:
+      - name: PKI_PATH
+        value: var/lib/k0s
     fullnameOverride: ""
     hostNetwork: false
     image:

--- a/demo/cluster/adopted-cluster-child.yaml
+++ b/demo/cluster/adopted-cluster-child.yaml
@@ -25,6 +25,9 @@ spec:
                 otlphttp/traces:
                   tls:
                     insecure_skip_verify: true
+            env:
+              - name: PKI_PATH
+                value: etc/kubernetes
         opencost:
           opencost:
             prometheus:

--- a/demo/cluster/adopted-cluster-regional.yaml
+++ b/demo/cluster/adopted-cluster-regional.yaml
@@ -25,3 +25,8 @@ spec:
           enabled: true
           args:
             - --kubelet-insecure-tls
+        opentelemetry-kube-stack:
+          defaultCRConfig:
+            env:
+              - name: PKI_PATH
+                value: etc/kubernetes

--- a/demo/collectors-values.yaml
+++ b/demo/collectors-values.yaml
@@ -3,6 +3,9 @@ kcm:
 opentelemetry-kube-stack:
   clusterName: mothership
   defaultCRConfig:
+    env:
+      - name: PKI_PATH
+        value: etc/kubernetes
     config:
       processors:
         resource/k8sclustername:
@@ -18,8 +21,3 @@ opentelemetry-kube-stack:
           external_labels:
             cluster: mothership
             clusterNamespace: kcm-system
-  collectors:
-    controller-k0s:
-      env:
-        - name: PKI_PATH
-          value: etc/kubernetes


### PR DESCRIPTION
Due to [mergeOverwrite in opentelemetry-kube-stack chart](https://github.com/open-telemetry/opentelemetry-helm-charts/blob/opentelemetry-kube-stack-0.5.3/charts/opentelemetry-kube-stack/templates/collector.yaml#L3) we cannot customize individual collector env independently from defaultCR env without loosing defaultCR env. 