### PR TITLE
fix: Added PKI_PATH for k0s to kof-child

### DIFF
--- a/charts/kof-child/values.yaml
+++ b/charts/kof-child/values.yaml
@@ -11,6 +11,15 @@ collectors:
       cpu: 500m
       memory: 512Mi
 
+  # While this duplicates default `env` value from `kof-collectors/values.yaml`,
+  # the kof-child MCS concatenates this `collectors...env` (or its override)
+  # with KOF_VM_USER/KOF_VM_PASSWORD env vars, as Helm does not merge lists.
+  opentelemetry-kube-stack:
+    defaultCRConfig:
+      env:
+        - name: PKI_PATH
+          value: var/lib/k0s
+
 fromManagement:
   cluster:
     name: mothership


### PR DESCRIPTION
* Found while testing https://github.com/k0rdent/kof/issues/542
  on `k0s`-based environment.
* This was not reproduced on `kind`-based local tests and CI.
* Workaround for `kof-values.yaml`:

```yaml
kof-child:
  values:
    collectors:
      opentelemetry-kube-stack:
        defaultCRConfig:
          env:
            - name: PKI_PATH
              value: var/lib/k0s
```

* While this duplicates default `env` value from `kof-collectors/values.yaml`,
  the kof-child MCS concatenates this `collectors...env` (or its override)
  with `KOF_VM_USER`/`KOF_VM_PASSWORD` env vars, as Helm does not merge lists.
* This PR makes the workaround above not needed for k0s-based envs.
