### PR TITLE
fix: Double custom registry in pod image

### DIFF
--- a/charts/kof-child/templates/child-multi-cluster-service.yaml
+++ b/charts/kof-child/templates/child-multi-cluster-service.yaml
@@ -1,7 +1,6 @@
 {{- $global := .Values.global | default dict }}
 {{- $globalValues := .Values.globalValues | fromYaml }}
 {{- $customRegistry := or $global.registry $globalValues.registry "" }}
-{{- if eq $customRegistry "docker.io" }}{{ $customRegistry = "" }}{{ end }}
 
 {{- range $istio := $.Values.istio.enabled | ternary (list true false) (list false) }}
 ---

--- a/charts/kof-collectors/templates/opentelemetry/instrumentation.yaml
+++ b/charts/kof-collectors/templates/opentelemetry/instrumentation.yaml
@@ -16,7 +16,7 @@ spec:
     argument: "1"
   go:
     image: "
-      {{- if and $global.registry (ne $global.registry "docker.io") }}{{ $global.registry }}
+      {{- with $global.registry }}{{ . }}
       {{- else }}ghcr.io/open-telemetry
       {{- end }}/opentelemetry-go-instrumentation/autoinstrumentation-go:v0.21.0"
     resourceRequirements:

--- a/charts/kof-mothership/README.md
+++ b/charts/kof-mothership/README.md
@@ -56,7 +56,7 @@ KOF Helm chart for KOF Management cluster
 | global<br>.clusterName | string | `"mothership"` | Value of clusterName usually identical to cluster used in some subcharts (e.g. otel) |
 | global<br>.random_password_length | int | `12` | Length of the auto-generated passwords for Grafana (if enabled) and VictoriaMetrics. |
 | global<br>.random_username_length | int | `8` | Length of the auto-generated usernames for Grafana (if enabled) and VictoriaMetrics. |
