### PR TITLE
fix: Deleted `envoy-gateway:` wrapper. Passing `global` without `--set-file globalValues=`. Split upstream `values:`

### DIFF
--- a/charts/kof-child/templates/child-multi-cluster-service.yaml
+++ b/charts/kof-child/templates/child-multi-cluster-service.yaml
@@ -1,6 +1,6 @@
 {{- $global := .Values.global | default dict }}
-{{- $globalValues := .Values.globalValues | fromYaml }}
-{{- $customRegistry := or $global.registry $globalValues.registry "" }}
+{{- $globalGlobal := dict "global" $global }}
+{{- $customRegistry := $global.registry | default "" }}
 
 {{- range $istio := $.Values.istio.enabled | ternary (list true false) (list false) }}
 ---
@@ -82,7 +82,7 @@ spec:
         values: |
           {{`{{ $operatorsValuesFromAnnotation := .Cluster.metadata | dig "annotations" "k0rdent.mirantis.com/kof-operators-values" "{}" | fromYaml }}`}}
           {{`{{`}} $operatorsValuesFromHelm := `{{ $.Values.operators | toYaml | nindent 10 }}` | fromYaml {{`}}`}}
-          {{`{{`}} $globalValuesFromHelm := `{{ $globalValues | toYaml | nindent 10 }}` | fromYaml {{`}}`}}
+          {{`{{`}} $globalValuesFromHelm := `{{ $globalGlobal | toYaml | nindent 10 }}` | fromYaml {{`}}`}}
           {{`{{ mergeOverwrite (dict) $globalValuesFromHelm $operatorsValuesFromHelm $operatorsValuesFromAnnotation | toYaml | nindent 4 }}`}}
 
       - name: kof-collectors
@@ -243,7 +243,7 @@ spec:
           {{- if $istio }} | replace "{regionalClusterName}" $regionalClusterName
           {{- else }} | replace "{tracesEndpoint}" $tracesEndpoint | replace "{logsEndpoint}" $logsEndpoint | replace "{writeMetricsEndpoint}" $writeMetricsEndpoint | replace "{readMetricsEndpoint}" $readMetricsEndpoint | replace "{vmuserSecretVersion}" $vmuserSecretVersion
           {{- end }} | fromYaml {{`}}`}}
