### PR TITLE
fix(acl): prevent error from duplicate header write

### DIFF
--- a/kof-operator/internal/acl/handlers/helper.go
+++ b/kof-operator/internal/acl/handlers/helper.go
@@ -27,12 +27,11 @@ func StreamProxyRequest(ctx context.Context, url, method string, writer http.Res
 		return fmt.Errorf("received non-OK response: %s", resp.Status)
 	}
 
+	writer.Header().Add("Content-Type", "application/json")
+
 	if _, err := io.Copy(writer, resp.Body); err != nil {
 		return fmt.Errorf("failed to proxy response body: %w", err)
 	}
-
-	writer.Header().Add("Content-Type", "application/json")
-	writer.WriteHeader(resp.StatusCode)
 
 	return nil
 }


### PR DESCRIPTION
This PR fixes a bug in the ACL handler's `StreamProxyRequest` function where headers and status were being written after the response body had already been sent via `io.Copy`, causing "http: superfluous response.WriteHeader call" errors.