### PR TITLE
fix: `make dev-deploy` failed on `cert-manager-chain` when istio is enabled

### DIFF
--- a/charts/kof-mothership/templates/k0rdent/kof/svctmpl.yaml
+++ b/charts/kof-mothership/templates/k0rdent/kof/svctmpl.yaml
@@ -48,6 +48,7 @@ spec:
 {{- range $alias := list "cert-manager-service-template" "ingress-nginx-service-template" "envoy-gateway-service-template" "victoria-metrics-operator-service-template" }}
   {{- $cfg := index $.Values $alias }}
   {{- if $cfg }}
+    {{- if $cfg.enabled | eq false }}{{ continue }}{{ end }}
     {{- $parts := split ":" $cfg.chart }}
     {{- $chartName := $parts._0 }}
     {{- $chartVersion := $parts._1 }}

--- a/charts/kof-mothership/templates/k0rdent/kof/svctmpl.yaml
+++ b/charts/kof-mothership/templates/k0rdent/kof/svctmpl.yaml
@@ -48,7 +48,7 @@ spec:
 {{- range $alias := list "cert-manager-service-template" "ingress-nginx-service-template" "envoy-gateway-service-template" "victoria-metrics-operator-service-template" }}
   {{- $cfg := index $.Values $alias }}
   {{- if $cfg }}
-    {{- if not ($cfg.enabled | default true) }}{{ continue }}{{ end }}
+    {{- if and (hasKey $cfg "enabled") (not $cfg.enabled) }}{{ continue }}{{ end }}
     {{- $parts := split ":" $cfg.chart }}
     {{- $chartName := $parts._0 }}
     {{- $chartVersion := $parts._1 }}

--- a/charts/kof-mothership/templates/k0rdent/kof/svctmpl.yaml
+++ b/charts/kof-mothership/templates/k0rdent/kof/svctmpl.yaml
@@ -48,7 +48,7 @@ spec:
 {{- range $alias := list "cert-manager-service-template" "ingress-nginx-service-template" "envoy-gateway-service-template" "victoria-metrics-operator-service-template" }}
   {{- $cfg := index $.Values $alias }}
   {{- if $cfg }}
-    {{- if not ($cfg.enabled | default false) }}{{ continue }}{{ end }}
+    {{- if not ($cfg.enabled | default true) }}{{ continue }}{{ end }}
     {{- $parts := split ":" $cfg.chart }}
     {{- $chartName := $parts._0 }}
     {{- $chartVersion := $parts._1 }}

--- a/charts/kof-mothership/templates/k0rdent/kof/svctmpl.yaml
+++ b/charts/kof-mothership/templates/k0rdent/kof/svctmpl.yaml
@@ -48,7 +48,7 @@ spec:
 {{- range $alias := list "cert-manager-service-template" "ingress-nginx-service-template" "envoy-gateway-service-template" "victoria-metrics-operator-service-template" }}
   {{- $cfg := index $.Values $alias }}
   {{- if $cfg }}
-    {{- if $cfg.enabled | eq false }}{{ continue }}{{ end }}
+    {{- if not ($cfg.enabled | default false) }}{{ continue }}{{ end }}
     {{- $parts := split ":" $cfg.chart }}
     {{- $chartName := $parts._0 }}
     {{- $chartVersion := $parts._1 }}


### PR DESCRIPTION
* `make dev-deploy` on new cluster fails when istio is enabled:
```
kubectl get helmreleases -n kof

Helm upgrade failed for release kof/kof-mothership
with chart kof-mothership@1.10.0-rc0: failed to create resource:
admission webhook "validation.servicetemplatechain.k0rdent.mirantis.com" denied the request:
ServiceTemplateChain.k0rdent.mirantis.com "cert-manager-chain" is invalid:
spec.supportedTemplates[0].name: Not found: "cert-manager-v1-19-3"
```
* It is caused by conflict between:
  * https://github.com/k0rdent/kof/pull/939/changes#diff-aa6ac1061354f6750264d1a3667426b77583169a04ae758d695de90bcae0ba0aR48
  * [Makefile lines](https://github.com/k0rdent/kof/blob/f0d7d58ae7c31720693c59c6e0d430a89def7af2/Makefile#L251-L254):
    ```Makefile
    @if $(KUBECTL) get namespace -l istio-injection=enabled | grep -q 'kof'; then \
    	echo "⚠️ Istio enabled, disable cert-manager installation"; \
    	$(YQ) eval -i '.kof-mothership.values.cert-manager-service-template.enabled = false' dev/values-local.yaml; \
    fi
    ```
  * `--set cert-manager-service-template.enabled=false` when istio is installed without `make` as in [the docs](https://docs.k0rdent.io/v1.9.0/admin/kof/kof-install/#istio).
* Current PR fixed the symptom, but the later installation of regional cluster found no `ServiceTemplate`.
* Found and verified the proper fix:
  don't use `--set cert-manager-service-template.enabled=false` when installing istio for use with KOF's `make dev-deploy`.