-          {{`{{`}} $globalValuesFromHelm := `{{ $globalValues | toYaml | nindent 10 }}` | fromYaml {{`}}`}}
+          {{`{{`}} $globalValuesFromHelm := `{{ $globalGlobal | toYaml | nindent 10 }}` | fromYaml {{`}}`}}
           {{`{{ $mergedValues := mergeOverwrite (dict) $globalValuesFromHelm $collectorsValuesHere $collectorsValuesFromHelm $collectorsValuesFromAnnotation }}`}}
           {{`{{ `}} $defaultCRConfigEnv := `
           env:

--- a/charts/kof-child/values.yaml
+++ b/charts/kof-child/values.yaml
@@ -2,9 +2,6 @@ cert-manager:
   enabled: true
   template: cert-manager-v1-19-3
 
-# --set-file globalValues=global-values.yaml
-globalValues: "{}"
-
 collectors:
   resources:
     requests:

--- a/charts/kof-regional/templates/regional-multi-cluster-service.yaml
+++ b/charts/kof-regional/templates/regional-multi-cluster-service.yaml
@@ -1,6 +1,6 @@
 {{- $global := .Values.global | default dict }}
-{{- $globalValues := .Values.globalValues | fromYaml }}
-{{- $customRegistry := or $global.registry $globalValues.registry "" }}
+{{- $globalGlobal := dict "global" $global }}
+{{- $customRegistry := $global.registry | default "" }}
 
 {{- range $istio := $.Values.istio.enabled | ternary (list true false) (list false) }}
 {{- $gatewayEnabled := and (not $istio) (index $.Values "envoy-gateway" "enabled") }}
@@ -81,7 +81,7 @@ spec:
           wait: true
         values: |
           {{`{{`}} $ingressNginxValuesFromAnnotation := .Cluster.metadata | dig "annotations" "k0rdent.mirantis.com/kof-ingress-nginx-values" "{}" | fromYaml {{`}}`}}
-          {{`{{`}} $ingressNginxValuesFromHelm := `{{ index $.Values "ingress-nginx" | toYaml | nindent 12 }}` | fromYaml {{`}}`}}
+          {{`{{`}} $ingressNginxValuesFromHelm := `{{ index $.Values "ingress-nginx" "values" | toYaml | nindent 10 }}` | fromYaml {{`}}`}}
           {{`{{`}} $ingressNginxValuesHere := `
           controller:
             image:
@@ -100,7 +100,7 @@ spec:
           ` | fromYaml {{`}}`}}
           {{`{{`}} $ingressNginxValuesHere = mergeOverwrite $ingressNginxValuesHere $ingressNginxValuesAzure {{`}}`}}
           {{`{{ end }}`}}
-          {{`{{`}} $globalValuesFromHelm := `{{ $globalValues | toYaml | nindent 12 }}` | fromYaml {{`}}`}}
+          {{`{{`}} $globalValuesFromHelm := `{{ $globalGlobal | toYaml | nindent 10 }}` | fromYaml {{`}}`}}
           {{`{{`}} mergeOverwrite (dict) $globalValuesFromHelm $ingressNginxValuesHere $ingressNginxValuesFromHelm $ingressNginxValuesFromAnnotation | toYaml | nindent 4 {{`}}`}}
       {{- end }}
 
@@ -111,11 +111,10 @@ spec:
         helmOptions:
           wait: true
         values: |
-          envoy-gateway:
-            {{`{{`}} $envoyGatewayValuesFromAnnotation := .Cluster.metadata | dig "annotations" "k0rdent.mirantis.com/kof-envoy-gateway-values" "{}" | fromYaml {{`}}`}}
-            {{`{{`}} $envoyGatewayValuesFromHelm := `{{ index $.Values "envoy-gateway" | toYaml | nindent 12 }}` | fromYaml {{`}}`}}
-            {{`{{`}} $globalValuesFromHelm := `{{ $globalValues | toYaml | nindent 12 }}` | fromYaml {{`}}`}}
-            {{`{{`}} mergeOverwrite (dict) $globalValuesFromHelm $envoyGatewayValuesFromHelm $envoyGatewayValuesFromAnnotation | toYaml | nindent 4 {{`}}`}}
+          {{`{{`}} $envoyGatewayValuesFromAnnotation := .Cluster.metadata | dig "annotations" "k0rdent.mirantis.com/kof-envoy-gateway-values" "{}" | fromYaml {{`}}`}}
+          {{`{{`}} $envoyGatewayValuesFromHelm := `{{ index $.Values "envoy-gateway" "values" | toYaml | nindent 10 }}` | fromYaml {{`}}`}}
+          {{`{{`}} $globalValuesFromHelm := `{{ $globalGlobal | toYaml | nindent 10 }}` | fromYaml {{`}}`}}
+          {{`{{`}} mergeOverwrite (dict) $globalValuesFromHelm $envoyGatewayValuesFromHelm $envoyGatewayValuesFromAnnotation | toYaml | nindent 4 {{`}}`}}
       {{- end }}
 
       {{- $dependsOnList := list }}
@@ -139,7 +138,7 @@ spec:
         values: |
           {{`{{ $operatorsValuesFromAnnotation := .Cluster.metadata | dig "annotations" "k0rdent.mirantis.com/kof-operators-values" "{}" | fromYaml }}`}}
           {{`{{`}} $operatorsValuesFromHelm := `{{ $.Values.operators | toYaml | nindent 10 }}` | fromYaml {{`}}`}}
-          {{`{{`}} $globalValuesFromHelm := `{{ $globalValues | toYaml | nindent 10 }}` | fromYaml {{`}}`}}
+          {{`{{`}} $globalValuesFromHelm := `{{ $globalGlobal | toYaml | nindent 10 }}` | fromYaml {{`}}`}}
           {{`{{ mergeOverwrite (dict) $globalValuesFromHelm $operatorsValuesFromHelm $operatorsValuesFromAnnotation | toYaml | nindent 4 }}`}}
 
       - name: kof-storage
@@ -306,7 +305,7 @@ spec:
             | replace "{metricsHost}" $metricsHost | replace "{gatewayName}" $gatewayName | replace "{gatewayNamespace}" $gatewayNamespace | replace "{grafanaHost}" $grafanaHost | replace "{certEmail}" $certEmail | replace "{dexIssuer}" $dexIssuer | replace "{dexHost}" $dexHost | replace "{vmuserSecretVersion}" $vmuserSecretVersion | replace "{regionalDomain}" $regionalDomain
           {{- end }}
             | fromYaml {{`}}`}}
-          {{`{{`}} $globalValuesFromHelm := `{{ $globalValues | toYaml | nindent 10 }}` | fromYaml {{`}}`}}
+          {{`{{`}} $globalValuesFromHelm := `{{ $globalGlobal | toYaml | nindent 10 }}` | fromYaml {{`}}`}}
           {{`{{ mergeOverwrite (dict) $globalValuesFromHelm $storageValuesHere $storageValuesFromHelm $storageValuesFromAnnotation | toYaml | nindent 4 }}`}}
         valuesFrom:
           - kind: ConfigMap
@@ -376,7 +375,7 @@ spec:
                 defaultClusterId: {clusterName}
           ` | replace "{clusterName}" .Cluster.metadata.name | replace "{clusterNamespace}" .Cluster.metadata.namespace
             | replace "{vmuserSecretVersion}" $vmuserSecretVersion | fromYaml {{`}}`}}