-| global<br>.registry | string | `"docker.io"` | Custom image registry, `sveltos-dashboard` requires not empty value. |
+| global<br>.registry | string | `""` | Custom image registry. |
 | global<br>.storageClass | string | `""` | Name of the storage class used by Grafana (if enabled), `vmstorage` (long-term storage of raw time series data), and `vmselect` (cache of query results). Keep it unset or empty to leverage the advantages of [default storage class](https://kubernetes.io/docs/concepts/storage/storage-classes/#default-storageclass). |
 | grafana<br>.enabled | bool | `false` | Enables Grafana. |
 | grafana<br>.gateway<br>.enabled | bool | `false` | Use gateway to access Grafana without port-forwarding. |

--- a/charts/kof-mothership/templates/acl/deployment.yaml
+++ b/charts/kof-mothership/templates/acl/deployment.yaml
@@ -67,7 +67,7 @@ spec:
         - "--development-mode=true"
         {{- end }}
         image: "
-          {{- if and $global.registry (ne $global.registry "docker.io") }}{{ $global.registry }}
+          {{- with $global.registry }}{{ . }}
           {{- else }}{{ .Values.kcm.kof.acl.image.registry }}
           {{- end }}/{{ .Values.kcm.kof.acl.image.repository }}:
           {{- with .Values.kcm.kof.acl.image.tag }}{{ . }}

--- a/charts/kof-mothership/templates/kof-operator/operator-deployment.yaml
+++ b/charts/kof-mothership/templates/kof-operator/operator-deployment.yaml
@@ -72,7 +72,7 @@ spec:
           - name: "RELEASE_NAME"
             value: {{ .Release.Name }}
         image: "
-          {{- if and $global.registry (ne $global.registry "docker.io") }}{{ $global.registry }}
+          {{- with $global.registry }}{{ . }}
           {{- else }}{{ .Values.kcm.kof.operator.image.registry }}
           {{- end }}/{{ .Values.kcm.kof.operator.image.repository }}:
           {{- with .Values.kcm.kof.operator.image.tag }}{{ . }}

--- a/charts/kof-mothership/templates/promxy/promxy-deployment.yaml
+++ b/charts/kof-mothership/templates/promxy/promxy-deployment.yaml
@@ -67,7 +67,7 @@ spec:
         command:
         - "/bin/promxy"
         image: "
-          {{- if and $global.registry (ne $global.registry "docker.io") }}{{ $global.registry }}
+          {{- with $global.registry }}{{ . }}
           {{- else }}{{ .Values.promxy.image.registry }}
           {{- end }}/{{ .Values.promxy.image.repository }}:{{ .Values.promxy.image.tag | default .Chart.Version }}"
         imagePullPolicy: {{ .Values.promxy.image.pullPolicy }}

--- a/charts/kof-mothership/templates/victoria/vmcluster.yaml
+++ b/charts/kof-mothership/templates/victoria/vmcluster.yaml
@@ -8,11 +8,6 @@ metadata:
   namespace: {{ .Release.Namespace }}
 spec:
   {{- $spec := deepCopy .Values.victoriametrics.vmcluster.spec }}
-  {{- if $global.registry }}
-  {{- $_ := set $spec.vminsert.image "repository" ( printf "%s/victoriametrics/vminsert" $global.registry) }}
-  {{- $_ := set $spec.vmselect.image "repository" ( printf "%s/victoriametrics/vmselect" $global.registry) }}
-  {{- $_ := set $spec.vmstorage.image "repository" ( printf "%s/victoriametrics/vmstorage" $global.registry) }}
-  {{- end }}
   {{- if $global.storageClass }}
   {{- $_ := set $spec.vmselect.storage.volumeClaimTemplate.spec "storageClassName" $global.storageClass }}
   {{- $_ := set $spec.vmstorage.storage.volumeClaimTemplate.spec "storageClassName" $global.storageClass }}

--- a/charts/kof-mothership/values.yaml
+++ b/charts/kof-mothership/values.yaml
@@ -16,8 +16,8 @@ global:
   # -- Length of the auto-generated passwords for Grafana (if enabled) and VictoriaMetrics.
   random_password_length: 12
 
-  # -- Custom image registry, `sveltos-dashboard` requires not empty value.
-  registry: docker.io
+  # -- Custom image registry.
+  registry: ""
 
 
 cert-manager:

--- a/charts/kof-regional/templates/regional-multi-cluster-service.yaml
+++ b/charts/kof-regional/templates/regional-multi-cluster-service.yaml
@@ -1,7 +1,6 @@
 {{- $global := .Values.global | default dict }}
 {{- $globalValues := .Values.globalValues | fromYaml }}
 {{- $customRegistry := or $global.registry $globalValues.registry "" }}
-{{- if eq $customRegistry "docker.io" }}{{ $customRegistry = "" }}{{ end }}
 
 {{- range $istio := $.Values.istio.enabled | ternary (list true false) (list false) }}
 {{- $gatewayEnabled := and (not $istio) (index $.Values "envoy-gateway" "enabled") }}

--- a/charts/kof-storage/templates/victoria/vmauth.yaml
+++ b/charts/kof-storage/templates/victoria/vmauth.yaml
@@ -21,9 +21,6 @@ spec:
   {{- if not (index $spec.extraArgs "reloadAuthKey") }}
   {{- $_ := set $spec.extraArgs "reloadAuthKey" (randAlphaNum 32) }}
   {{- end }}
-  {{- if $global.registry }}
-  {{- $_ := set $spec.image "repository" ( printf "%s/victoriametrics/vmauth" $global.registry) }}
-  {{- end }}
   {{- if hasKey $spec "ingress" }}
   {{- if $spec.ingress.enabled }}
     {{- if not (get $spec.ingress.annotations "cert-manager.io/cluster-issuer") }}

--- a/charts/kof-storage/templates/victoria/vmcluster.yaml
+++ b/charts/kof-storage/templates/victoria/vmcluster.yaml
@@ -8,11 +8,6 @@ metadata:
   namespace: {{ .Release.Namespace }}
 spec:
   {{- $spec := deepCopy .Values.victoriametrics.vmcluster.spec }}
-  {{- if $global.image.registry }}
-  {{- $_ := set $spec.vminsert.image "repository" ( printf "%s/victoriametrics/vminsert" $global.image.registry) }}
-  {{- $_ := set $spec.vmselect.image "repository" ( printf "%s/victoriametrics/vmselect" $global.image.registry) }}
-  {{- $_ := set $spec.vmstorage.image "repository" ( printf "%s/victoriametrics/vmstorage" $global.image.registry) }}
-  {{- end }}
   {{- if $global.storageClass }}
   {{- $_ := set $spec.vmselect.storage.volumeClaimTemplate.spec "storageClassName" $global.storageClass }}
   {{- $_ := set $spec.vmstorage.storage.volumeClaimTemplate.spec "storageClassName" $global.storageClass }}


### PR DESCRIPTION
* Fixes `InvalidImageName` when using custom registry.
* [Our template](https://github.com/k0rdent/kof/blob/v1.8.0/charts/kof-mothership/templates/victoria/vmcluster.yaml#L14) collided with VMO template [here](https://github.com/VictoriaMetrics/helm-charts/blob/victoria-metrics-operator-0.58.1/charts/victoria-metrics-common/templates/_image.tpl#L53C1-L55C76) and [here](https://github.com/VictoriaMetrics/helm-charts/blob/victoria-metrics-operator-0.58.1/charts/victoria-metrics-common/templates/_image.tpl#L10-L12) resulting in the double `registry` component added to the pod image.
* We did not detect it with default `global.registry: docker.io` because `docker pull docker.io/docker.io/victoriametrics/vmstorage:v1.105.0-cluster` actually works, unexpectedly.
* We did not detect it with custom registries earlier too, probably due to some fixes in the upstream charts.