### PR TITLE
fix: add CLUSTER_NAME to opencost extraEnv list

### DIFF
--- a/charts/kof-child/templates/child-multi-cluster-service.yaml
+++ b/charts/kof-child/templates/child-multi-cluster-service.yaml
@@ -239,6 +239,10 @@ spec:
                 {{- end }}
               exporter:
                 defaultClusterId: {childClusterName}
+                extraEnv:
+                  CLUSTER_NAME: {childClusterName}
+                  EMIT_KSM_V1_METRICS: "false"
+                  EMIT_KSM_V1_METRICS_ONLY: "true"
           ` | replace "{childClusterName}" .Cluster.metadata.name | replace "{childClusterNamespace}" .Cluster.metadata.namespace | replace "{vmuserSecretName}" $vmuserSecretName
           {{- if $istio }} | replace "{regionalClusterName}" $regionalClusterName
           {{- else }} | replace "{tracesEndpoint}" $tracesEndpoint | replace "{logsEndpoint}" $logsEndpoint | replace "{writeMetricsEndpoint}" $writeMetricsEndpoint | replace "{readMetricsEndpoint}" $readMetricsEndpoint | replace "{vmuserSecretVersion}" $vmuserSecretVersion

--- a/charts/kof-collectors/values.yaml
+++ b/charts/kof-collectors/values.yaml
@@ -1610,6 +1610,7 @@ opencost:
     exporter:
       defaultClusterId: "mothership"
       extraEnv:
+        CLUSTER_NAME: "mothership"
         EMIT_KSM_V1_METRICS: "false"
         EMIT_KSM_V1_METRICS_ONLY: "true"
       image:

--- a/charts/kof-regional/templates/regional-multi-cluster-service.yaml
+++ b/charts/kof-regional/templates/regional-multi-cluster-service.yaml
@@ -390,6 +390,10 @@ spec:
                 password_key: ""
               exporter:
                 defaultClusterId: {clusterName}
+                extraEnv:
+                  CLUSTER_NAME: {clusterName}
+                  EMIT_KSM_V1_METRICS: "false"
+                  EMIT_KSM_V1_METRICS_ONLY: "true"
           ` | replace "{clusterName}" .Cluster.metadata.name | replace "{clusterNamespace}" .Cluster.metadata.namespace
             | replace "{vmuserSecretVersion}" $vmuserSecretVersion | fromYaml {{`}}`}}
           {{`{{`}} $globalValuesFromHelm := `{{ $globalValues | toYaml | nindent 10 }}` | fromYaml {{`}}`}}


### PR DESCRIPTION
Fix WRN Failed to load 'name' field for ClusterInfo