### PR TITLE
fix: duplicate MultiClusterService rendering when Istio is disabled

### DIFF
--- a/charts/kof-child/templates/child-multi-cluster-service.yaml
+++ b/charts/kof-child/templates/child-multi-cluster-service.yaml
@@ -3,13 +3,12 @@
 {{- $customRegistry := or $global.registry $globalValues.registry "" }}
 {{- if eq $customRegistry "docker.io" }}{{ $customRegistry = "" }}{{ end }}
 
-{{- $istioList := ternary (list true false) (list false) $.Values.istio.enabled }}
-{{- range $istio := $istioList }}
+{{- range $istio := $.Values.istio.enabled | ternary (list true false) (list false) }}
 ---
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: MultiClusterService
 metadata:
-{{- if and ($istio) ($.Values.istio.enabled) }}
+{{- if $istio }}
    name: kof-istio-child-cluster
 {{- else }}
   name: kof-child-cluster
@@ -18,7 +17,7 @@ spec:
   clusterSelector:
     matchLabels:
       k0rdent.mirantis.com/kof-cluster-role: child
-    {{- if and ($istio) ($.Values.istio.enabled) }}
+    {{- if $istio }}
       k0rdent.mirantis.com/istio-role: member
     {{- else }}
     matchExpressions:
@@ -26,7 +25,7 @@ spec:
         operator: DoesNotExist
     {{- end }}
 
-  {{- if and ($istio) ($.Values.istio.enabled) }}
+  {{- if $istio }}
    {{- if $.Values.istio.dependsOn }}
   dependsOn:
   {{- range $.Values.istio.dependsOn }}
@@ -99,7 +98,7 @@ spec:
         values: |
           {{`{{ $vmuserHash := printf "kof-cluster-config-%s/%s" .Cluster.metadata.name .Cluster.metadata.namespace | adler32sum }}`}}
           {{`{{ $vmuserSecretName := printf "kof-vmuser-creds-%s" $vmuserHash }}`}}
-        {{- if and ($istio) ($.Values.istio.enabled) }}
+        {{- if $istio }}
           {{`{{ $regionalClusterName := getField "ChildConfig" "data.regional_cluster_name" }}`}}
         {{- else }}
           {{`{{ $writeMetricsEndpoint := getField "ChildConfig" "data.write_metrics_endpoint" }}`}}
@@ -117,12 +116,12 @@ spec:
           opentelemetry-kube-stack:
             clusterName: {childClusterName}
             collectors:
-            {{- if and ($istio) ($.Values.istio.enabled) }}
+            {{- if $istio }}
               controller-k0s:
                 enabled: false
             {{- end }}
               daemon:
-              {{- if and ($istio) ($.Values.istio.enabled) }}
+              {{- if $istio }}
                 hostNetwork: false
               {{- else }}
                 hostNetwork: true
@@ -201,7 +200,7 @@ spec:
                 exporters:
                   debug: {}
                   otlphttp/logs:
-                  {{- if and ($istio) ($.Values.istio.enabled) }}
+                  {{- if $istio }}
                     logs_endpoint: http://{regionalClusterName}-vmauth:8427/vli/insert/opentelemetry/v1/logs
                   {{- else }}
                     logs_endpoint: {logsEndpoint}
@@ -209,7 +208,7 @@ spec:
                     auth:
                       authenticator: basicauth/logs
                   otlphttp/traces:
-                  {{- if and ($istio) ($.Values.istio.enabled) }}
+                  {{- if $istio }}
                     traces_endpoint: http://{regionalClusterName}-vmauth:8427/vti/insert/opentelemetry/v1/traces
                   {{- else }}
                     traces_endpoint: {tracesEndpoint}
@@ -217,7 +216,7 @@ spec:
                     auth:
                       authenticator: basicauth/traces
                   prometheusremotewrite:
-                  {{- if and ($istio) ($.Values.istio.enabled) }}
+                  {{- if $istio }}
                     endpoint: http://{regionalClusterName}-vmauth:8427/vm/insert/0/prometheus/api/v1/write
                   {{- else }}
                     endpoint: {writeMetricsEndpoint}
@@ -232,7 +231,7 @@ spec:
               prometheus:
                 existingSecretName: {vmuserSecretName}
                 external:
-                {{- if and ($istio) ($.Values.istio.enabled) }}
+                {{- if $istio }}
                   url: http://{regionalClusterName}-vmauth:8427/vm/select/0/prometheus
                 {{- else }}
                   url: {readMetricsEndpoint}
