### PR TITLE
fix: Warkaround for selfManagement without clusterSelector applied to all clusters

### DIFF
--- a/charts/kof-child/templates/child-multi-cluster-service.yaml
+++ b/charts/kof-child/templates/child-multi-cluster-service.yaml
@@ -25,18 +25,21 @@ kind: MultiClusterService
 metadata:
   name: kof-{{ if $istio }}istio-{{ end }}{{ if $mgmt }}mgmt{{ else }}child{{ end }}-cluster
 spec:
-  {{- if not $mgmt }}
   clusterSelector:
     matchLabels:
-      k0rdent.mirantis.com/kof-cluster-role: child
-    {{- if $istio }}
-      k0rdent.mirantis.com/istio-role: member
+    {{- if $mgmt }}
+      k0rdent.mirantis.com/management-cluster: "true"
+      # Workaround for https://github.com/k0rdent/kcm/issues/2610
     {{- else }}
+      k0rdent.mirantis.com/kof-cluster-role: child
+      {{- if $istio }}
+      k0rdent.mirantis.com/istio-role: member
+      {{- else }}
     matchExpressions:
       - key: "k0rdent.mirantis.com/istio-role"
         operator: DoesNotExist
+      {{- end }}
     {{- end }}
-  {{- end }}
 
   {{- if $istio }}
    {{- if $.Values.istio.dependsOn }}

--- a/charts/kof-regional/templates/regional-multi-cluster-service.yaml
+++ b/charts/kof-regional/templates/regional-multi-cluster-service.yaml
@@ -27,18 +27,21 @@ metadata:
   name: kof-regional-cluster
 {{- end }}
 spec:
-  {{- if not $regionless }}
   clusterSelector:
     matchLabels:
-      k0rdent.mirantis.com/kof-cluster-role: regional
-    {{- if $istio }}
-      k0rdent.mirantis.com/istio-role: member
+    {{- if $regionless }}
+      k0rdent.mirantis.com/management-cluster: "true"
+      # Workaround for https://github.com/k0rdent/kcm/issues/2610
     {{- else }}
+      k0rdent.mirantis.com/kof-cluster-role: regional
+      {{- if $istio }}
+      k0rdent.mirantis.com/istio-role: member
+      {{- else }}
     matchExpressions:
       - key: "k0rdent.mirantis.com/istio-role"
         operator: DoesNotExist
+      {{- end }}
     {{- end }}
-  {{- end }}
 
   {{- if $istio }}
   {{- if $.Values.istio.dependsOn }}


### PR DESCRIPTION
* The old bug https://github.com/k0rdent/kcm/issues/2610
  was found while testing new https://github.com/k0rdent/kof/issues/542
  on an existing KCM env that cannot be upgraded yet.
* A workaround was:
  * Edit MCS manually like in this PR.
  * Add `suspend: true` to related `HelmRelease` to stop Flux from overwriting MCS.
  * Keep editing MCS manually adding any new values as it cannot be configured normally via helm values any more.
* This PR makes this complicated workaround not needed.
