### PR TITLE
fix: MCS valuesFrom has no namespace, helm v3 warns, helm v4 fails

### DIFF
--- a/charts/kof-regional/templates/regional-multi-cluster-service.yaml
+++ b/charts/kof-regional/templates/regional-multi-cluster-service.yaml
@@ -209,7 +209,6 @@ spec:
           {{`{{ mergeOverwrite (dict) $globalValuesFromHelm $storageValuesHere $storageValuesFromHelm $storageValuesFromAnnotation | toYaml | nindent 4 }}`}}
         valuesFrom:
           - kind: ConfigMap
-            namespace: "{{`{{ .Cluster.metadata.namespace }}`}}"
             name: kof-record-vmrules-{{`{{ .Cluster.metadata.name }}`}}
 
       - name: kof-collectors


### PR DESCRIPTION
* Closes https://github.com/k0rdent/kof/issues/716