### PR TITLE
fix: replace TargetPathSuffix with QueryArgs for correct tenant filtering

### DIFF
--- a/kof-operator/internal/controller/clusterdeployment_kof_cluster_child_role.go
+++ b/kof-operator/internal/controller/clusterdeployment_kof_cluster_child_role.go
@@ -82,8 +82,10 @@ func (c *ChildClusterRole) CreateVMUserCredentials(regionalClusterName string) e
 		Name:           GetVMUserName(GetConfigMapName(c.clusterName), c.clusterNamespace),
 		Namespace:      c.clusterNamespace,
 		ClusterRef:     c.clusterDeployment,
-		ClusterName:    c.clusterName,
 		OwnerReference: c.ownerReference,
+		ExtraLabels: map[string]string{
+			labels.ClusterNameLabel: c.clusterName,
+		},
 		MCSConfig: &vmuser.MCSConfig{
 			ClusterSelector: metav1.LabelSelector{
 				MatchLabels: map[string]string{
@@ -97,9 +99,7 @@ func (c *ChildClusterRole) CreateVMUserCredentials(regionalClusterName string) e
 	}
 
 	if tenantID, ok := c.clusterDeployment.Labels[labels.KofTenantLabel]; ok {
-		opts.ExtraLabels = map[string]string{
-			labels.KofTenantLabel: tenantID,
-		}
+		opts.ExtraLabels[labels.KofTenantLabel] = tenantID
 		opts.VMUserConfig = &vmuser.VMUserConfig{
 			ExtraFilters: map[string]string{"tenant": tenantID},
 			ExtraLabel:   &vmuser.ExtraLabel{Key: "tenant", Value: tenantID},

--- a/kof-operator/internal/controller/clusterdeployment_kof_cluster_child_role.go
+++ b/kof-operator/internal/controller/clusterdeployment_kof_cluster_child_role.go
@@ -96,9 +96,9 @@ func (c *ChildClusterRole) CreateVMUserCredentials(regionalClusterName string) e
 		},
 	}
 
-	if tenantID, ok := c.clusterDeployment.Labels[vmuser.KofTenantLabel]; ok {
+	if tenantID, ok := c.clusterDeployment.Labels[labels.KofTenantLabel]; ok {
 		opts.ExtraLabels = map[string]string{
-			vmuser.KofTenantLabel: tenantID,
+			labels.KofTenantLabel: tenantID,
 		}
 		opts.VMUserConfig = &vmuser.VMUserConfig{
 			ExtraFilters: map[string]string{"tenant": tenantID},

--- a/kof-operator/internal/controller/configmap_cluster_regional.go
+++ b/kof-operator/internal/controller/configmap_cluster_regional.go
@@ -129,7 +129,9 @@ func (c *RegionalClusterConfigMap) CreateVMUser() error {
 		Namespace:      c.clusterNamespace,
 		ClusterRef:     c.configMap,
 		OwnerReference: c.ownerReference,
-		ClusterName:    c.clusterName,
+		ExtraLabels: map[string]string{
+			labels.ClusterNameLabel: c.clusterName,
+		},
 		MCSConfig: &vmuser.MCSConfig{
 			ClusterSelector: metav1.LabelSelector{
 				MatchLabels: map[string]string{

--- a/kof-operator/internal/controller/regional_cluster_configmap_controller.go
+++ b/kof-operator/internal/controller/regional_cluster_configmap_controller.go
@@ -67,7 +67,9 @@ func (r *RegionalClusterConfigMapReconciler) Reconcile(
 }
 
 func ResourceCleanup(ctx context.Context, client client.Client, cmName, namespace string) (ctrl.Result, error) {
-	if err := vmuser.NewManager(client).Delete(ctx, cmName, namespace); err != nil {
+	vmuserName := GetVMUserName(cmName, namespace)
+
+	if err := vmuser.NewManager(client).Delete(ctx, vmuserName, namespace); err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to delete VMUser resources: %v", err)
 	}
 

--- a/kof-operator/internal/controller/regional_cluster_configmap_controller.go
+++ b/kof-operator/internal/controller/regional_cluster_configmap_controller.go
@@ -67,7 +67,7 @@ func (r *RegionalClusterConfigMapReconciler) Reconcile(
 }
 
 func ResourceCleanup(ctx context.Context, client client.Client, cmName, namespace string) (ctrl.Result, error) {
-	vmuserName := GetVMUserName(cmName, namespace)
+	vmuserName := GetVMUserAdminName(cmName, namespace)
 
 	if err := vmuser.NewManager(client).Delete(ctx, vmuserName, namespace); err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to delete VMUser resources: %v", err)

--- a/kof-operator/internal/controller/vmuser/victoriametrics_user.go
+++ b/kof-operator/internal/controller/vmuser/victoriametrics_user.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 	"maps"
-	"reflect"
+	"sort"
 	"strings"
 
 	kcmv1beta1 "github.com/K0rdent/kcm/api/v1beta1"
@@ -20,6 +20,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
@@ -65,8 +66,6 @@ type ExtraLabel struct {
 	Value string
 }
 
-const KofTenantLabel = "k0rdent.mirantis.com/kof-tenant-id"
-
 const (
 	UsernameKey = "username"
 	PasswordKey = "password"
@@ -88,19 +87,24 @@ const (
 	vtSelectURL      = "http://kof-storage-vt-cluster-vtselect.kof.svc:10471"
 	vtInsertURL      = "http://kof-storage-vt-cluster-vtinsert.kof.svc:10481"
 
-	// VlSelectPathPrefix and VlAuditSelectPathPrefix are the exported VMAuth URL path
-	// prefixes used by other packages to derive audit-logs routing paths.
-	VlSelectPathPrefix      = "/vls"
-	VlAuditSelectPathPrefix = "/vlas"
-
-	vlSelectPath      = VlSelectPathPrefix + "/.*"
+	vlSelectPath      = "/vls/.*"
 	vlInsertPath      = "/vli/.*"
-	vlAuditSelectPath = VlAuditSelectPathPrefix + "/.*"
+	vlAuditSelectPath = "/vlas/.*"
 	vlAuditInsertPath = "/vlai/.*"
 	vmSelectPath      = "/vm/select/.*"
 	vmInsertPath      = "/vm/insert/.*"
 	vtSelectPath      = "/vts/.*"
 	vtInsertPath      = "/vti/.*"
+)
+
+const (
+	EventTypeVMUserCreationOrUpdateFailed = "VMUserCreationOrUpdateFailed"
+	EventTypeVMUserCreated                = "VMUserCreated"
+	EventTypeVMUserUpdated                = "VMUserUpdated"
+
+	EventTypeVMUserMCSCreationOrUpdateFailed = "VMUserMCSCreationOrUpdateFailed"
+	EventTypeVMUserMCSCreated                = "VMUserMCSCreated"
+	EventTypeVMUserMCSUpdated                = "VMUserMCSUpdated"
 )
 
 type Manager struct {
@@ -168,301 +172,78 @@ func (m *Manager) Delete(ctx context.Context, name, namespace string) error {
 	return nil
 }
 
+// Reconcile ensures that the VMUser and related resources are created or updated according to the provided options.
 func (m *Manager) createSecret(ctx context.Context, opts *CreateOptions) error {
 	log := log.FromContext(ctx)
 	secretName := BuildSecretName(opts.Name)
+	log.Info("Creating or updating VMUser credentials secret", "name", secretName, "namespace", opts.Namespace)
 
-	// Create secret in the target namespace
-	targetSecret, err := buildCredsSecret(opts)
-	if err != nil {
-		return fmt.Errorf("failed to build credentials secret: %w", err)
-	}
-
-	log.Info("Creating VMUser credentials secret in target namespace", "name", secretName, "namespace", opts.Namespace)
-	created, err := k8s.EnsureCreated(ctx, m.client, targetSecret)
-	if err != nil {
-		return fmt.Errorf("failed to create creds secret in namespace %s: %w", opts.Namespace, err)
-	}
-
-	if !created {
-		log.Info("VMUser credentials secret already exists in target namespace", "name", secretName, "namespace", opts.Namespace)
-		// Get the existing secret from cluster to use its actual password
-		existingSecret := &corev1.Secret{}
-		if err := m.client.Get(ctx, client.ObjectKey{Name: secretName, Namespace: opts.Namespace}, existingSecret); err != nil {
-			return fmt.Errorf("failed to get existing secret: %w", err)
-		}
-		targetSecret = existingSecret
-	}
-
-	// Sync the actual secret (with real password) to kof namespace
-	if err := m.createOrUpdateKofNamespaceSecret(ctx, targetSecret); err != nil {
-		return fmt.Errorf("failed to create secret in kof namespace: %w", err)
-	}
-
-	log.Info("VMUser credentials secrets created successfully", "name", secretName)
-	return nil
-}
-
-// createOrUpdateKofNamespaceSecret creates a copy of the VMUser credentials secret in the kof namespace.
-// The secret needs to be created in the kof namespace for promxy access.
-func (m *Manager) createOrUpdateKofNamespaceSecret(ctx context.Context, secret *corev1.Secret) error {
-	log := log.FromContext(ctx)
-
-	kofSecret := &corev1.Secret{}
-	if err := m.client.Get(ctx, client.ObjectKey{
-		Name:      secret.Name,
-		Namespace: k8s.KofNamespace,
-	}, kofSecret); err != nil {
-		if errors.IsNotFound(err) {
-			newKofSecret := &corev1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      secret.Name,
-					Namespace: k8s.KofNamespace,
-					Labels:    secret.Labels,
-				},
-				Data: secret.Data,
-			}
-
-			log.Info("Creating VMUser credentials secret in kof namespace", "name", secret.Name, "namespace", k8s.KofNamespace)
-			if err := m.client.Create(ctx, newKofSecret); err != nil {
-				return fmt.Errorf("failed to create secret in kof namespace: %w", err)
-			}
-			return nil
-		}
-
-		return fmt.Errorf("failed to get secret in kof namespace: %w", err)
-	}
-
-	if reflect.DeepEqual(kofSecret.Data, secret.Data) {
-		return nil
-	}
-
-	kofSecret.Data = secret.Data
-	if err := m.client.Update(ctx, kofSecret); err != nil {
-		return fmt.Errorf("failed to update secret in kof namespace: %w", err)
-	}
-
-	log.Info("Updated VMUser credentials secret in kof namespace", "name", secret.Name)
-	return nil
-}
-
-func (m *Manager) getPropagationMCS(ctx context.Context, name string) (*kcmv1beta1.MultiClusterService, error) {
-	mcs := new(kcmv1beta1.MultiClusterService)
-	err := m.client.Get(ctx, client.ObjectKey{Name: BuildMCSName(name)}, mcs)
-	if err != nil {
-		if errors.IsNotFound(err) {
-			return nil, nil
-		}
-		return nil, err
-	}
-	return mcs, nil
-}
-
-func (m *Manager) createPropagationMCS(ctx context.Context, opts *CreateOptions) error {
-	mcs := buildPropagationMCS(opts)
-	log := log.FromContext(ctx)
-
-	log.Info("Creating MultiClusterService for VMUser propagation", "name", mcs.Name)
-	created, err := k8s.EnsureCreated(ctx, m.client, mcs)
-	if err != nil {
-		return err
-	}
-
-	if !created {
-		log.Info("MultiClusterService already exists", "name", mcs.Name)
-		return nil
-	}
-
-	log.Info("MultiClusterService created successfully", "name", mcs.Name)
-	return nil
-}
-
-func (m *Manager) updatePropagationMCS(ctx context.Context, opts *CreateOptions, existingMCS, newMCS *kcmv1beta1.MultiClusterService) error {
-	if reflect.DeepEqual(existingMCS.Spec, newMCS.Spec) {
-		return nil
-	}
-
-	existingMCS.Spec = newMCS.Spec
-	if err := m.client.Update(ctx, existingMCS); err != nil {
-		record.LogEvent(
-			ctx,
-			"PropagationMCSUpdateFailed",
-			"Failed to update propagation MultiClusterService",
-			opts.ClusterRef,
-			err,
-			"name", existingMCS.Name,
-		)
-		return err
-	}
-
-	record.LogEvent(
-		ctx,
-		"PropagationMCSUpdateSuccessful",
-		"Propagation MultiClusterService updated successfully",
-		opts.ClusterRef,
-		nil,
-		"name", existingMCS.Name,
-	)
-	return nil
-}
-
-func (m *Manager) createOrUpdatePropagationMCS(ctx context.Context, opts *CreateOptions) error {
-	mcs, err := m.getPropagationMCS(ctx, opts.Name)
-	if err != nil {
-		return fmt.Errorf("failed to get propagation MultiClusterService: %w", err)
-	}
-
-	if mcs == nil {
-		if err := m.createPropagationMCS(ctx, opts); err != nil {
-			return fmt.Errorf("failed to create propagation MultiClusterService for VMUser %s: %w", opts.Name, err)
-		}
-		return nil
-	}
-
-	newMCS := buildPropagationMCS(opts)
-	if err := m.updatePropagationMCS(ctx, opts, mcs, newMCS); err != nil {
-		return fmt.Errorf("failed to update propagation MultiClusterService for VMUser %s: %w", opts.Name, err)
-	}
-	return nil
-}
-
-func (m *Manager) createOrUpdateVMUser(ctx context.Context, opts *CreateOptions) error {
-	vmUser, err := m.getVMUser(ctx, opts.Name, opts.Namespace)
-	if err != nil {
-		return fmt.Errorf("failed to get VMUser: %w", err)
-	}
-
-	if vmUser == nil {
-		if err := m.createVMUser(ctx, opts); err != nil {
-			return fmt.Errorf("failed to create VMUser %s: %w", opts.Name, err)
-		}
-		return nil
-	}
-
-	newVMUser := buildVMUser(opts)
-	if err := m.updateVMUser(ctx, opts, vmUser, newVMUser); err != nil {
-		return fmt.Errorf("failed to update VMUser %s: %w", opts.Name, err)
-	}
-	return nil
-}
-
-func (m *Manager) updateVMUser(ctx context.Context, opts *CreateOptions, existingVMUser, newVMUser *vmv1beta1.VMUser) error {
-	if reflect.DeepEqual(existingVMUser.Spec, newVMUser.Spec) {
-		return nil
-	}
-
-	existingVMUser.Spec = newVMUser.Spec
-	if err := m.client.Update(ctx, existingVMUser); err != nil {
-		record.LogEvent(
-			ctx,
-			"VMUserUpdateFailed",
-			"Failed to update VMUser",
-			opts.ClusterRef,
-			err,
-			"name", existingVMUser.Name,
-		)
-		return err
-	}
-
-	record.LogEvent(
-		ctx,
-		"VMUserUpdateSuccessful",
-		"VMUser updated successfully",
-		opts.ClusterRef,
-		nil,
-		"name", existingVMUser.Name,
-	)
-
-	return nil
-}
-
-func (m *Manager) getVMUser(ctx context.Context, name, namespace string) (*vmv1beta1.VMUser, error) {
-	vmUser := &vmv1beta1.VMUser{}
-	err := m.client.Get(ctx, client.ObjectKey{Name: BuildVMUserName(name), Namespace: namespace}, vmUser)
-	if err != nil {
-		if errors.IsNotFound(err) {
-			return nil, nil
-		}
-		return nil, err
-	}
-	return vmUser, nil
-}
-
-func (m *Manager) createVMUser(ctx context.Context, opts *CreateOptions) error {
-	log := log.FromContext(ctx)
-	vmUserName := BuildVMUserName(opts.Name)
-	vmUser := buildVMUser(opts)
-
-	log.Info("Creating VMUser", "name", vmUserName)
-	created, err := k8s.EnsureCreated(ctx, m.client, vmUser)
-	if err != nil {
-		record.LogEvent(
-			ctx,
-			"VMUserCreationFailed",
-			"Failed to create VMUser",
-			opts.ClusterRef,
-			err,
-			"name", vmUserName,
-		)
-		return err
-	}
-
-	if !created {
-		log.Info("VMUser already exists", "name", vmUserName)
-		return nil
-	}
-
-	record.LogEvent(
-		ctx,
-		"VMUserCreated",
-		"VMUser created successfully",
-		opts.ClusterRef,
-		nil,
-		"name", vmUserName,
-	)
-	return nil
-}
-
-func (m *Manager) deleteResource(ctx context.Context, obj client.Object, name, namespace string) error {
-	log := log.FromContext(ctx)
-	kind := obj.GetObjectKind().GroupVersionKind().Kind
-
-	obj.SetName(name)
-	obj.SetNamespace(namespace)
-
-	log.Info(fmt.Sprintf("Deleting VMUser %s resource", kind), "name", name)
-	if err := m.client.Delete(ctx, obj); err != nil {
-		if errors.IsNotFound(err) {
-			log.Info(fmt.Sprintf("VMUser %s resource already deleted", kind), "name", name)
-			return nil
-		}
-		return err
-	}
-
-	log.Info(fmt.Sprintf("VMUser %s resource deleted successfully", kind), "name", name)
-	return nil
-}
-
-// buildPropagationMCS constructs a MultiClusterService for propagating VMUser resources to managed clusters.
-func buildPropagationMCS(opts *CreateOptions) *kcmv1beta1.MultiClusterService {
-	propagationTemplate := env.GetPropagationTemplateName()
-
-	labels := getMandatoryLabels()
-	maps.Copy(labels, opts.ExtraLabels)
-
-	return &kcmv1beta1.MultiClusterService{
+	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:   BuildMCSName(opts.Name),
-			Labels: labels,
+			Name:      secretName,
+			Namespace: opts.Namespace,
 		},
-		Spec: kcmv1beta1.MultiClusterServiceSpec{
+	}
+
+	if _, err := controllerutil.CreateOrUpdate(ctx, m.client, secret, func() error {
+		// Only generate a new password when creating; preserve the existing one on update.
+		if len(secret.Data[PasswordKey]) == 0 {
+			pass, err := crypto.GeneratePassword(passwordLength)
+			if err != nil {
+				return fmt.Errorf("failed to generate password: %w", err)
+			}
+			secret.Data = map[string][]byte{
+				UsernameKey: []byte(opts.Name),
+				PasswordKey: []byte(pass),
+			}
+		}
+
+		secret.Labels = getLabels(opts.ExtraLabels)
+		secret.OwnerReferences = getOwnerReferences(opts.OwnerReference)
+		return nil
+	}); err != nil {
+		return fmt.Errorf("failed to create or update credentials secret: %w", err)
+	}
+
+	kofSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      secret.Name,
+			Namespace: k8s.KofNamespace,
+		},
+	}
+
+	if _, err := controllerutil.CreateOrUpdate(ctx, m.client, kofSecret, func() error {
+		kofSecret.Labels = secret.Labels
+		kofSecret.Data = secret.Data
+		return nil
+	}); err != nil {
+		return fmt.Errorf("failed to create or update secret in kof namespace: %w", err)
+	}
+	return nil
+}
+
+// CreateOrUpdateVMUser creates or updates the VMUser resource based on the provided options, including setting up target references with query arguments derived from VMUserConfig.
+func (m *Manager) createOrUpdatePropagationMCS(ctx context.Context, opts *CreateOptions) error {
+	log := log.FromContext(ctx)
+	log.Info("Creating or updating MultiClusterService for VMUser propagation", "name", BuildMCSName(opts.Name))
+
+	mcs := &kcmv1beta1.MultiClusterService{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: BuildMCSName(opts.Name),
+		},
+	}
+
+	op, err := controllerutil.CreateOrUpdate(ctx, m.client, mcs, func() error {
+		mcs.Labels = getLabels(opts.ExtraLabels)
+		mcs.OwnerReferences = getOwnerReferences(opts.OwnerReference)
+		mcs.Spec = kcmv1beta1.MultiClusterServiceSpec{
 			ClusterSelector: opts.MCSConfig.ClusterSelector,
 			DependsOn:       opts.MCSConfig.DependsOn,
 			ServiceSpec: kcmv1beta1.ServiceSpec{
 				Services: []kcmv1beta1.Service{
 					{
 						Name:      BuildVMUserName(opts.Name),
-						Template:  propagationTemplate,
+						Template:  env.GetPropagationTemplateName(),
 						Namespace: opts.Namespace,
 						Values:    "propagation:\n  enabled: true\n  data: |\n{{ removeField \"vmuser\" \"metadata.ownerReferences\" | nindent 14 }}\n",
 						HelmOptions: &kcmv1beta1.ServiceHelmOptions{
@@ -476,7 +257,7 @@ func buildPropagationMCS(opts *CreateOptions) *kcmv1beta1.MultiClusterService {
 					},
 					{
 						Name:      BuildSecretName(opts.Name),
-						Template:  propagationTemplate,
+						Template:  env.GetPropagationTemplateName(),
 						Namespace: opts.Namespace,
 						Values:    "propagation:\n  enabled: true\n  data: |\n{{ removeField \"secret\" \"metadata.ownerReferences\" | nindent 14 }}\n",
 						HelmOptions: &kcmv1beta1.ServiceHelmOptions{
@@ -510,54 +291,47 @@ func buildPropagationMCS(opts *CreateOptions) *kcmv1beta1.MultiClusterService {
 					},
 				},
 			},
-		},
-	}
-}
+		}
+		return nil
+	})
 
-// buildCredsSecret constructs a Secret containing VMUser credentials with a generated password.
-func buildCredsSecret(opts *CreateOptions) (*corev1.Secret, error) {
-	pass, err := crypto.GeneratePassword(passwordLength)
+	logEvent := func(reason, message string, err error) {
+		record.LogEvent(ctx, reason, message, opts.ClusterRef, err, "VMUser propagation MultiClusterService name", mcs.Name)
+	}
+
 	if err != nil {
-		return nil, fmt.Errorf("failed to generate password: %w", err)
+		logEvent(EventTypeVMUserMCSCreationOrUpdateFailed, "Failed to create or update VMUser propagation MultiClusterService", err)
+		return fmt.Errorf("failed to create or update VMUser propagation MultiClusterService: %w", err)
 	}
 
-	secretLabels := getMandatoryLabels()
-	maps.Copy(secretLabels, opts.ExtraLabels)
-	if opts.ClusterName != "" {
-		secretLabels[labels.ClusterNameLabel] = opts.ClusterName
+	switch op {
+	case controllerutil.OperationResultCreated:
+		logEvent(EventTypeVMUserMCSCreated, "VMUser propagation MultiClusterService created successfully", nil)
+	case controllerutil.OperationResultUpdated:
+		logEvent(EventTypeVMUserMCSUpdated, "VMUser propagation MultiClusterService updated successfully", nil)
+	case controllerutil.OperationResultNone:
+		log.Info("VMUser propagation MultiClusterService already up to date", "name", mcs.Name)
 	}
 
-	secret := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      BuildSecretName(opts.Name),
-			Namespace: opts.Namespace,
-			Labels:    secretLabels,
-		},
-		Data: map[string][]byte{
-			UsernameKey: []byte(opts.Name),
-			PasswordKey: []byte(pass),
-		},
-	}
-
-	if opts.OwnerReference != nil {
-		secret.OwnerReferences = []metav1.OwnerReference{*opts.OwnerReference}
-	}
-
-	return secret, nil
+	return nil
 }
 
-// buildVMUser constructs a VMUser resource with the specified configuration.
-func buildVMUser(opts *CreateOptions) *vmv1beta1.VMUser {
-	labels := getMandatoryLabels()
-	maps.Copy(labels, opts.ExtraLabels)
+// createOrUpdateVMUser creates or updates the VMUser resource based on the provided options, including setting up target references with query arguments derived from VMUserConfig.
+func (m *Manager) createOrUpdateVMUser(ctx context.Context, opts *CreateOptions) error {
+	log := log.FromContext(ctx)
+	log.Info("Creating or updating VMUser", "name", BuildVMUserName(opts.Name))
 
 	vmUser := &vmv1beta1.VMUser{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      BuildVMUserName(opts.Name),
 			Namespace: opts.Namespace,
-			Labels:    labels,
 		},
-		Spec: vmv1beta1.VMUserSpec{
+	}
+
+	op, err := controllerutil.CreateOrUpdate(ctx, m.client, vmUser, func() error {
+		vmUser.OwnerReferences = getOwnerReferences(opts.OwnerReference)
+		vmUser.Labels = getLabels(opts.ExtraLabels)
+		vmUser.Spec = vmv1beta1.VMUserSpec{
 			UserName: &opts.Name,
 			PasswordRef: &corev1.SecretKeySelector{
 				Key: PasswordKey,
@@ -566,104 +340,163 @@ func buildVMUser(opts *CreateOptions) *vmv1beta1.VMUser {
 				},
 			},
 			TargetRefs: buildTargetRefs(opts.VMUserConfig),
-		},
+		}
+		return nil
+	})
+
+	logEvent := func(reason, message string, err error) {
+		record.LogEvent(ctx, reason, message, opts.ClusterRef, err, "name", vmUser.Name)
 	}
 
-	if opts.OwnerReference != nil {
-		vmUser.OwnerReferences = []metav1.OwnerReference{*opts.OwnerReference}
+	if err != nil {
+		logEvent(EventTypeVMUserCreationOrUpdateFailed, "Failed to create or update VMUser", err)
+		return fmt.Errorf("failed to create or update VMUser: %w", err)
 	}
 
-	return vmUser
+	switch op {
+	case controllerutil.OperationResultCreated:
+		logEvent(EventTypeVMUserCreated, "VMUser created successfully", nil)
+	case controllerutil.OperationResultUpdated:
+		logEvent(EventTypeVMUserUpdated, "VMUser updated successfully", nil)
+	case controllerutil.OperationResultNone:
+		log.Info("VMUser already up to date", "name", vmUser.Name)
+	}
+
+	return nil
 }
 
-// Returns the list of target references for VMUser.
-func buildTargetRefs(vmUserConfig *VMUserConfig) []vmv1beta1.TargetRef {
-	var vmInsertTargetPathSuffix string
-	var insertTargetPathSuffix string
-	var vtInsertTargetPathSuffix string
-	var selectTargetPathSuffix string
-	var vtSelectTargetPathSuffix string
+func (m *Manager) deleteResource(ctx context.Context, obj client.Object, name, namespace string) error {
+	log := log.FromContext(ctx)
+	kind := obj.GetObjectKind().GroupVersionKind().Kind
 
-	if vmUserConfig != nil {
-		if vmUserConfig.ExtraLabel != nil {
-			vmInsertTargetPathSuffix = "?extra_label=" + formatLabelParam(vmUserConfig.ExtraLabel)
-			insertTargetPathSuffix = "?extra_fields=" + formatLabelParam(vmUserConfig.ExtraLabel)
-			vtInsertTargetPathSuffix = "?extra_fields=resource_attr:" + formatLabelParam(vmUserConfig.ExtraLabel)
+	obj.SetName(name)
+	obj.SetNamespace(namespace)
+
+	log.Info(fmt.Sprintf("Deleting VMUser %s resource", kind), "name", name)
+	if err := m.client.Delete(ctx, obj); err != nil {
+		if errors.IsNotFound(err) {
+			log.Info(fmt.Sprintf("VMUser %s resource already deleted", kind), "name", name)
+			return nil
 		}
-		if len(vmUserConfig.ExtraFilters) > 0 {
-			selectTargetPathSuffix = "?extra_filters[]=" + formatFilterParams(vmUserConfig.ExtraFilters)
-			vtSelectTargetPathSuffix = "?extra_filters[]=" + formatVTFilterParams(vmUserConfig.ExtraFilters)
-		}
+		return err
 	}
 
+	log.Info(fmt.Sprintf("VMUser %s resource deleted successfully", kind), "name", name)
+	return nil
+}
+
+func getLabels(extraLabels map[string]string) map[string]string {
+	labels := map[string]string{
+		labels.ManagedByLabel: k8s.ManagedByValue,
+	}
+	maps.Copy(labels, extraLabels)
+	return labels
+}
+
+func getOwnerReferences(ownerRef *metav1.OwnerReference) []metav1.OwnerReference {
+	if ownerRef == nil {
+		return nil
+	}
+	return []metav1.OwnerReference{*ownerRef}
+}
+
+// queryArgs holds the per-component query arguments derived from VMUserConfig.
+type queryArgs struct {
+	vlSelectArgs []vmv1beta1.QueryArg
+	vlInsertArgs []vmv1beta1.QueryArg
+	vmInsertArgs []vmv1beta1.QueryArg
+	vmSelectArgs []vmv1beta1.QueryArg
+	vtSelectArgs []vmv1beta1.QueryArg
+	vtInsertArgs []vmv1beta1.QueryArg
+}
+
+// buildQueryArgs derives per-component query arguments from the VMUserConfig.
+func buildQueryArgs(cfg *VMUserConfig) queryArgs {
+	var args queryArgs
+	if cfg == nil {
+		return args
+	}
+	args.applyExtraLabel(cfg.ExtraLabel)
+	args.applyExtraFilters(cfg.ExtraFilters)
+	return args
+}
+
+// applyExtraLabel appends insert-side label-tagging query args for each storage backend.
+func (a *queryArgs) applyExtraLabel(label *ExtraLabel) {
+	if label == nil {
+		return
+	}
+	labelParam := formatLabelParam(label.Key, label.Value)
+	a.vmInsertArgs = append(a.vmInsertArgs, vmv1beta1.QueryArg{Name: "extra_label", Values: []string{labelParam}})
+	a.vlInsertArgs = append(a.vlInsertArgs, vmv1beta1.QueryArg{Name: "extra_fields", Values: []string{labelParam}})
+	a.vtInsertArgs = append(a.vtInsertArgs, vmv1beta1.QueryArg{Name: "extra_fields", Values: []string{formatLabelParam("resource_attr:"+label.Key, label.Value)}})
+}
+
+// applyExtraFilters appends select-side filter query args for each storage backend.
+// VM filters are combined into a single MetricsQL selector to ensure correct AND semantics.
+func (a *queryArgs) applyExtraFilters(filters map[string]string) {
+	if len(filters) == 0 {
+		return
+	}
+
+	vlValues := make([]string, 0, len(filters))
+	vmValues := make([]string, 0, len(filters))
+	vtValues := make([]string, 0, len(filters))
+
+	for key, value := range filters {
+		vlValues = append(vlValues, formatFilterParams(key, value))
+		vtValues = append(vtValues, formatFilterParams("resource_attr:"+key, value))
+		vmValues = append(vmValues, fmt.Sprintf(`%s="%s"`, key, value))
+	}
+
+	sort.Strings(vlValues)
+	sort.Strings(vtValues)
+	sort.Strings(vmValues)
+
+	a.vlSelectArgs = append(a.vlSelectArgs, vmv1beta1.QueryArg{Name: "extra_filters", Values: vlValues})
+	a.vtSelectArgs = append(a.vtSelectArgs, vmv1beta1.QueryArg{Name: "extra_filters", Values: vtValues})
+	a.vmSelectArgs = append(a.vmSelectArgs, vmv1beta1.QueryArg{Name: "extra_filters", Values: []string{"{" + strings.Join(vmValues, ",") + "}"}})
+}
+
+// buildTargetRefs returns the list of target references for VMUser.
+func buildTargetRefs(vmUserConfig *VMUserConfig) []vmv1beta1.TargetRef {
+	a := buildQueryArgs(vmUserConfig)
+
 	targets := []struct {
-		path       string
-		url        string
-		pathSuffix string
+		path string
+		url  string
+		args []vmv1beta1.QueryArg
 	}{
-		{vlSelectPath, vlSelectURL, selectTargetPathSuffix},
-		{vlInsertPath, vlInsertURL, insertTargetPathSuffix},
-		{vlAuditSelectPath, vlAuditSelectURL, selectTargetPathSuffix},
-		{vlAuditInsertPath, vlAuditInsertURL, insertTargetPathSuffix},
-		{vmSelectPath, vmSelectURL, selectTargetPathSuffix},
-		{vmInsertPath, vmInsertURL, vmInsertTargetPathSuffix},
-		{vtSelectPath, vtSelectURL, vtSelectTargetPathSuffix},
-		{vtInsertPath, vtInsertURL, vtInsertTargetPathSuffix},
+		{path: vlAuditSelectPath, url: vlAuditSelectURL, args: a.vlSelectArgs},
+		{path: vlAuditInsertPath, url: vlAuditInsertURL, args: a.vlInsertArgs},
+		{path: vlSelectPath, url: vlSelectURL, args: a.vlSelectArgs},
+		{path: vlInsertPath, url: vlInsertURL, args: a.vlInsertArgs},
+		{path: vmSelectPath, url: vmSelectURL, args: a.vmSelectArgs},
+		{path: vmInsertPath, url: vmInsertURL, args: a.vmInsertArgs},
+		{path: vtSelectPath, url: vtSelectURL, args: a.vtSelectArgs},
+		{path: vtInsertPath, url: vtInsertURL, args: a.vtInsertArgs},
 	}
 
 	refs := make([]vmv1beta1.TargetRef, 0, len(targets))
-	for _, target := range targets {
+	for _, t := range targets {
 		refs = append(refs, vmv1beta1.TargetRef{
-			Paths: []string{target.path},
-			Static: &vmv1beta1.StaticRef{
-				URL: target.url,
-			},
+			Paths:  []string{t.path},
+			Static: &vmv1beta1.StaticRef{URL: t.url},
 			URLMapCommon: vmv1beta1.URLMapCommon{
 				DropSrcPathPrefixParts: ptr.To(1),
 			},
-			TargetPathSuffix: target.pathSuffix,
+			QueryArgs: t.args,
 		})
 	}
-
 	return refs
 }
 
-func getMandatoryLabels() map[string]string {
-	return map[string]string{
-		labels.ManagedByLabel: k8s.ManagedByValue,
-	}
+func formatLabelParam(key, value string) string {
+	return fmt.Sprintf("%s=%s", key, value)
 }
 
-func formatLabelParam(extraLabel *ExtraLabel) string {
-	return fmt.Sprintf("%s=%s", extraLabel.Key, extraLabel.Value)
-}
-
-// formatFilterParams formats filter parameters into VictoriaMetrics-specific format: {key1="value1",key2="value2"}
-func formatFilterParams(params map[string]string) string {
-	if len(params) == 0 {
-		return ""
-	}
-
-	pairs := make([]string, 0, len(params))
-	for key, value := range params {
-		pairs = append(pairs, fmt.Sprintf("%s=\"%s\"", key, value))
-	}
-
-	return fmt.Sprintf("{%s}", strings.Join(pairs, ","))
-}
-
-// formatVTFilterParams formats filter parameters for VictoriaTrace using LogsQL resource_attr syntax.
-func formatVTFilterParams(params map[string]string) string {
-	if len(params) == 0 {
-		return ""
-	}
-
-	pairs := make([]string, 0, len(params))
-	for key, value := range params {
-		pairs = append(pairs, fmt.Sprintf("\"resource_attr:%s\":=\"%s\"", key, value))
-	}
-
-	return fmt.Sprintf("{%s}", strings.Join(pairs, ","))
+func formatFilterParams(key, value string) string {
+	return fmt.Sprintf("\"%s\":=\"%s\"", key, value)
 }
 
 // BuildSecretName returns the secret name for VMUser credentials.

--- a/kof-operator/internal/controller/vmuser/victoriametrics_user.go
+++ b/kof-operator/internal/controller/vmuser/victoriametrics_user.go
@@ -32,9 +32,6 @@ type CreateOptions struct {
 	Namespace string
 	// OwnerReference links resources to an owner for garbage collection.
 	OwnerReference *metav1.OwnerReference
-	// ClusterName is the name of the cluster associated with the VMUser,
-	// added as a label to allow efficient secret lookup by cluster.
-	ClusterName string
 	// ExtraLabels to apply to VMUser, Secret, and MultiClusterService resources.
 	ExtraLabels map[string]string
 	// MCSConfig defines MultiClusterService propagation settings. If nil, MCS will not be created.
@@ -235,7 +232,6 @@ func (m *Manager) createOrUpdatePropagationMCS(ctx context.Context, opts *Create
 
 	op, err := controllerutil.CreateOrUpdate(ctx, m.client, mcs, func() error {
 		mcs.Labels = getLabels(opts.ExtraLabels)
-		mcs.OwnerReferences = getOwnerReferences(opts.OwnerReference)
 		mcs.Spec = kcmv1beta1.MultiClusterServiceSpec{
 			ClusterSelector: opts.MCSConfig.ClusterSelector,
 			DependsOn:       opts.MCSConfig.DependsOn,

--- a/kof-operator/internal/controller/vmuser/victoriametrics_user_test.go
+++ b/kof-operator/internal/controller/vmuser/victoriametrics_user_test.go
@@ -5,12 +5,16 @@ import (
 	"testing"
 
 	kcmv1beta1 "github.com/K0rdent/kcm/api/v1beta1"
+	vmv1beta1 "github.com/VictoriaMetrics/operator/api/operator/v1beta1"
 	"github.com/k0rdent/kof/kof-operator/internal/controller/record"
+	"github.com/k0rdent/kof/kof-operator/internal/k8s"
+	"github.com/k0rdent/kof/kof-operator/internal/models/labels"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	addoncontrollerv1beta1 "github.com/projectsveltos/addon-controller/api/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
 	k8sevents "k8s.io/client-go/tools/events"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -26,6 +30,121 @@ var _ = BeforeSuite(func() {
 	record.DefaultRecorder = new(k8sevents.FakeRecorder)
 })
 
+func newTestScheme() *runtime.Scheme {
+	s := scheme.Scheme
+	Expect(kcmv1beta1.AddToScheme(s)).To(Succeed())
+	Expect(addoncontrollerv1beta1.AddToScheme(s)).To(Succeed())
+	Expect(corev1.AddToScheme(s)).To(Succeed())
+	Expect(vmv1beta1.AddToScheme(s)).To(Succeed())
+	return s
+}
+
+var _ = Describe("Build helper functions", func() {
+	DescribeTable("formatLabelParam",
+		func(key, value, expected string) {
+			Expect(formatLabelParam(key, value)).To(Equal(expected))
+		},
+		Entry("basic", "tenant", "acme", "tenant=acme"),
+		Entry("empty value", "tenant", "", "tenant="),
+	)
+
+	DescribeTable("formatFilterParams",
+		func(key, value, expected string) {
+			Expect(formatFilterParams(key, value)).To(Equal(expected))
+		},
+		Entry("basic", "tenant", "acme", `"tenant":="acme"`),
+		Entry("resource_attr prefix", "resource_attr:tenant", "acme", `"resource_attr:tenant":="acme"`),
+	)
+
+	Describe("getLabels", func() {
+		It("includes managed-by label", func() {
+			l := getLabels(nil)
+			Expect(l).To(HaveKeyWithValue(labels.ManagedByLabel, k8s.ManagedByValue))
+		})
+
+		It("merges extra labels", func() {
+			extra := map[string]string{"foo": "bar", "baz": "qux"}
+			l := getLabels(extra)
+			Expect(l).To(HaveKeyWithValue(labels.ManagedByLabel, k8s.ManagedByValue))
+			Expect(l).To(HaveKeyWithValue("foo", "bar"))
+			Expect(l).To(HaveKeyWithValue("baz", "qux"))
+		})
+
+		It("extra labels do not override managed-by", func() {
+			extra := map[string]string{labels.ManagedByLabel: "something-else"}
+			l := getLabels(extra)
+			// maps.Copy overwrites, so this documents current behavior
+			Expect(l).To(HaveKey(labels.ManagedByLabel))
+		})
+	})
+})
+
+var _ = Describe("buildQueryArgs and buildTargetRefs", func() {
+	Describe("buildQueryArgs with nil config", func() {
+		It("returns zero-value queryArgs", func() {
+			a := buildQueryArgs(nil)
+			Expect(a.vlSelectArgs).To(BeEmpty())
+			Expect(a.vlInsertArgs).To(BeEmpty())
+			Expect(a.vmSelectArgs).To(BeEmpty())
+			Expect(a.vmInsertArgs).To(BeEmpty())
+			Expect(a.vtSelectArgs).To(BeEmpty())
+			Expect(a.vtInsertArgs).To(BeEmpty())
+		})
+	})
+
+	Describe("buildQueryArgs with ExtraLabel", func() {
+		It("applies extra_label to vmInsert and vlInsert and vtInsert", func() {
+			cfg := &VMUserConfig{
+				ExtraLabel: &ExtraLabel{Key: "tenant", Value: "acme"},
+			}
+			a := buildQueryArgs(cfg)
+
+			Expect(a.vmInsertArgs).To(HaveLen(1))
+			Expect(a.vmInsertArgs[0].Name).To(Equal("extra_label"))
+			Expect(a.vmInsertArgs[0].Values).To(ConsistOf("tenant=acme"))
+
+			Expect(a.vlInsertArgs).To(HaveLen(1))
+			Expect(a.vlInsertArgs[0].Name).To(Equal("extra_fields"))
+			Expect(a.vlInsertArgs[0].Values).To(ConsistOf("tenant=acme"))
+
+			Expect(a.vtInsertArgs).To(HaveLen(1))
+			Expect(a.vtInsertArgs[0].Name).To(Equal("extra_fields"))
+			Expect(a.vtInsertArgs[0].Values).To(ConsistOf("resource_attr:tenant=acme"))
+
+			// Select args should be unaffected
+			Expect(a.vmSelectArgs).To(BeEmpty())
+			Expect(a.vlSelectArgs).To(BeEmpty())
+			Expect(a.vtSelectArgs).To(BeEmpty())
+		})
+	})
+
+	Describe("buildQueryArgs with ExtraFilters", func() {
+		It("applies extra_filters to select args", func() {
+			cfg := &VMUserConfig{
+				ExtraFilters: map[string]string{"tenant": "acme"},
+			}
+			a := buildQueryArgs(cfg)
+
+			Expect(a.vlSelectArgs).To(HaveLen(1))
+			Expect(a.vlSelectArgs[0].Name).To(Equal("extra_filters"))
+			Expect(a.vlSelectArgs[0].Values).To(ConsistOf(`"tenant":="acme"`))
+
+			Expect(a.vtSelectArgs).To(HaveLen(1))
+			Expect(a.vtSelectArgs[0].Name).To(Equal("extra_filters"))
+			Expect(a.vtSelectArgs[0].Values).To(ConsistOf(`"resource_attr:tenant":="acme"`))
+
+			Expect(a.vmSelectArgs).To(HaveLen(1))
+			Expect(a.vmSelectArgs[0].Name).To(Equal("extra_filters"))
+			Expect(a.vmSelectArgs[0].Values).To(ConsistOf(`{tenant="acme"}`))
+
+			// Insert args should be unaffected
+			Expect(a.vmInsertArgs).To(BeEmpty())
+			Expect(a.vlInsertArgs).To(BeEmpty())
+			Expect(a.vtInsertArgs).To(BeEmpty())
+		})
+	})
+})
+
 var _ = Describe("VMUser Manager - MCS Update Tests", func() {
 	var (
 		ctx        context.Context
@@ -34,18 +153,8 @@ var _ = Describe("VMUser Manager - MCS Update Tests", func() {
 	)
 
 	BeforeEach(func() {
-		// Setup scheme
-		s := scheme.Scheme
-		err := kcmv1beta1.AddToScheme(s)
-		Expect(err).NotTo(HaveOccurred())
-		err = addoncontrollerv1beta1.AddToScheme(s)
-		Expect(err).NotTo(HaveOccurred())
-		err = corev1.AddToScheme(s)
-		Expect(err).NotTo(HaveOccurred())
-
-		// Create fake client with scheme
 		fakeClient = fake.NewClientBuilder().
-			WithScheme(s).
+			WithScheme(newTestScheme()).
 			Build()
 
 		manager = NewManager(fakeClient)
@@ -179,5 +288,260 @@ var _ = Describe("VMUser Manager - MCS Update Tests", func() {
 		Expect(updatedMCS.Spec.ServiceSpec.Services[0].Name).NotTo(Equal(initialMCS.Spec.ServiceSpec.Services[0].Name))
 		Expect(updatedMCS.Spec.ServiceSpec.Services[0].Namespace).NotTo(Equal(initialMCS.Spec.ServiceSpec.Services[0].Namespace))
 		Expect(updatedMCS.Spec.ServiceSpec.Services[0].Template).NotTo(Equal(initialMCS.Spec.ServiceSpec.Services[0].Template))
+	})
+})
+
+var _ = Describe("VMUser Manager - createSecret", func() {
+	var (
+		ctx        context.Context
+		fakeClient client.Client
+		manager    *Manager
+	)
+
+	BeforeEach(func() {
+		fakeClient = fake.NewClientBuilder().
+			WithScheme(newTestScheme()).
+			Build()
+		manager = NewManager(fakeClient)
+		ctx = context.Background()
+	})
+
+	It("creates secrets in both the given namespace and the kof namespace", func() {
+		opts := &CreateOptions{
+			Name:      "my-cluster",
+			Namespace: "test-ns",
+		}
+
+		err := manager.createSecret(ctx, opts)
+		Expect(err).NotTo(HaveOccurred())
+
+		secret := &corev1.Secret{}
+		err = fakeClient.Get(ctx, client.ObjectKey{Name: BuildSecretName(opts.Name), Namespace: opts.Namespace}, secret)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(secret.Data[UsernameKey]).To(Equal([]byte(opts.Name)))
+		Expect(secret.Data[PasswordKey]).NotTo(BeEmpty())
+
+		kofSecret := &corev1.Secret{}
+		err = fakeClient.Get(ctx, client.ObjectKey{Name: BuildSecretName(opts.Name), Namespace: k8s.KofNamespace}, kofSecret)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(kofSecret.Data[PasswordKey]).To(Equal(secret.Data[PasswordKey]))
+	})
+
+	It("preserves the existing password on update", func() {
+		opts := &CreateOptions{
+			Name:      "my-cluster",
+			Namespace: "test-ns",
+		}
+
+		Expect(manager.createSecret(ctx, opts)).To(Succeed())
+
+		secret := &corev1.Secret{}
+		Expect(fakeClient.Get(ctx, client.ObjectKey{Name: BuildSecretName(opts.Name), Namespace: opts.Namespace}, secret)).To(Succeed())
+		originalPassword := string(secret.Data[PasswordKey])
+
+		// Call createSecret again — password must not change
+		Expect(manager.createSecret(ctx, opts)).To(Succeed())
+
+		Expect(fakeClient.Get(ctx, client.ObjectKey{Name: BuildSecretName(opts.Name), Namespace: opts.Namespace}, secret)).To(Succeed())
+		Expect(string(secret.Data[PasswordKey])).To(Equal(originalPassword))
+	})
+
+	It("applies extra labels to the secret", func() {
+		opts := &CreateOptions{
+			Name:        "my-cluster",
+			Namespace:   "test-ns",
+			ExtraLabels: map[string]string{"env": "prod"},
+		}
+
+		Expect(manager.createSecret(ctx, opts)).To(Succeed())
+
+		secret := &corev1.Secret{}
+		Expect(fakeClient.Get(ctx, client.ObjectKey{Name: BuildSecretName(opts.Name), Namespace: opts.Namespace}, secret)).To(Succeed())
+		Expect(secret.Labels).To(HaveKeyWithValue("env", "prod"))
+		Expect(secret.Labels).To(HaveKeyWithValue(labels.ManagedByLabel, k8s.ManagedByValue))
+	})
+
+	It("sets owner reference on the secret when provided", func() {
+		ownerRef := &metav1.OwnerReference{
+			APIVersion: "v1",
+			Kind:       "ConfigMap",
+			Name:       "owner",
+			UID:        "uid-1",
+		}
+		opts := &CreateOptions{
+			Name:           "my-cluster",
+			Namespace:      "test-ns",
+			OwnerReference: ownerRef,
+		}
+
+		Expect(manager.createSecret(ctx, opts)).To(Succeed())
+
+		secret := &corev1.Secret{}
+		Expect(fakeClient.Get(ctx, client.ObjectKey{Name: BuildSecretName(opts.Name), Namespace: opts.Namespace}, secret)).To(Succeed())
+		Expect(secret.OwnerReferences).To(HaveLen(1))
+		Expect(secret.OwnerReferences[0]).To(Equal(*ownerRef))
+	})
+})
+
+var _ = Describe("VMUser Manager - createOrUpdateVMUser", func() {
+	var (
+		ctx        context.Context
+		fakeClient client.Client
+		manager    *Manager
+	)
+
+	BeforeEach(func() {
+		fakeClient = fake.NewClientBuilder().
+			WithScheme(newTestScheme()).
+			Build()
+		manager = NewManager(fakeClient)
+		ctx = context.Background()
+	})
+
+	It("creates a VMUser with correct spec", func() {
+		opts := &CreateOptions{
+			Name:      "my-cluster",
+			Namespace: "test-ns",
+		}
+
+		Expect(manager.createOrUpdateVMUser(ctx, opts)).To(Succeed())
+
+		vmUser := &vmv1beta1.VMUser{}
+		Expect(fakeClient.Get(ctx, client.ObjectKey{Name: BuildVMUserName(opts.Name), Namespace: opts.Namespace}, vmUser)).To(Succeed())
+		Expect(*vmUser.Spec.UserName).To(Equal(opts.Name))
+		Expect(vmUser.Spec.PasswordRef.Key).To(Equal(PasswordKey))
+		Expect(vmUser.Spec.PasswordRef.LocalObjectReference.Name).To(Equal(BuildSecretName(opts.Name)))
+		Expect(vmUser.Spec.TargetRefs).To(HaveLen(8))
+	})
+
+	It("applies extra labels and owner references", func() {
+		ownerRef := &metav1.OwnerReference{APIVersion: "v1", Kind: "ConfigMap", Name: "owner", UID: "uid-2"}
+		opts := &CreateOptions{
+			Name:           "my-cluster",
+			Namespace:      "test-ns",
+			ExtraLabels:    map[string]string{"tier": "regional"},
+			OwnerReference: ownerRef,
+		}
+
+		Expect(manager.createOrUpdateVMUser(ctx, opts)).To(Succeed())
+
+		vmUser := &vmv1beta1.VMUser{}
+		Expect(fakeClient.Get(ctx, client.ObjectKey{Name: BuildVMUserName(opts.Name), Namespace: opts.Namespace}, vmUser)).To(Succeed())
+		Expect(vmUser.Labels).To(HaveKeyWithValue("tier", "regional"))
+		Expect(vmUser.OwnerReferences).To(HaveLen(1))
+		Expect(vmUser.OwnerReferences[0]).To(Equal(*ownerRef))
+	})
+})
+
+var _ = Describe("VMUser Manager - Create", func() {
+	var (
+		ctx        context.Context
+		fakeClient client.Client
+		manager    *Manager
+	)
+
+	BeforeEach(func() {
+		fakeClient = fake.NewClientBuilder().
+			WithScheme(newTestScheme()).
+			Build()
+		manager = NewManager(fakeClient)
+		ctx = context.Background()
+	})
+
+	It("returns an error when name is empty", func() {
+		err := manager.Create(ctx, &CreateOptions{Name: "", Namespace: "test-ns"})
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("name cannot be empty"))
+	})
+
+	It("creates all resources when MCSConfig is set", func() {
+		opts := &CreateOptions{
+			Name:      "my-cluster",
+			Namespace: "test-ns",
+			MCSConfig: &MCSConfig{
+				ClusterSelector: metav1.LabelSelector{
+					MatchLabels: map[string]string{"role": "regional"},
+				},
+			},
+		}
+
+		Expect(manager.Create(ctx, opts)).To(Succeed())
+
+		// Secret exists in both namespaces
+		secret := &corev1.Secret{}
+		Expect(fakeClient.Get(ctx, client.ObjectKey{Name: BuildSecretName(opts.Name), Namespace: opts.Namespace}, secret)).To(Succeed())
+		kofSecret := &corev1.Secret{}
+		Expect(fakeClient.Get(ctx, client.ObjectKey{Name: BuildSecretName(opts.Name), Namespace: k8s.KofNamespace}, kofSecret)).To(Succeed())
+
+		// VMUser exists
+		vmUser := &vmv1beta1.VMUser{}
+		Expect(fakeClient.Get(ctx, client.ObjectKey{Name: BuildVMUserName(opts.Name), Namespace: opts.Namespace}, vmUser)).To(Succeed())
+
+		// MCS exists
+		mcs := &kcmv1beta1.MultiClusterService{}
+		Expect(fakeClient.Get(ctx, client.ObjectKey{Name: BuildMCSName(opts.Name)}, mcs)).To(Succeed())
+	})
+
+	It("does not create MCS when MCSConfig is nil", func() {
+		opts := &CreateOptions{
+			Name:      "my-cluster",
+			Namespace: "test-ns",
+		}
+
+		Expect(manager.Create(ctx, opts)).To(Succeed())
+
+		mcs := &kcmv1beta1.MultiClusterService{}
+		err := fakeClient.Get(ctx, client.ObjectKey{Name: BuildMCSName(opts.Name)}, mcs)
+		Expect(err).To(HaveOccurred())
+	})
+})
+
+var _ = Describe("VMUser Manager - Delete", func() {
+	var (
+		ctx        context.Context
+		fakeClient client.Client
+		manager    *Manager
+	)
+
+	BeforeEach(func() {
+		fakeClient = fake.NewClientBuilder().
+			WithScheme(newTestScheme()).
+			Build()
+		manager = NewManager(fakeClient)
+		ctx = context.Background()
+	})
+
+	It("returns an error when name is empty", func() {
+		err := manager.Delete(ctx, "", "test-ns")
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("name cannot be empty"))
+	})
+
+	It("succeeds even when resources do not exist (already deleted)", func() {
+		Expect(manager.Delete(ctx, "non-existent", "test-ns")).To(Succeed())
+	})
+
+	It("deletes all created resources", func() {
+		opts := &CreateOptions{
+			Name:      "my-cluster",
+			Namespace: "test-ns",
+			MCSConfig: &MCSConfig{
+				ClusterSelector: metav1.LabelSelector{
+					MatchLabels: map[string]string{"role": "regional"},
+				},
+			},
+		}
+		Expect(manager.Create(ctx, opts)).To(Succeed())
+
+		Expect(manager.Delete(ctx, opts.Name, opts.Namespace)).To(Succeed())
+
+		vmUser := &vmv1beta1.VMUser{}
+		Expect(fakeClient.Get(ctx, client.ObjectKey{Name: BuildVMUserName(opts.Name), Namespace: opts.Namespace}, vmUser)).To(HaveOccurred())
+
+		secret := &corev1.Secret{}
+		Expect(fakeClient.Get(ctx, client.ObjectKey{Name: BuildSecretName(opts.Name), Namespace: opts.Namespace}, secret)).To(HaveOccurred())
+
+		kofSecret := &corev1.Secret{}
+		Expect(fakeClient.Get(ctx, client.ObjectKey{Name: BuildSecretName(opts.Name), Namespace: k8s.KofNamespace}, kofSecret)).To(HaveOccurred())
 	})
 })

--- a/kof-operator/internal/models/labels/labels.go
+++ b/kof-operator/internal/models/labels/labels.go
@@ -26,6 +26,9 @@ const (
 	// KofKcmRegionLabel marks a cluster deployment as belonging to a KCM region.
 	KofKcmRegionLabel = "k0rdent.mirantis.com/kcm-region-cluster"
 
+	// KofTenantLabel is used to associate cluster deployments with a specific tenant in multi-tenant environments.
+	KofTenantLabel = "k0rdent.mirantis.com/kof-tenant-id"
+
 	// ClusterNameLabelKey is applied to VMStorageConnection resources to indicate which
 	// cluster resource they reference. This allows the VMStorageConnection controller to
 	// efficiently list all connections associated with a given cluster.


### PR DESCRIPTION
* Fixed bug where tenants could access metrics from other tenants due to incorrect TargetPathSuffix validation
* Refactored VMUser package to improve readability