### PR TITLE
fix: Unusual cloud providers should not block DiscoverRegionalCluster, especially in Regionless case

### DIFF
--- a/kof-operator/internal/controller/clusterdeployment_controller_test.go
+++ b/kof-operator/internal/controller/clusterdeployment_controller_test.go
@@ -595,7 +595,7 @@ var _ = Describe("ClusterDeployment Controller", func() {
 			Expect(configMap.Data[RegionalClusterNamespaceKey]).To(Equal(k8s.DefaultSystemNamespace))
 		})
 
-		It("should not fail cloud detection for an unknown infrastructure provider", func() {
+		It("should report unknown infrastructure providers from cloud detection", func() {
 			const unusualClusterTemplateName = "unusual-cluster-template"
 			const unusualClusterDeploymentName = "test-child-unusual"
 
@@ -665,8 +665,40 @@ var _ = Describe("ClusterDeployment Controller", func() {
 			Expect(k8sClient.Create(ctx, clusterDeployment)).To(Succeed())
 
 			cloudName, err := getCloud(ctx, k8sClient, clusterDeployment)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(BeAssignableToTypeOf(&UnknownCloudProviderError{}))
+			Expect(err.Error()).To(ContainSubstring("unknown infrastructure provider"))
 			Expect(cloudName).To(BeEmpty())
+
+			By("checking child location discovery reports that explicit regional label is required")
+			childClusterRole, err := NewChildClusterRole(ctx, clusterDeployment, k8sClient)
+			Expect(err).NotTo(HaveOccurred())
+			_, err = childClusterRole.DiscoverRegionalClusterConfigMapByLocation()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("unknown infrastructure provider"))
+			Expect(err.Error()).To(ContainSubstring(KofRegionalClusterNameLabel))
+
+			By("checking regional child selection with unknown cloud does not fail")
+			regionalConfigMap := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      GetRegionalClusterConfigMapName("test-regional-unusual"),
+					Namespace: k8s.DefaultSystemNamespace,
+				},
+			}
+			regionalClusterConfigMap := &RegionalClusterConfigMap{
+				clusterName:      "test-regional-unusual",
+				clusterNamespace: k8s.DefaultSystemNamespace,
+				ctx:              ctx,
+				client:           k8sClient,
+				configMap:        regionalConfigMap,
+				configData: &ConfigData{
+					RegionalClusterName:      "test-regional-unusual",
+					RegionalClusterNamespace: k8s.DefaultSystemNamespace,
+				},
+			}
+			childClusters, err := regionalClusterConfigMap.GetChildClusters()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(childClusters).To(BeEmpty())
 		})
 
 		It("should update the ConfigMap when regional cluster annotation changes", func() {

--- a/kof-operator/internal/controller/clusterdeployment_controller_test.go
+++ b/kof-operator/internal/controller/clusterdeployment_controller_test.go
@@ -35,6 +35,7 @@ import (
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
@@ -471,6 +472,201 @@ var _ = Describe("ClusterDeployment Controller", func() {
 			Expect(configMap.Data[WriteTracesKey]).To(Equal(
 				"https://vmauth.test-aws-ue2.kof.example.com/vti/insert/opentelemetry/v1/traces",
 			))
+		})
+
+		It("should use the regionless ConfigMap without matching child cluster cloud", func() {
+			const managementClusterName = "mothership"
+			const unusualClusterTemplateName = "unusual-standalone-cp-0-1-2"
+			const regionlessChildClusterDeploymentName = "test-child-regionless"
+
+			Expect(os.Setenv("KOF_REGIONLESS_ENABLED", "true")).To(Succeed())
+			DeferCleanup(func() {
+				Expect(os.Unsetenv("KOF_REGIONLESS_ENABLED")).To(Succeed())
+			})
+			DeferCleanup(func() {
+				for _, object := range []client.Object{
+					&corev1.ConfigMap{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      GetConfigMapName(regionlessChildClusterDeploymentName),
+							Namespace: k8s.DefaultSystemNamespace,
+						},
+					},
+					&corev1.ConfigMap{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      GetRegionalClusterConfigMapName(managementClusterName),
+							Namespace: k8s.DefaultSystemNamespace,
+						},
+					},
+					&kcmv1beta1.ClusterDeployment{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      regionlessChildClusterDeploymentName,
+							Namespace: k8s.DefaultSystemNamespace,
+						},
+					},
+					&kcmv1beta1.ClusterTemplate{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      unusualClusterTemplateName,
+							Namespace: k8s.DefaultSystemNamespace,
+						},
+					},
+				} {
+					if err := k8sClient.Get(ctx, types.NamespacedName{
+						Name:      object.GetName(),
+						Namespace: object.GetNamespace(),
+					}, object); err == nil {
+						Expect(k8sClient.Delete(ctx, object)).To(Succeed())
+					}
+				}
+			})
+
+			By("creating the regionless management cluster ConfigMap")
+			Expect(CreateOrUpdateRegionlessConfigMap(ctx, k8sClient, managementClusterName)).To(Succeed())
+
+			By("creating an unusual ClusterTemplate with no cloud provider known to KOF")
+			clusterTemplate := &kcmv1beta1.ClusterTemplate{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      unusualClusterTemplateName,
+					Namespace: k8s.DefaultSystemNamespace,
+				},
+				Spec: kcmv1beta1.ClusterTemplateSpec{
+					Helm: kcmv1beta1.HelmSpec{
+						ChartSpec: &sourcev1.HelmChartSpec{
+							Chart: "unusual-standalone-cp",
+							SourceRef: sourcev1.LocalHelmChartSourceReference{
+								Name: "kcm-templates",
+								Kind: "HelmRepository",
+							},
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, clusterTemplate)).To(Succeed())
+			clusterTemplate.Status = kcmv1beta1.ClusterTemplateStatus{
+				Providers: []string{"infrastructure-unusual"},
+			}
+			Expect(k8sClient.Status().Update(ctx, clusterTemplate)).To(Succeed())
+
+			By("creating a child ClusterDeployment that uses the unusual ClusterTemplate")
+			childClusterDeployment := &kcmv1beta1.ClusterDeployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      regionlessChildClusterDeploymentName,
+					Namespace: k8s.DefaultSystemNamespace,
+					Labels: map[string]string{
+						KofClusterRoleLabel:     "child",
+						labels.ClusterNameLabel: regionlessChildClusterDeploymentName,
+					},
+				},
+				Spec: kcmv1beta1.ClusterDeploymentSpec{
+					Template: unusualClusterTemplateName,
+					Config:   &apiextensionsv1.JSON{Raw: []byte(`{}`)},
+				},
+			}
+			Expect(k8sClient.Create(ctx, childClusterDeployment)).To(Succeed())
+			childClusterDeployment.Status = kcmv1beta1.ClusterDeploymentStatus{
+				Conditions: []metav1.Condition{
+					{
+						Type:               kcmv1beta1.ReadyCondition,
+						Status:             metav1.ConditionTrue,
+						LastTransitionTime: metav1.Time{Time: time.Now()},
+						Reason:             "ClusterReady",
+						Message:            "Cluster is ready",
+					},
+				},
+			}
+			Expect(k8sClient.Status().Update(ctx, childClusterDeployment)).To(Succeed())
+
+			By("reconciling the child ClusterDeployment")
+			_, err := clusterDeploymentReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      regionlessChildClusterDeploymentName,
+					Namespace: k8s.DefaultSystemNamespace,
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("reading the child ConfigMap")
+			configMap := &corev1.ConfigMap{}
+			err = k8sClient.Get(ctx, types.NamespacedName{
+				Name:      GetConfigMapName(regionlessChildClusterDeploymentName),
+				Namespace: k8s.DefaultSystemNamespace,
+			}, configMap)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(configMap.Data[RegionalClusterNameKey]).To(Equal(managementClusterName))
+			Expect(configMap.Data[RegionalClusterNamespaceKey]).To(Equal(k8s.DefaultSystemNamespace))
+		})
+
+		It("should not fail cloud detection for an unknown infrastructure provider", func() {
+			const unusualClusterTemplateName = "unusual-cluster-template"
+			const unusualClusterDeploymentName = "test-child-unusual"
+
+			DeferCleanup(func() {
+				for _, object := range []client.Object{
+					&kcmv1beta1.ClusterDeployment{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      unusualClusterDeploymentName,
+							Namespace: k8s.DefaultSystemNamespace,
+						},
+					},
+					&kcmv1beta1.ClusterTemplate{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      unusualClusterTemplateName,
+							Namespace: k8s.DefaultSystemNamespace,
+						},
+					},
+				} {
+					if err := k8sClient.Get(ctx, types.NamespacedName{
+						Name:      object.GetName(),
+						Namespace: object.GetNamespace(),
+					}, object); err == nil {
+						Expect(k8sClient.Delete(ctx, object)).To(Succeed())
+					}
+				}
+			})
+
+			By("creating an unusual ClusterTemplate")
+			clusterTemplate := &kcmv1beta1.ClusterTemplate{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      unusualClusterTemplateName,
+					Namespace: k8s.DefaultSystemNamespace,
+				},
+				Spec: kcmv1beta1.ClusterTemplateSpec{
+					Helm: kcmv1beta1.HelmSpec{
+						ChartSpec: &sourcev1.HelmChartSpec{
+							Chart: "unusual-standalone-cp",
+							SourceRef: sourcev1.LocalHelmChartSourceReference{
+								Name: "kcm-templates",
+								Kind: "HelmRepository",
+							},
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, clusterTemplate)).To(Succeed())
+			clusterTemplate.Status = kcmv1beta1.ClusterTemplateStatus{
+				Providers: []string{"infrastructure-unusual"},
+			}
+			Expect(k8sClient.Status().Update(ctx, clusterTemplate)).To(Succeed())
+
+			By("creating a child ClusterDeployment that uses the unusual ClusterTemplate")
+			clusterDeployment := &kcmv1beta1.ClusterDeployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      unusualClusterDeploymentName,
+					Namespace: k8s.DefaultSystemNamespace,
+					Labels: map[string]string{
+						KofClusterRoleLabel:     "child",
+						labels.ClusterNameLabel: unusualClusterDeploymentName,
+					},
+				},
+				Spec: kcmv1beta1.ClusterDeploymentSpec{
+					Template: unusualClusterTemplateName,
+					Config:   &apiextensionsv1.JSON{Raw: []byte(`{}`)},
+				},
+			}
+			Expect(k8sClient.Create(ctx, clusterDeployment)).To(Succeed())
+
+			cloudName, err := getCloud(ctx, k8sClient, clusterDeployment)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(cloudName).To(BeEmpty())
 		})
 
 		It("should update the ConfigMap when regional cluster annotation changes", func() {

--- a/kof-operator/internal/controller/clusterdeployment_kof_cluster_child_role.go
+++ b/kof-operator/internal/controller/clusterdeployment_kof_cluster_child_role.go
@@ -249,6 +249,14 @@ func (c *ChildClusterRole) DiscoverRegionalClusterConfigMapByLocation() (*corev1
 	childCloud, err := getCloud(c.ctx, c.client, c.clusterDeployment)
 	if err != nil {
 		if _, ok := err.(*UnknownCloudProviderError); ok {
+			if crossNamespace {
+				return nil, fmt.Errorf(
+					"cannot discover regional cluster by location: %v; please set .metadata.labels[%q] and .metadata.labels[%q] explicitly",
+					err,
+					KofRegionalClusterNameLabel,
+					KofRegionalClusterNamespaceLabel,
+				)
+			}
 			return nil, fmt.Errorf(
 				"cannot discover regional cluster by location: %v; please set .metadata.labels[%q] explicitly",
 				err,

--- a/kof-operator/internal/controller/clusterdeployment_kof_cluster_child_role.go
+++ b/kof-operator/internal/controller/clusterdeployment_kof_cluster_child_role.go
@@ -248,6 +248,13 @@ func (c *ChildClusterRole) DiscoverRegionalClusterConfigMapByLocation() (*corev1
 
 	childCloud, err := getCloud(c.ctx, c.client, c.clusterDeployment)
 	if err != nil {
+		if _, ok := err.(*UnknownCloudProviderError); ok {
+			return nil, fmt.Errorf(
+				"cannot discover regional cluster by location: %v; please set .metadata.labels[%q] explicitly",
+				err,
+				KofRegionalClusterNameLabel,
+			)
+		}
 		return nil, fmt.Errorf("failed to get child cluster cloud: %v", err)
 	}
 

--- a/kof-operator/internal/controller/clusterdeployment_kof_cluster_child_role.go
+++ b/kof-operator/internal/controller/clusterdeployment_kof_cluster_child_role.go
@@ -224,16 +224,6 @@ func (c *ChildClusterRole) DiscoverRegionalClusterConfigMapByLocation() (*corev1
 	log := log.FromContext(c.ctx)
 	crossNamespace := env.CrossNamespaceEnabled()
 
-	childCloud, err := getCloud(c.ctx, c.client, c.clusterDeployment)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get child cluster cloud: %v", err)
-	}
-
-	configMap, err := c.GetConfigMap()
-	if err != nil {
-		return nil, fmt.Errorf("failed to get ConfigMap: %v", err)
-	}
-
 	regionalClusterConfigMapList := &corev1.ConfigMapList{}
 
 	selector := k8slabels.Set{labels.KofClusterRoleLabel: KofRoleRegional}.AsSelector()
@@ -254,6 +244,16 @@ func (c *ChildClusterRole) DiscoverRegionalClusterConfigMapByLocation() (*corev1
 			}
 		}
 		return nil, fmt.Errorf("regionless is enabled but no regionless ConfigMap was found")
+	}
+
+	childCloud, err := getCloud(c.ctx, c.client, c.clusterDeployment)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get child cluster cloud: %v", err)
+	}
+
+	configMap, err := c.GetConfigMap()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get ConfigMap: %v", err)
 	}
 
 	candidates := make([]*corev1.ConfigMap, 0)

--- a/kof-operator/internal/controller/clusterdeployment_kof_cluster_role.go
+++ b/kof-operator/internal/controller/clusterdeployment_kof_cluster_role.go
@@ -77,6 +77,14 @@ const KofRoleRegional = "regional"
 
 var defaultDialTimeout = metav1.Duration{Duration: time.Second * 5}
 
+type UnknownCloudProviderError struct {
+	ClusterTemplate string
+}
+
+func (e *UnknownCloudProviderError) Error() string {
+	return fmt.Sprintf("unknown infrastructure provider in ClusterTemplate %q", e.ClusterTemplate)
+}
+
 func (r *ClusterDeploymentReconciler) ReconcileKofClusterRole(
 	ctx context.Context,
 	clusterDeployment *kcmv1beta1.ClusterDeployment,
@@ -120,7 +128,7 @@ func getCloud(ctx context.Context, client client.Client, cd *kcmv1beta1.ClusterD
 		}
 	}
 
-	return "", nil
+	return "", &UnknownCloudProviderError{ClusterTemplate: cd.Spec.Template}
 }
 
 func locationIsTheSame(cloudName string, c1, c2 *ClusterDeploymentConfig) bool {

--- a/kof-operator/internal/controller/clusterdeployment_kof_cluster_role.go
+++ b/kof-operator/internal/controller/clusterdeployment_kof_cluster_role.go
@@ -120,7 +120,7 @@ func getCloud(ctx context.Context, client client.Client, cd *kcmv1beta1.ClusterD
 		}
 	}
 
-	return "", fmt.Errorf("no valid cloud provider found in ClusterTemplate %s", cd.Spec.Template)
+	return "", nil
 }
 
 func locationIsTheSame(cloudName string, c1, c2 *ClusterDeploymentConfig) bool {

--- a/kof-operator/internal/controller/configmap_cluster_regional.go
+++ b/kof-operator/internal/controller/configmap_cluster_regional.go
@@ -278,7 +278,24 @@ func (c *RegionalClusterConfigMap) GetChildClusters() ([]*ChildClusterRole, erro
 	}
 
 	if regionalCloud == "" {
-		return nil, fmt.Errorf("failed to get regional cloud from config map '%s'", c.configMap.Name)
+		for _, childClusterDeployment := range childClusterDeploymentsList.Items {
+			if childClusterDeployment.Labels[KofRegionalClusterNameLabel] != c.clusterName {
+				continue
+			}
+
+			regionalClusterNamespace := childClusterDeployment.Labels[KofRegionalClusterNamespaceLabel]
+			if regionalClusterNamespace != "" && regionalClusterNamespace != c.clusterNamespace {
+				continue
+			}
+
+			childClusterRole, err := NewChildClusterRole(c.ctx, &childClusterDeployment, c.client)
+			if err != nil {
+				return nil, fmt.Errorf("failed to create child cluster: %v", err)
+			}
+
+			childClusterRoleList = append(childClusterRoleList, childClusterRole)
+		}
+		return childClusterRoleList, nil
 	}
 
 	regionalClusterDeploymentConfig := c.configData.ToClusterDeploymentConfig()

--- a/kof-operator/internal/controller/configmap_cluster_regional.go
+++ b/kof-operator/internal/controller/configmap_cluster_regional.go
@@ -277,14 +277,14 @@ func (c *RegionalClusterConfigMap) GetChildClusters() ([]*ChildClusterRole, erro
 		return childClusterRoleList, nil
 	}
 
+	// Clusters in unknown clouds cannot be matched by location,
+	// so only explicitly labeled child clusters
+	// can be associated with the regional cluster.
 	if regionalCloud == "" {
 		for _, childClusterDeployment := range childClusterDeploymentsList.Items {
-			if childClusterDeployment.Labels[KofRegionalClusterNameLabel] != c.clusterName {
-				continue
-			}
-
+			regionalClusterName := childClusterDeployment.Labels[KofRegionalClusterNameLabel]
 			regionalClusterNamespace := childClusterDeployment.Labels[KofRegionalClusterNamespaceLabel]
-			if regionalClusterNamespace != "" && regionalClusterNamespace != c.clusterNamespace {
+			if regionalClusterName != c.clusterName || regionalClusterNamespace != c.clusterNamespace {
 				continue
 			}
 


### PR DESCRIPTION
* Part of https://github.com/k0rdent/kof/issues/542
* Follow-up for https://github.com/k0rdent/kof/pull/1055
* Error we fix here:

```
ERROR    regional cluster ConfigMap not found by location
{"controller": "clusterdeployment", "controllerGroup": "k0rdent.mirantis.com",
"controllerKind": "ClusterDeployment", "ClusterDeployment":
{"name":"CHILD-cluster","namespace":"kcm-system"},...
error": "failed to get child cluster cloud:
no valid cloud provider found in ClusterTemplate UNUSUAL-standalone-cp-0-1-2"}

github.com/k0rdent/kof/kof-operator/internal/controller.(*ChildClusterRole).GetRegionalConfigMap
    github.com/k0rdent/kof/kof-operator/internal/controller/clusterdeployment_kof_cluster_child_role.go:145
...
```
