### PR TITLE
chore: ignore prometheus package update

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -42,3 +42,5 @@ updates:
       prefix: "chore"
       include: "scope"
     rebase-strategy: "auto"
+    ignore:
+      - dependency-name: "github.com/prometheus/prometheus" # incompatibility with istio package


### PR DESCRIPTION
Currently new Prometheus client is not compatible with Istio