### PR TITLE
fix: Separate envoy-gateway LoadBalancer for each regional cluster

### DIFF
--- a/charts/kof-regional/templates/regional-multi-cluster-service.yaml
+++ b/charts/kof-regional/templates/regional-multi-cluster-service.yaml
@@ -112,9 +112,19 @@ spec:
           wait: true
         values: |
           {{`{{`}} $envoyGatewayValuesFromAnnotation := .Cluster.metadata | dig "annotations" "k0rdent.mirantis.com/kof-envoy-gateway-values" "{}" | fromYaml {{`}}`}}
+          {{`{{`}} $envoyGatewayValuesHere := `
+          config:
+            envoyGateway:
+              envoyProxy:
+                provider:
+                  type: Kubernetes
+                  kubernetes:
+                    envoyService:
+                      name: gateway-{clusterName}
+          ` | replace "{clusterName}" .Cluster.metadata.name | fromYaml {{`}}`}}
           {{`{{`}} $envoyGatewayValuesFromHelm := `{{ index $.Values "envoy-gateway" "values" | toYaml | nindent 10 }}` | fromYaml {{`}}`}}
           {{`{{`}} $globalValuesFromHelm := `{{ $globalGlobal | toYaml | nindent 10 }}` | fromYaml {{`}}`}}
-          {{`{{`}} mergeOverwrite (dict) $globalValuesFromHelm $envoyGatewayValuesFromHelm $envoyGatewayValuesFromAnnotation | toYaml | nindent 4 {{`}}`}}
+          {{`{{`}} mergeOverwrite (dict) $globalValuesFromHelm $envoyGatewayValuesFromHelm $envoyGatewayValuesHere $envoyGatewayValuesFromAnnotation | toYaml | nindent 4 {{`}}`}}
       {{- end }}
 
       {{- $dependsOnList := list }}


### PR DESCRIPTION
* When multiple KOF regional clusters are deployed to the same cloud account, envoy-gateway creates LoadBalancer based on the k8s Service name.
* To have separate envoy-gateway LoadBalancer for each regional cluster we need to have unique k8s Service names.
* This PR uses regional cluster name as a unique component of the k8s Service name.