@@ -240,7 +239,7 @@ spec:
               exporter:
                 defaultClusterId: {childClusterName}
           ` | replace "{childClusterName}" .Cluster.metadata.name | replace "{childClusterNamespace}" .Cluster.metadata.namespace | replace "{vmuserSecretName}" $vmuserSecretName
-          {{- if and ($istio) ($.Values.istio.enabled) }} | replace "{regionalClusterName}" $regionalClusterName
+          {{- if $istio }} | replace "{regionalClusterName}" $regionalClusterName
           {{- else }} | replace "{tracesEndpoint}" $tracesEndpoint | replace "{logsEndpoint}" $logsEndpoint | replace "{writeMetricsEndpoint}" $writeMetricsEndpoint | replace "{readMetricsEndpoint}" $readMetricsEndpoint | replace "{vmuserSecretVersion}" $vmuserSecretVersion
           {{- end }} | fromYaml {{`}}`}}
           {{`{{`}} $globalValuesFromHelm := `{{ $globalValues | toYaml | nindent 10 }}` | fromYaml {{`}}`}}

--- a/charts/kof-regional/templates/regional-multi-cluster-service.yaml
+++ b/charts/kof-regional/templates/regional-multi-cluster-service.yaml
@@ -3,13 +3,12 @@
 {{- $customRegistry := or $global.registry $globalValues.registry "" }}
 {{- if eq $customRegistry "docker.io" }}{{ $customRegistry = "" }}{{ end }}
 
-{{- $istioList := ternary (list true false) (list false) $.Values.istio.enabled }}
-{{- range $istio := $istioList }}
+{{- range $istio := $.Values.istio.enabled | ternary (list true false) (list false) }}
 ---
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: MultiClusterService
 metadata:
-{{- if and ($istio) ($.Values.istio.enabled) }}
+{{- if $istio }}
   name: kof-istio-regional-cluster
 {{- else }}
   name: kof-regional-cluster
@@ -18,7 +17,7 @@ spec:
   clusterSelector:
     matchLabels:
       k0rdent.mirantis.com/kof-cluster-role: regional
-    {{- if and ($istio) ($.Values.istio.enabled) }}
+    {{- if $istio }}
       k0rdent.mirantis.com/istio-role: member
     {{- else }}
     matchExpressions:
@@ -26,7 +25,7 @@ spec:
         operator: DoesNotExist
     {{- end }}
 
-  {{- if and ($istio) ($.Values.istio.enabled) }}
+  {{- if $istio }}
   {{- if $.Values.istio.dependsOn }}
   dependsOn:
   {{- range $.Values.istio.dependsOn }}
@@ -169,7 +168,7 @@ spec:
                   current: {}
                 filters: {}
                 istio_dashboard_enabled: {{ $istio }}
-        {{- if and ($istio) ($.Values.istio.enabled) }}
+        {{- if $istio }}
           istio_endpoints: true
         {{- else }}
           external-dns:
@@ -189,7 +188,7 @@ spec:
             {{- end }}
           grafana:
             ingress:
-            {{- if and ($istio) ($.Values.istio.enabled) }}
+            {{- if $istio }}
               enabled: false
             {{- else }}
               host: %q
@@ -243,7 +242,7 @@ spec:
                       - file_storage/filelogsyslogreceiver
                       - file_storage/filelogk8sauditreceiver
                       - file_storage/journaldreceiver
-          {{- if and ($istio) ($.Values.istio.enabled) }}
+          {{- if $istio }}
               controller-k0s:
                 enabled: false
           {{- end }}


### PR DESCRIPTION
This PR fixes an issue where the Helm templates in **kof-child** and **kof-regional** would always iterate over both `true` and `false` for the Istio loop, even when `istio.enabled` was set to `false`.

As a result, the chart rendered duplicate `MultiClusterService` resources with identical IDs, causing Kustomize reconciliation failures (`already registered id`):

```yaml
status:
  conditions:
    - lastTransitionTime: '2026-02-20T08:56:38Z'
      message: >-
        Helm upgrade failed for release kof/kof-regional with chart
        kof-regional@1.7.1: error while running post render on files: may not
        add resource with an already registered id:
        MultiClusterService.v1beta1.k0rdent.mirantis.com/kof-regional-cluster.[noNs]
```

## Change

Updated the loop logic to conditionally build the iteration list based on `$.Values.istio.enabled`:

- When `istio.enabled = true` → iterate over `true` and `false` (existing behavior)
- When `istio.enabled = false` → iterate only over `false`

This prevents duplicate manifests from being rendered while preserving the intended behavior when Istio is enabled.

## Impact

- Fixes Helm failures due to duplicate resource IDs
- Keeps backward-compatible behavior when Istio is enabled
- Applies consistently to both **kof-child** and **kof-regional**

## Suggestion

Include this fix as part of a patch-release to make `kof` usable again in non-istio setups. Otherwise, if I am not mistaken, it is currently a hard blocker.