### PR TITLE
fix: Conditional `VM_GATEWAY_API_ENABLED` to avoid `no matches for kind "HTTPRoute"` in Istio or Nginx cases

### DIFF
--- a/charts/kof-regional/templates/regional-multi-cluster-service.yaml
+++ b/charts/kof-regional/templates/regional-multi-cluster-service.yaml
@@ -162,8 +162,13 @@ spec:
         values: |
           {{`{{ $vmoValuesFromAnnotation := .Cluster.metadata | dig "annotations" "k0rdent.mirantis.com/kof-victoria-metrics-operator-values" "{}" | fromYaml }}`}}
           {{`{{`}} $vmoValuesFromHelm := `{{ index $.Values "victoria-metrics-operator" "values" | toYaml | nindent 10 }}` | fromYaml {{`}}`}}
+          {{`{{`}} $vmoValuesHere := `
+          env:
+            - name: VM_GATEWAY_API_ENABLED
+              value: "{{ $gatewayEnabled }}"
+          ` | fromYaml {{`}}`}}
           {{`{{`}} $globalValuesFromHelm := `{{ $globalGlobal | toYaml | nindent 10 }}` | fromYaml {{`}}`}}
-          {{`{{ mergeOverwrite (dict) $globalValuesFromHelm $vmoValuesFromHelm $vmoValuesFromAnnotation | toYaml | nindent 4 }}`}}
+          {{`{{ mergeOverwrite (dict) $globalValuesFromHelm $vmoValuesHere $vmoValuesFromHelm $vmoValuesFromAnnotation | toYaml | nindent 4 }}`}}
 
       - name: kof-storage
         namespace: {{ $.Release.Namespace }}

--- a/charts/kof-regional/values.yaml
+++ b/charts/kof-regional/values.yaml
@@ -33,9 +33,6 @@ victoria-metrics-operator:
       plain: true
       cleanup:
         enabled: false
-    env:
-      - name: VM_GATEWAY_API_ENABLED
-        value: "true"
 
 collectors: {}
 storage: {}


### PR DESCRIPTION
* We faced bad status of `VMAuth` in the Istio case in a real cloud (non-`kind`):
  ```
  KUBECONFIG=regional-kubeconfig k get vmauth -A -o yaml

  status:
    observedGeneration: 2
    reason: 'cannot create or update vmauth deploy: cannot delete httproute from prev
      state: no matches for kind "HTTPRoute" in version "gateway.networking.k8s.io/v1"'
    updateStatus: failed
  ```
* We did not notice it locally and in CI
  due to Gateway CRDs auto-installed by default by `cloud-provider-kind`,
  hence https://github.com/k0rdent/kof/pull/961
* Debug proved the unconditional `VM_GATEWAY_API_ENABLED` was the cause,
  while Istio used `.envoy-gateway.enabled: false` values.
* This PR makes `VM_GATEWAY_API_ENABLED` conditional, fixing the issue.
* Tested manually on AWS cluster, it works OK.
