### PR TITLE
fix: add `take-ownership` to Helm install/upgrade options for vmuser propagation MCS

### DIFF
--- a/kof-operator/internal/controller/vmuser/victoriametrics_user.go
+++ b/kof-operator/internal/controller/vmuser/victoriametrics_user.go
@@ -449,12 +449,28 @@ func buildPropagationMCS(opts *CreateOptions) *kcmv1beta1.MultiClusterService {
 						Template:  propagationTemplate,
 						Namespace: opts.Namespace,
 						Values:    "propagation:\n  enabled: true\n  data: |\n{{ removeField \"vmuser\" \"metadata.ownerReferences\" | nindent 14 }}\n",
+						HelmOptions: &kcmv1beta1.ServiceHelmOptions{
+							InstallOptions: &addoncontrollerv1beta1.HelmInstallOptions{
+								TakeOwnership: true,
+							},
+							UpgradeOptions: &addoncontrollerv1beta1.HelmUpgradeOptions{
+								TakeOwnership: true,
+							},
+						},
 					},
 					{
 						Name:      BuildSecretName(opts.Name),
 						Template:  propagationTemplate,
 						Namespace: opts.Namespace,
 						Values:    "propagation:\n  enabled: true\n  data: |\n{{ removeField \"secret\" \"metadata.ownerReferences\" | nindent 14 }}\n",
+						HelmOptions: &kcmv1beta1.ServiceHelmOptions{
+							InstallOptions: &addoncontrollerv1beta1.HelmInstallOptions{
+								TakeOwnership: true,
+							},
+							UpgradeOptions: &addoncontrollerv1beta1.HelmUpgradeOptions{
+								TakeOwnership: true,
+							},
+						},
 					},
 				},
 				TemplateResourceRefs: []addoncontrollerv1beta1.TemplateResourceRef{


### PR DESCRIPTION
This PR fixes a KOF upgrade issue where resources failed to deploy via the kof-propagation chart because existing resources were not deleted or owned by any chart.
The fix enables the takeOwnership option to adopt existing resources.