### PR TITLE
chore: add label for vmuser creds

### DIFF
--- a/kof-operator/internal/controller/clusterdeployment_kof_cluster_child_role.go
+++ b/kof-operator/internal/controller/clusterdeployment_kof_cluster_child_role.go
@@ -79,9 +79,10 @@ func (c *ChildClusterRole) Reconcile() error {
 
 func (c *ChildClusterRole) CreateVMUserCredentials(regionalClusterName string) error {
 	opts := &vmuser.CreateOptions{
-		Name:           GetVMUserName(GetConfigMapName(c.clusterName), c.clusterNamespace),
-		Namespace:      c.clusterNamespace,
-		ClusterRef:     c.clusterDeployment,
+		Name:        GetVMUserName(GetConfigMapName(c.clusterName), c.clusterNamespace),
+		Namespace:   c.clusterNamespace,
+		ClusterRef:  c.clusterDeployment,
+		ClusterName: c.clusterName,
 		OwnerReference: c.ownerReference,
 		MCSConfig: &vmuser.MCSConfig{
 			ClusterSelector: metav1.LabelSelector{

--- a/kof-operator/internal/controller/configmap_cluster_regional.go
+++ b/kof-operator/internal/controller/configmap_cluster_regional.go
@@ -129,6 +129,7 @@ func (c *RegionalClusterConfigMap) CreateVMUser() error {
 		Namespace:      c.clusterNamespace,
 		ClusterRef:     c.configMap,
 		OwnerReference: c.ownerReference,
+		ClusterName: c.clusterName,
 		MCSConfig: &vmuser.MCSConfig{
 			ClusterSelector: metav1.LabelSelector{
 				MatchLabels: map[string]string{

--- a/kof-operator/internal/controller/vmuser/victoriametrics_user.go
+++ b/kof-operator/internal/controller/vmuser/victoriametrics_user.go
@@ -31,6 +31,9 @@ type CreateOptions struct {
 	Namespace string
 	// OwnerReference links resources to an owner for garbage collection.
 	OwnerReference *metav1.OwnerReference
+	// ClusterName is the name of the cluster associated with the VMUser,
+	// added as a label to allow efficient secret lookup by cluster.
+	ClusterName string
 	// ExtraLabels to apply to VMUser, Secret, and MultiClusterService resources.
 	ExtraLabels map[string]string
 	// MCSConfig defines MultiClusterService propagation settings. If nil, MCS will not be created.
@@ -509,14 +512,17 @@ func buildCredsSecret(opts *CreateOptions) (*corev1.Secret, error) {
 		return nil, fmt.Errorf("failed to generate password: %w", err)
 	}
 
-	labels := getMandatoryLabels()
-	maps.Copy(labels, opts.ExtraLabels)
+	secretLabels := getMandatoryLabels()
+	maps.Copy(secretLabels, opts.ExtraLabels)
+	if opts.ClusterName != "" {
+		secretLabels[labels.ClusterNameLabel] = opts.ClusterName
+	}
 
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      BuildSecretName(opts.Name),
 			Namespace: opts.Namespace,
-			Labels:    labels,
+			Labels:    secretLabels,
 		},
 		Data: map[string][]byte{
 			UsernameKey: []byte(opts.Name),


### PR DESCRIPTION
Resolve this issue: https://github.com/k0rdent/kof/issues/868
Helped to recognize correct secrets in case when we have multiple regional clusters