### PR TITLE
ci: disable gateway API CRDs auto install

### DIFF
--- a/.agents/skills/kind-deploy/SKILL.md
+++ b/.agents/skills/kind-deploy/SKILL.md
@@ -238,7 +238,7 @@ grep -qxF "127.0.0.1 dex.example.com" /etc/hosts || \
 docker start cloud-provider-kind 2>/dev/null || \
   docker run -d --name cloud-provider-kind --network kind \
     -v /var/run/docker.sock:/var/run/docker.sock \
-    registry.k8s.io/cloud-provider-kind/cloud-controller-manager:v0.10.0
+    registry.k8s.io/cloud-provider-kind/cloud-controller-manager:v0.10.0 --gateway-channel="disabled"
 ```
 
 This allocates external IPs for `LoadBalancer` services inside kind clusters. The command is idempotent: if the container already exists (running or stopped) it is restarted via `docker start`; otherwise a new container is created. To stop it: `docker stop cloud-provider-kind`.

--- a/.github/workflows/pr_test_cross_namespace.yaml
+++ b/.github/workflows/pr_test_cross_namespace.yaml
@@ -59,7 +59,7 @@ jobs:
         run: |
           make helm-push
       - name: Run KIND cloud provider
-        run: docker run -d --rm --network kind -v /var/run/docker.sock:/var/run/docker.sock registry.k8s.io/cloud-provider-kind/cloud-controller-manager:v0.10.0
+        run: docker run -d --rm --network kind -v /var/run/docker.sock:/var/run/docker.sock registry.k8s.io/cloud-provider-kind/cloud-controller-manager:v0.10.0 --gateway-channel="disabled"
       - name: "[PR] Deploy KOF components on Mothership cluster"
         run: |
           DISABLE_KOF_COLLECTORS=true DISABLE_KOF_STORAGE=true make dev-deploy

--- a/.github/workflows/pr_test_kcm_region_with_kof.yaml
+++ b/.github/workflows/pr_test_kcm_region_with_kof.yaml
@@ -111,7 +111,7 @@ jobs:
         run: |
           make helm-push
       - name: Run KIND cloud provider
-        run: docker run -d --rm --network kind -v /var/run/docker.sock:/var/run/docker.sock registry.k8s.io/cloud-provider-kind/cloud-controller-manager:v0.10.0
+        run: docker run -d --rm --network kind -v /var/run/docker.sock:/var/run/docker.sock registry.k8s.io/cloud-provider-kind/cloud-controller-manager:v0.10.0 --gateway-channel="disabled"
       - name: "[PR] Deploy KOF components on Mothership cluster"
         run: |
           DISABLE_KOF_COLLECTORS=true DISABLE_KOF_STORAGE=true make dev-deploy

--- a/.github/workflows/pr_test_kof_installation.yaml
+++ b/.github/workflows/pr_test_kof_installation.yaml
@@ -107,7 +107,7 @@ jobs:
         run: |
           make helm-push
       - name: Run KIND cloud provider
-        run: docker run -d --rm --network kind -v /var/run/docker.sock:/var/run/docker.sock registry.k8s.io/cloud-provider-kind/cloud-controller-manager:v0.10.0
+        run: docker run -d --rm --network kind -v /var/run/docker.sock:/var/run/docker.sock registry.k8s.io/cloud-provider-kind/cloud-controller-manager:v0.10.0 --gateway-channel="disabled"
       - name: "[PR] Deploy KOF components on Mothership cluster"
         run: |
           DISABLE_KOF_COLLECTORS=true DISABLE_KOF_STORAGE=true make dev-deploy

--- a/.github/workflows/pr_test_tenant_isolation_test.yaml
+++ b/.github/workflows/pr_test_tenant_isolation_test.yaml
@@ -99,7 +99,7 @@ jobs:
         run: |
           make helm-push
       - name: Run KIND cloud provider
-        run: docker run -d --rm --network kind -v /var/run/docker.sock:/var/run/docker.sock registry.k8s.io/cloud-provider-kind/cloud-controller-manager:v0.10.0
+        run: docker run -d --rm --network kind -v /var/run/docker.sock:/var/run/docker.sock registry.k8s.io/cloud-provider-kind/cloud-controller-manager:v0.10.0 --gateway-channel="disabled"
       - name: "[PR] Deploy KOF components on Mothership cluster"
         run: |
           DISABLE_KOF_COLLECTORS=true DISABLE_KOF_STORAGE=true make dev-deploy

--- a/.github/workflows/test_builds.yml
+++ b/.github/workflows/test_builds.yml
@@ -140,7 +140,7 @@ jobs:
           cat kof-values.yaml
 
       - name: Run KIND cloud provider
-        run: docker run -d --rm --network kind -v /var/run/docker.sock:/var/run/docker.sock registry.k8s.io/cloud-provider-kind/cloud-controller-manager:v0.10.0
+        run: docker run -d --rm --network kind -v /var/run/docker.sock:/var/run/docker.sock registry.k8s.io/cloud-provider-kind/cloud-controller-manager:v0.10.0 --gateway-channel="disabled"
 
       - name: Install KOF
         run: |

--- a/Makefile
+++ b/Makefile
@@ -92,6 +92,8 @@ package-chart-%: lint-chart-%
 
 .PHONY: kcm-dev-apply
 kcm-dev-apply: dev cli-install kind-deploy
+	$(HELM) upgrade --install eg oci://docker.io/envoyproxy/gateway-helm --version v1.7.2 -n envoy-gateway-system --create-namespace
+	$(YQ) eval -i '.regional.cert-manager.config.enableGatewayAPI = true' $(KCM_REPO_PATH)/config/dev/kcm_values.yaml
 	make -C $(KCM_REPO_PATH) dev-apply
 	$(KUBECTL) wait --for create mgmt/kcm --timeout=1m
 	$(KUBECTL) wait --for=condition=Ready mgmt/kcm --timeout=10m
@@ -99,7 +101,8 @@ kcm-dev-apply: dev cli-install kind-deploy
 
 .PHONY: kcm-dev-upgrade
 kcm-dev-upgrade: dev cli-install
-	$(YQ) eval -i '.resources.limits.memory = "512Mi"' $(KCM_REPO_PATH)/config/dev/kcm_values.yaml
+	$(HELM) upgrade --install eg oci://docker.io/envoyproxy/gateway-helm --version v1.7.2 -n envoy-gateway-system --create-namespace
+	$(YQ) eval -i '.regional.cert-manager.config.enableGatewayAPI = true' $(KCM_REPO_PATH)/config/dev/kcm_values.yaml
 	make -C $(KCM_REPO_PATH) dev-upgrade
 	$(KUBECTL) wait --for=condition=Ready mgmt/kcm --timeout=10m
 	$(KUBECTL) wait --for condition=available deployment/kcm-controller-manager --timeout=1m -n $(KCM_NAMESPACE)

--- a/charts/kof-mothership/Chart.lock
+++ b/charts/kof-mothership/Chart.lock
@@ -26,8 +26,5 @@ dependencies:
 - name: external-dns
   repository: https://kubernetes-sigs.github.io/external-dns/
   version: 1.20.0
-- name: gateway-helm
-  repository: oci://docker.io/envoyproxy
-  version: v1.7.2
-digest: sha256:d87569decb48068001318857f4f50dc2cb8861225123ae66873264d675556560
-generated: "2026-04-23T17:04:22.540054+03:00"
+digest: sha256:cbf06283bb655c38fcbec813337b93f043854d0fe5773ed7f91848fc1cf9c7d7
+generated: "2026-04-28T11:38:20.986566+03:00"

--- a/charts/kof-mothership/Chart.yaml
+++ b/charts/kof-mothership/Chart.yaml
@@ -41,8 +41,3 @@ dependencies:
     version: "1.20.0"
     repository: https://kubernetes-sigs.github.io/external-dns/
     condition: external-dns.enabled
-  - name: gateway-helm
-    alias: envoy-gateway
-    version: "v1.7.2"
-    repository: oci://docker.io/envoyproxy
-    condition: envoy-gateway.enabled

--- a/charts/kof-mothership/README.md
+++ b/charts/kof-mothership/README.md
@@ -12,7 +12,6 @@ KOF Helm chart for KOF Management cluster
 | https://charts.dexidp.io | dex | 0.23.0 |
 | https://kubernetes-sigs.github.io/external-dns/ | external-dns | 1.20.0 |
 | https://kubernetes-sigs.github.io/metrics-server/ | metrics-server | 3.13.0 |
-| oci://docker.io/envoyproxy | envoy-gateway(gateway-helm) | v1.7.2 |
 | oci://ghcr.io/k0rdent/catalog/charts | cert-manager-service-template(kgst) | 2.0.1 |
 | oci://ghcr.io/k0rdent/catalog/charts | ingress-nginx-service-template(kgst) | 2.0.1 |
 | oci://ghcr.io/k0rdent/catalog/charts | envoy-gateway-service-template(kgst) | 2.0.1 |
@@ -60,9 +59,7 @@ KOF Helm chart for KOF Management cluster
 | dex<br>.volumeMounts[0]<br>.readOnly | bool | `true` |  |
 | dex<br>.volumes[0]<br>.name | string | `"tls"` |  |
 | dex<br>.volumes[0]<br>.secret<br>.secretName | string | `"dex-tls"` |  |
-| envoy-gateway | object | `{"enabled":false}` | [Docs](https://docs.envoyproxy.io/gateway/latest/) Installs Envoy Gateway on the mothership cluster. |
 | envoy-gateway-service-template | object | `{"chart":"gateway-helm:v1.7.1",`<br>`"namespace":"kcm-system",`<br>`"repo":{"name":"envoy-gateway",`<br>`"spec":{"url":"oci://docker.io/envoyproxy"}}}` | Config of `ServiceTemplate` to use `envoy-gateway` in `MultiClusterService`. |
-| envoy-gateway<br>.enabled | bool | `false` | Enables Envoy Gateway deployment. |
 | external-dns | object | `{"enabled":false,`<br>`"provider":{"name":"aws"},`<br>`"sources":["service",`<br>`"ingress",`<br>`"gateway-httproute"]}` | [Docs](https://kubernetes-sigs.github.io/external-dns/) Installs ExternalDNS on the mothership cluster. |
 | external-dns<br>.enabled | bool | `false` | Enables ExternalDNS deployment. |
 | external-dns<br>.provider | object | `{"name":"aws"}` | DNS provider to use (e.g. aws, azure, cloudflare, google). |

--- a/charts/kof-mothership/values.yaml
+++ b/charts/kof-mothership/values.yaml
@@ -506,12 +506,6 @@ metrics-server:
   # -- Enables Metrics Server.
   enabled: false
 
-# -- [Docs](https://docs.envoyproxy.io/gateway/latest/)
-# Installs Envoy Gateway on the mothership cluster.
-envoy-gateway:
-  # -- Enables Envoy Gateway deployment.
-  enabled: false
-
 # -- [Docs](https://kubernetes-sigs.github.io/external-dns/)
 # Installs ExternalDNS on the mothership cluster.
 external-dns:

--- a/charts/kof/values-local.yaml
+++ b/charts/kof/values-local.yaml
@@ -18,6 +18,8 @@ kof-mothership:
   values:
     global:
       registry: ""
+    envoy-gateway:
+      enabled: true
     kcm:
       kof:
         mcs:

--- a/charts/kof/values-local.yaml
+++ b/charts/kof/values-local.yaml
@@ -18,8 +18,6 @@ kof-mothership:
   values:
     global:
       registry: ""
-    envoy-gateway:
-      enabled: true
     kcm:
       kof:
         mcs:

--- a/docs/dev.md
+++ b/docs/dev.md
@@ -88,7 +88,7 @@ grep -qxF "127.0.0.1 dex.example.com" /etc/hosts || echo "127.0.0.1 dex.example.
 * Run kind cloud provider to support external IP allocation for gateways
 
   ```bash
