### PR TITLE
fix: Enabled daemon-collector metrics in M2M case

### DIFF
--- a/.github/workflows/pr_test_kcm_region_with_kof.yaml
+++ b/.github/workflows/pr_test_kcm_region_with_kof.yaml
@@ -120,6 +120,7 @@ jobs:
             --set cert-manager.enable=false \
             --set operator.image.registry=docker.io/library \
             --set operator.image.repository=istio-operator-controller \
+            --set istiod.global.proxy.resources.requests.cpu=50m \
             --set "istiod.meshConfig.extensionProviders[0].name=otel-tracing" \
             --set "istiod.meshConfig.extensionProviders[0].opentelemetry.port=4317" \
             --set "istiod.meshConfig.extensionProviders[0].opentelemetry.service=kof-collectors-daemon-collector.kof.svc.cluster.local" \

--- a/.github/workflows/pr_test_kof_installation.yaml
+++ b/.github/workflows/pr_test_kof_installation.yaml
@@ -121,6 +121,7 @@ jobs:
             --set cert-manager.enable=false \
             --set operator.image.registry=docker.io/library \
             --set operator.image.repository=istio-operator-controller \
+            --set istiod.global.proxy.resources.requests.cpu=50m \
             --set "istiod.meshConfig.extensionProviders[0].name=otel-tracing" \
             --set "istiod.meshConfig.extensionProviders[0].opentelemetry.port=4317" \
             --set "istiod.meshConfig.extensionProviders[0].opentelemetry.service=kof-collectors-daemon-collector.kof.svc.cluster.local" \

--- a/.github/workflows/pr_test_tenant_isolation_test.yaml
+++ b/.github/workflows/pr_test_tenant_isolation_test.yaml
@@ -114,6 +114,7 @@ jobs:
             --set cert-manager.enable=false \
             --set operator.image.registry=docker.io/library \
             --set operator.image.repository=istio-operator-controller \
+            --set istiod.global.proxy.resources.requests.cpu=50m \
             --set "istiod.meshConfig.extensionProviders[0].name=otel-tracing" \
             --set "istiod.meshConfig.extensionProviders[0].opentelemetry.port=4317" \
             --set "istiod.meshConfig.extensionProviders[0].opentelemetry.service=kof-collectors-daemon-collector.kof.svc.cluster.local" \

--- a/charts/kof-child/templates/child-multi-cluster-service.yaml
+++ b/charts/kof-child/templates/child-multi-cluster-service.yaml
@@ -217,7 +217,7 @@ spec:
               daemon:
               {{- if $istio }}
                 hostNetwork: false
-              {{- else if not $m2m }}
+              {{- else }}
                 image:
                   tag: v{{ $.Chart.Version | trimPrefix "v" }}
                 hostNetwork: true

--- a/charts/kof/values-local.yaml
+++ b/charts/kof/values-local.yaml
@@ -162,6 +162,11 @@ kof-mothership:
     kube-state-metrics:
       enabled: true
 
+    victoria-traces-multilevel-select:
+      resources:
+        requests:
+          cpu: 50m
+
 # KOF Regional - MultiClusterService template for regional clusters
 kof-regional:
   values:
@@ -208,6 +213,15 @@ kof-child:
     fromManagement:
       collectors:
         opentelemetry-kube-stack:
+          collectors:
+            target-allocator:
+              resources:
+                requests:
+                  cpu: 50m
+              targetAllocator:
+                resources:
+                  requests:
+                    cpu: 50m
           defaultCRConfig:
             env:
               - name: PKI_PATH

--- a/scripts/metrics_smoke_test.py
+++ b/scripts/metrics_smoke_test.py
@@ -34,14 +34,11 @@ METRICS = [
     metric % labels
     for metric in [
         'up{job=~"kubernetes-apiservers|apiserver", %s}',
+        'up{app_kubernetes_io_name="kof-collectors-daemon-collector", %s}',
         'sum(node_total_hourly_cost{%s})',
     ]
     for labels in [MGMT_LABELS, REGIONAL_LABELS, CHILD_LABELS]
 ] + [
-    'up{job="kof-collectors-ta-daemon-targetallocator", %s}' % MGMT_LABELS,
-    'up{app_kubernetes_io_name="kof-collectors-daemon-collector", %s}' % REGIONAL_LABELS,
-    'up{app_kubernetes_io_name="kof-collectors-daemon-collector", %s}' % CHILD_LABELS,
-
     'vm_app_uptime_seconds{%s}' % REGIONAL_LABELS,
 ]
 


### PR DESCRIPTION
* Fixes https://github.com/k0rdent/kof/issues/1010
  and https://github.com/k0rdent/kof/pull/1021
  to use daemon-collector metrics in all clusters in the same way.