-          {{`{{`}} $globalValuesFromHelm := `{{ $globalValues | toYaml | nindent 10 }}` | fromYaml {{`}}`}}
+          {{`{{`}} $globalValuesFromHelm := `{{ $globalGlobal | toYaml | nindent 10 }}` | fromYaml {{`}}`}}
           {{`{{ mergeOverwrite (dict) $globalValuesFromHelm $collectorsValuesHere $collectorsValuesFromHelm $collectorsValuesFromAnnotation | toYaml | nindent 4 }}`}}
     templateResourceRefs:
     - identifier: RegionalKCMCluster

--- a/charts/kof-regional/values.yaml
+++ b/charts/kof-regional/values.yaml
@@ -7,17 +7,16 @@ cert-manager:
 ingress-nginx:
   enabled: false
   template: ingress-nginx-4-14-3
+  values: {}
 
 envoy-gateway:
   enabled: true
   template: gateway-helm-v1-7-1
+  values: {}
 
 gateway:
   name: gateway
   namespace: kof
-
-# --set-file globalValues=global-values.yaml
-globalValues: "{}"
 
 collectors: {}
 storage: {}


### PR DESCRIPTION
* Deleted `envoy-gateway:` wrapper in `kof-regional` as we switched from catalog wrapper-chart to direct upstream chart. Similar: https://github.com/k0rdent/kof/pull/901
* Passing custom `global` values like `global: imageRegistry: ...` to `envoy-gateway` and others automatically, without `--set-file globalValues=global-values.yaml` or similar hacks.
* Split upstream `values:` to avoid possible validation issues when we pass e.g. our `template:` to upstream charts. Similar: https://github.com/k0rdent/kof/pull/920#pullrequestreview-4098636550
  * Upgrade instructions to move old upstream values into `values:` are not critical as we're replacing `ingress-nginx` with `envoy-gateway` in this release as documented already.
