### PR TITLE
ci: Revert decreased CPU requests for CI/local to avoid `Insufficient CPU` in istio cases

### DIFF
--- a/.github/workflows/pr_test_kcm_region_with_kof.yaml
+++ b/.github/workflows/pr_test_kcm_region_with_kof.yaml
@@ -120,7 +120,6 @@ jobs:
             --set cert-manager.enable=false \
             --set operator.image.registry=docker.io/library \
             --set operator.image.repository=istio-operator-controller \
-            --set istiod.global.proxy.resources.requests.cpu=50m \
             --set "istiod.meshConfig.extensionProviders[0].name=otel-tracing" \
             --set "istiod.meshConfig.extensionProviders[0].opentelemetry.port=4317" \
             --set "istiod.meshConfig.extensionProviders[0].opentelemetry.service=kof-collectors-daemon-collector.kof.svc.cluster.local" \

--- a/.github/workflows/pr_test_kof_installation.yaml
+++ b/.github/workflows/pr_test_kof_installation.yaml
@@ -121,7 +121,6 @@ jobs:
             --set cert-manager.enable=false \
             --set operator.image.registry=docker.io/library \
             --set operator.image.repository=istio-operator-controller \
-            --set istiod.global.proxy.resources.requests.cpu=50m \
             --set "istiod.meshConfig.extensionProviders[0].name=otel-tracing" \
             --set "istiod.meshConfig.extensionProviders[0].opentelemetry.port=4317" \
             --set "istiod.meshConfig.extensionProviders[0].opentelemetry.service=kof-collectors-daemon-collector.kof.svc.cluster.local" \

--- a/.github/workflows/pr_test_tenant_isolation_test.yaml
+++ b/.github/workflows/pr_test_tenant_isolation_test.yaml
@@ -114,7 +114,6 @@ jobs:
             --set cert-manager.enable=false \
             --set operator.image.registry=docker.io/library \
             --set operator.image.repository=istio-operator-controller \
-            --set istiod.global.proxy.resources.requests.cpu=50m \
             --set "istiod.meshConfig.extensionProviders[0].name=otel-tracing" \
             --set "istiod.meshConfig.extensionProviders[0].opentelemetry.port=4317" \
             --set "istiod.meshConfig.extensionProviders[0].opentelemetry.service=kof-collectors-daemon-collector.kof.svc.cluster.local" \

--- a/charts/kof/values-local.yaml
+++ b/charts/kof/values-local.yaml
@@ -166,11 +166,6 @@ kof-mothership:
     kube-state-metrics:
       enabled: true
 
-    victoria-traces-multilevel-select:
-      resources:
-        requests:
-          cpu: 50m
-
 # KOF Regional - MultiClusterService template for regional clusters
 kof-regional:
   values:
@@ -226,15 +221,6 @@ kof-child:
     fromManagement:
       collectors:
         opentelemetry-kube-stack:
-          collectors:
-            target-allocator:
-              resources:
-                requests:
-                  cpu: 50m
-              targetAllocator:
-                resources:
-                  requests:
-                    cpu: 50m
           defaultCRConfig:
             env:
               - name: PKI_PATH


### PR DESCRIPTION
* This reverts commit 6fbc0728bee71b3321c0927fa592ba80b80d0ab5 because our CI runner got CPU upgrade.