### PR TITLE
ci: Tests for M2M and M2R cases

### DIFF
--- a/.github/workflows/pr_test_adopted_upgrade.yml
+++ b/.github/workflows/pr_test_adopted_upgrade.yml
@@ -260,7 +260,7 @@ jobs:
           cache: false
       - name: "[PR] Deploy KOF components on Mothership cluster"
         run: |
-          DISABLE_KOF_COLLECTORS=true DISABLE_KOF_STORAGE=true make dev-deploy
+          DISABLE_KOF_COLLECTORS=true DISABLE_KOF_STORAGE=true M2R=regional-adopted make dev-deploy
       - uses: actions/setup-python@v6
         with:
           python-version: "3.13"

--- a/.github/workflows/pr_test_cross_namespace.yaml
+++ b/.github/workflows/pr_test_cross_namespace.yaml
@@ -59,7 +59,7 @@ jobs:
         run: docker run -d --rm --network kind -v /var/run/docker.sock:/var/run/docker.sock registry.k8s.io/cloud-provider-kind/cloud-controller-manager:v0.10.0 --gateway-channel="disabled"
       - name: "[PR] Deploy KOF components on Mothership cluster"
         run: |
-          DISABLE_KOF_COLLECTORS=true DISABLE_KOF_STORAGE=true make dev-deploy
+          DISABLE_KOF_COLLECTORS=true DISABLE_KOF_STORAGE=true M2M=true make dev-deploy
       - uses: actions/setup-python@v6
         with:
           python-version: "3.13"

--- a/.github/workflows/pr_test_kcm_region_with_kof.yaml
+++ b/.github/workflows/pr_test_kcm_region_with_kof.yaml
@@ -111,7 +111,7 @@ jobs:
         run: docker run -d --rm --network kind -v /var/run/docker.sock:/var/run/docker.sock registry.k8s.io/cloud-provider-kind/cloud-controller-manager:v0.10.0 --gateway-channel="disabled"
       - name: "[PR] Deploy KOF components on Mothership cluster"
         run: |
-          DISABLE_KOF_COLLECTORS=true DISABLE_KOF_STORAGE=true make dev-deploy
+          DISABLE_KOF_COLLECTORS=true DISABLE_KOF_STORAGE=true M2M=true make dev-deploy
       - uses: actions/setup-python@v6
         with:
           python-version: "3.13"

--- a/.github/workflows/pr_test_kof_installation.yaml
+++ b/.github/workflows/pr_test_kof_installation.yaml
@@ -107,7 +107,7 @@ jobs:
         run: docker run -d --rm --network kind -v /var/run/docker.sock:/var/run/docker.sock registry.k8s.io/cloud-provider-kind/cloud-controller-manager:v0.10.0 --gateway-channel="disabled"
       - name: "[PR] Deploy KOF components on Mothership cluster"
         run: |
-          DISABLE_KOF_COLLECTORS=true DISABLE_KOF_STORAGE=true make dev-deploy
+          DISABLE_KOF_COLLECTORS=true DISABLE_KOF_STORAGE=true M2M=true make dev-deploy
       - uses: actions/setup-python@v6
         with:
           python-version: "3.13"

--- a/.github/workflows/pr_test_tenant_isolation_test.yaml
+++ b/.github/workflows/pr_test_tenant_isolation_test.yaml
@@ -99,7 +99,7 @@ jobs:
         run: docker run -d --rm --network kind -v /var/run/docker.sock:/var/run/docker.sock registry.k8s.io/cloud-provider-kind/cloud-controller-manager:v0.10.0 --gateway-channel="disabled"
       - name: "[PR] Deploy KOF components on Mothership cluster"
         run: |
-          DISABLE_KOF_COLLECTORS=true DISABLE_KOF_STORAGE=true make dev-deploy
+          DISABLE_KOF_COLLECTORS=true DISABLE_KOF_STORAGE=true M2M=true make dev-deploy
       - uses: actions/setup-python@v6
         with:
           python-version: "3.13"

