### PR TITLE
fix: audit logs exporter build

### DIFF
--- a/.github/workflows/build_images.yml
+++ b/.github/workflows/build_images.yml
@@ -63,6 +63,7 @@ jobs:
           IMAGE_OPERATOR_REPO: ghcr.io/${{ github.repository }}/kof-operator-controller
           IMAGE_OTEL_COLLECTOR_REPO: ghcr.io/${{ github.repository }}/kof-opentelemetry-collector-contrib
           IMAGE_ACL_SERVER_REPO: ghcr.io/${{ github.repository }}/kof-acl-server
+          IMAGE_AUDIT_LOGS_EXPORTER_REPO: ghcr.io/${{ github.repository }}/kof-audit-logs-exporter
           GITHUB_OWNER: ${{ github.repository_owner }}
           GITHUB_REPO_NAME: ${{ github.event.repository.name }}
           VERSION: ${{ steps.vars.outputs.version }}

--- a/.github/workflows/release_images.yml
+++ b/.github/workflows/release_images.yml
@@ -64,6 +64,7 @@ jobs:
           IMAGE_OPERATOR_REPO: ghcr.io/${{ github.repository }}/kof-operator-controller
           IMAGE_OTEL_COLLECTOR_REPO: ghcr.io/${{ github.repository }}/kof-opentelemetry-collector-contrib
           IMAGE_ACL_SERVER_REPO: ghcr.io/${{ github.repository }}/kof-acl-server
+          IMAGE_AUDIT_LOGS_EXPORTER_REPO: ghcr.io/${{ github.repository }}/kof-audit-logs-exporter
           GITHUB_OWNER: ${{ github.repository_owner }}
           GITHUB_REPO_NAME: ${{ github.event.repository.name }}
           VERSION: ${{ steps.vars.outputs.version }}

--- a/Makefile
+++ b/Makefile
@@ -214,6 +214,8 @@ kof-operator-docker-build: ## Build kof-operator controller docker image
 	$(KIND) load docker-image ghcr.io/k0rdent/kof/kof-opentelemetry-collector-contrib:v$(KOF_VERSION) --name $(KIND_CLUSTER_NAME); \
 	$(CONTAINER_TOOL) tag kof-acl-server kof-acl-server:v$(KOF_VERSION); \
 	$(KIND) load docker-image kof-acl-server:v$(KOF_VERSION) --name $(KIND_CLUSTER_NAME)
+	$(CONTAINER_TOOL) tag audit-logs-exporter audit-logs-exporter:v$(KOF_VERSION); \
+	$(KIND) load docker-image audit-logs-exporter:v$(KOF_VERSION) --name $(KIND_CLUSTER_NAME)
 
 .PHONY: dev-adopted-rm
 dev-adopted-rm: dev kind envsubst ## Create adopted cluster deployment


### PR DESCRIPTION
Fixing build error
```
docker build failed: failed to execute image template '{{ .Env.IMAGE_AUDIT_LOGS_EXPORTER_REPO }}:{{ .Env.VERSION }}-arm64': template: failed to apply "{{ .Env.IMAGE_AUDIT_LOGS_EXPORTER_REPO }}:{{ .Env.VERSION }}-arm64": map has no entry for key "IMAGE_AUDIT_LOGS_EXPORTER_REPO"
```