-  docker run --rm --network kind -v /var/run/docker.sock:/var/run/docker.sock registry.k8s.io/cloud-provider-kind/cloud-controller-manager:v0.10.0
+  docker run --rm --network kind -v /var/run/docker.sock:/var/run/docker.sock registry.k8s.io/cloud-provider-kind/cloud-controller-manager:v0.10.0 --gateway-channel="disabled"
   ```
 
 * Deploy KOF using the Helm chart with local values:

--- a/docs/kcm-region.md
+++ b/docs/kcm-region.md
@@ -118,7 +118,7 @@ make dev-adopted-deploy KIND_CLUSTER_NAME=regional-adopted
 Run kind cloud provider to support gateway implementation
 
 ```bash
-docker run --rm --network kind -v /var/run/docker.sock:/var/run/docker.sock registry.k8s.io/cloud-provider-kind/cloud-controller-manager:v0.10.0
+docker run --rm --network kind -v /var/run/docker.sock:/var/run/docker.sock registry.k8s.io/cloud-provider-kind/cloud-controller-manager:v0.10.0 --gateway-channel="disabled"
 ```
 
 Create regional adopted cluster deployment and registering the regional


### PR DESCRIPTION
- Disabling Gateway API CRDs auto installation when kind cloud-controller-manager is running for more realistic testing
- Gateway's CRDs should be installed before KCM as to use it the cert-manager should be configured for Gateway API support, so envoy-gateway removed from mothership