--- a/Makefile
+++ b/Makefile
@@ -282,6 +282,14 @@ dev-deploy: dev kof-namespace ## Deploy KOF umbrella chart with local developmen
 		echo "⚠️ Disabling kof-storage"; \
 		$(YQ) eval -i '.kof-storage.enabled = false' dev/values-local.yaml; \
 	fi
+	@if [ "$(M2M)" = true ]; then \
+		echo "Enabling export fromManagement toManagementCluster"; \
+		$(YQ) eval -i '.kof-child.values.fromManagement.toManagementCluster.enabled = true' dev/values-local.yaml; \
+	fi
+	@if [ "$(M2R)" != "" ]; then \
+		echo "Enabling export fromManagement toRegionalCluster"; \
+		$(YQ) eval -i '.kof-child.values.fromManagement.toRegionalCluster.name = "$(M2R)"' dev/values-local.yaml; \
+	fi
 	@$(call set_local_registry, "dev/values-local.yaml")
 	@if [ -n "$(HELM_CHART_NAME)" ]; then \
 		echo "Deploying specific chart: $(HELM_CHART_NAME)"; \

--- a/scripts/metrics_smoke_test.py
+++ b/scripts/metrics_smoke_test.py
@@ -34,7 +34,6 @@ METRICS = [
     metric % labels
     for metric in [
         'up{job=~"kubernetes-apiservers|apiserver", %s}',
-        'vm_app_uptime_seconds{%s}',
         'sum(node_total_hourly_cost{%s})',
     ]
     for labels in [MGMT_LABELS, REGIONAL_LABELS, CHILD_LABELS]
@@ -42,6 +41,8 @@ METRICS = [
     'up{job="kof-collectors-ta-daemon-targetallocator", %s}' % MGMT_LABELS,
     'up{app_kubernetes_io_name="kof-collectors-daemon-collector", %s}' % REGIONAL_LABELS,
     'up{app_kubernetes_io_name="kof-collectors-daemon-collector", %s}' % CHILD_LABELS,
+
+    'vm_app_uptime_seconds{%s}' % REGIONAL_LABELS,
 ]
 
 # Helpers

--- a/scripts/metrics_smoke_test.py
+++ b/scripts/metrics_smoke_test.py
@@ -15,21 +15,33 @@ NAMESPACE = "kof"
 GRAFANA_URL = os.environ.get("GRAFANA_URL", "http://localhost:3000")
 CREDENTIALS_SECRET = "grafana-admin-credentials"
 DATASOURCE_NAME = os.environ.get("METRICS_DATASOURCE", "kof-metrics")
-REGIONAL_CLUSTER = os.environ.get("REGIONAL_CLUSTER", "regional-adopted")
-CHILD_CLUSTER = os.environ.get("CHILD_CLUSTER", "child-adopted")
-CHILD_LABELS = f", {v}" if (v := os.environ.get("CHILD_LABELS", "")) else ""
-REGIONAL_LABELS = f", {v}" if (v := os.environ.get("REGIONAL_LABELS", "")) else ""
 TIMEOUT = int(os.environ.get("SMOKE_TIMEOUT", "300"))
 POLL = 10
 
+MGMT_CLUSTER = os.environ.get("MGMT_CLUSTER", "mothership")
+REGIONAL_CLUSTER = os.environ.get("REGIONAL_CLUSTER", "regional-adopted")
+CHILD_CLUSTER = os.environ.get("CHILD_CLUSTER", "child-adopted")
+
+get_labels = lambda cluster, env_var: f'cluster="{cluster}"' + (
+    f", {labels}" if (labels := os.environ.get(env_var, "")) else ""
+)
+
+MGMT_LABELS = get_labels(MGMT_CLUSTER, "MGMT_LABELS")
+REGIONAL_LABELS = get_labels(REGIONAL_CLUSTER, "REGIONAL_LABELS")
+CHILD_LABELS = get_labels(CHILD_CLUSTER, "CHILD_LABELS")
+
 METRICS = [
-    f'up{{job=~"kubernetes-apiservers|apiserver", cluster="{CHILD_CLUSTER}"{CHILD_LABELS}}}',
-    f'up{{job=~"kubernetes-apiservers|apiserver", cluster="{REGIONAL_CLUSTER}"{REGIONAL_LABELS}}}',
-    f'up{{app_kubernetes_io_name="kof-collectors-daemon-collector", cluster="{CHILD_CLUSTER}"{CHILD_LABELS}}}',
-    f'up{{app_kubernetes_io_name="kof-collectors-daemon-collector", cluster="{REGIONAL_CLUSTER}"{REGIONAL_LABELS}}}',
-    f'vm_app_uptime_seconds{{cluster="{REGIONAL_CLUSTER}"{REGIONAL_LABELS}}}',
-    f'sum(node_total_hourly_cost{{cluster="{CHILD_CLUSTER}"{CHILD_LABELS}}})',
-    f'sum(node_total_hourly_cost{{cluster="{REGIONAL_CLUSTER}"{REGIONAL_LABELS}}})',
+    metric % labels
+    for metric in [
+        'up{job=~"kubernetes-apiservers|apiserver", %s}',
+        'vm_app_uptime_seconds{%s}',
+        'sum(node_total_hourly_cost{%s})',
+    ]
+    for labels in [MGMT_LABELS, REGIONAL_LABELS, CHILD_LABELS]
+] + [
+    'up{job="kof-collectors-ta-daemon-targetallocator", %s}' % MGMT_LABELS,
+    'up{app_kubernetes_io_name="kof-collectors-daemon-collector", %s}' % REGIONAL_LABELS,
+    'up{app_kubernetes_io_name="kof-collectors-daemon-collector", %s}' % CHILD_LABELS,
 ]
 
 # Helpers


### PR DESCRIPTION
* Adds CI tests related to:
  * https://github.com/k0rdent/kof/issues/733
  * https://github.com/k0rdent/kof/issues/1010
* Makes `metrics_smoke_test.py` easier to support more clusters and metrics without duplication.
* Tested both [M2M](https://github.com/k0rdent/kof/actions/runs/26052487571/job/76592299861?pr=1021#step:30:24) and [M2R](https://github.com/k0rdent/kof/actions/runs/26052487569/job/76592507981?pr=1021#step:55:24) cases via CI:
  ```
  scripts/metrics_smoke_test.py::test_metric_has_data[up{job=~"kubernetes-apiservers|apiserver", cluster="mothership"}] PASSED [ 18%]
  scripts/metrics_smoke_test.py::test_metric_has_data[up{job=~"kubernetes-apiservers|apiserver", cluster="regional-adopted"}] PASSED [ 27%]
  scripts/metrics_smoke_test.py::test_metric_has_data[up{job=~"kubernetes-apiservers|apiserver", cluster="child-adopted"}] PASSED [ 36%]
  scripts/metrics_smoke_test.py::test_metric_has_data[sum(node_total_hourly_cost{cluster="mothership"})] PASSED [ 45%]
  scripts/metrics_smoke_test.py::test_metric_has_data[sum(node_total_hourly_cost{cluster="regional-adopted"})] PASSED [ 54%]
  scripts/metrics_smoke_test.py::test_metric_has_data[sum(node_total_hourly_cost{cluster="child-adopted"})] PASSED [ 63%]
  scripts/metrics_smoke_test.py::test_metric_has_data[up{job="kof-collectors-ta-daemon-targetallocator", cluster="mothership"}] PASSED [ 72%]
  scripts/metrics_smoke_test.py::test_metric_has_data[up{app_kubernetes_io_name="kof-collectors-daemon-collector", cluster="regional-adopted"}] PASSED [ 81%]
  scripts/metrics_smoke_test.py::test_metric_has_data[up{app_kubernetes_io_name="kof-collectors-daemon-collector", cluster="child-adopted"}] PASSED [ 90%]
  scripts/metrics_smoke_test.py::test_metric_has_data[vm_app_uptime_seconds{cluster="regional-adopted"}] PASSED [100%]
  ```
