### PR TITLE
feat: TLS auto-configuration propagated to component chart values

### DIFF
--- a/charts/kof/README.md
+++ b/charts/kof/README.md
@@ -63,6 +63,9 @@ KOF umbrella Helm chart that uses FluxCD to manage sequential installation of KO
 | regionless<br>.clusterName | string | `"mothership"` | Management cluster name. |
 | regionless<br>.domain | string | `"mothership.example.com"` | Child clusters send KOF data to `https://vmauth.{domain}` when istio is not used. |
 | regionless<br>.enabled | bool | `false` | Enables the regionless setup: there are no regional clusters, metrics/logs/traces from child clusters are sent to the management cluster for storage. |
+| tls | object | `{"insecureSkipVerify":false,`<br>`"selfSigned":false}` | TLS auto-configuration propagated to component chart values. |
+| tls<br>.insecureSkipVerify | bool | `false` | Skip verification of TLS certificates when collectors connect to KOF endpoints. |
+| tls<br>.selfSigned | bool | `false` | Use self-signed TLS certificates for KOF gateways. |
 | victoria-metrics-operator | object | `{"dependsOn":["kof-operators"],`<br>`"enabled":true,`<br>`"notes":"VM CRDs and operator",`<br>`"repo":{"type":"default",`<br>`"url":"https://victoriametrics.github.io/helm-charts/"},`<br>`"values":{"crds":{"cleanup":{"enabled":false},`<br>`"plain":true},`<br>`"global":{"cluster":{"dnsDomain":"cluster.local"}},`<br>`"operator":{"disable_prometheus_converter":true},`<br>`"serviceMonitor":{"enabled":true,`<br>`"vm":false}},`<br>`"version":"0.58.1"}` | Victoria Metrics Operator configuration |
 | victoria-metrics-operator<br>.values | object | `{"crds":{"cleanup":{"enabled":false},`<br>`"plain":true},`<br>`"global":{"cluster":{"dnsDomain":"cluster.local"}},`<br>`"operator":{"disable_prometheus_converter":true},`<br>`"serviceMonitor":{"enabled":true,`<br>`"vm":false}}` | [Docs](https://github.com/VictoriaMetrics/helm-charts/tree/master/charts/victoria-metrics-operator#parameters) |
 | victoria-metrics-operator<br>.version | string | `"0.58.1"` | Victoria Metrics Operator chart version |

--- a/charts/kof/templates/helmreleases.yaml
+++ b/charts/kof/templates/helmreleases.yaml
@@ -135,6 +135,15 @@ spec:
             annotations:
               cert-manager.io/cluster-issuer: selfsigned
         ` | fromYaml) }}
+
+        {{- if and $.Values.regionless.enabled ($.Values | merge | dig "kof-mothership" "values" "cert-manager" "cluster-issuer" "create" false) }}
+          {{- $values = mergeOverwrite $values (`
+          storage:
+            cert-manager:
+              cluster-issuer:
+                create: false
+          ` | fromYaml) }}
+        {{- end }}
       {{- end }}
     {{- end }}
 

--- a/charts/kof/templates/helmreleases.yaml
+++ b/charts/kof/templates/helmreleases.yaml
@@ -74,36 +74,96 @@ spec:
             enabled: false
         ` | fromYaml) }}
       {{- end }}
+
+      {{- if $.Values.tls.selfSigned }}
+        {{- $values = mergeOverwrite $values (`
+        cert-manager:
+          cluster-issuer:
+            provider: self-signed
+            name: selfsigned
+        gateway:
+          annotations:
+            cert-manager.io/cluster-issuer: selfsigned
+        ` | fromYaml) }}
+      {{- end }}
     {{- end }}
 
-    {{- if and (eq $component "victoria-metrics-operator") $.Values.regionless.enabled }}
-      {{- $values = mergeOverwrite $values (`
-      # Using VM-operator from kof umbrella as required for kof-mothership,
-      # just enabling Gateway API for regionless.
-      env:
-        - name: VM_GATEWAY_API_ENABLED
-          value: "true"
-      ` | fromYaml) }}
+    {{- if eq $component "victoria-metrics-operator" }}
+      {{- if $.Values.regionless.enabled }}
+        {{- $values = mergeOverwrite $values (`
+        # Using VM-operator from kof umbrella as required for kof-mothership,
+        # just enabling Gateway API for regionless.
+        env:
+          - name: VM_GATEWAY_API_ENABLED
+            value: "true"
+        ` | fromYaml) }}
+      {{- end }}
     {{- end }}
 
-    {{- if and (eq $component "kof-regional") $.Values.regionless.enabled }}
-      {{- $values = mergeOverwrite $values (print `
-      # Using VM-operator and kof-operators from kof umbrella, not from kof-regional MCS.
-      victoria-metrics-operator:
-        enabled: false
-      kof-operators:
-        enabled: false
+    {{- if eq $component "kof-regional" }}
+      {{- if $.Values.regionless.enabled }}
+        {{- $values = mergeOverwrite $values (print `
+        # Using VM-operator and kof-operators from kof umbrella, not from kof-regional MCS.
+        victoria-metrics-operator:
+          enabled: false
+        kof-operators:
+          enabled: false
 
-      # Using cert-manager installed to mgmt cluster by KCM, it has enableGatewayAPI.
-      cert-manager:
-        enabled: false
+        # Using cert-manager installed to mgmt cluster by KCM, it has enableGatewayAPI.
+        cert-manager:
+          enabled: false
 
-      # Switch MCS to the regionless setup.
-      regionless:
-        enabled: true
-        clusterName: ` (quote $.Values.regionless.clusterName) `
-        domain: ` (quote $.Values.regionless.domain) `
-      ` | fromYaml) }}
+        # Switch MCS to the regionless setup.
+        regionless:
+          enabled: true
+          clusterName: ` (quote $.Values.regionless.clusterName) `
+          domain: ` (quote $.Values.regionless.domain) `
+        ` | fromYaml) }}
+      {{- end }}
+
+      {{- if $.Values.tls.selfSigned }}
+        {{- $values = mergeOverwrite $values (`
+        cert-manager:
+          cluster-issuer:
+            provider: self-signed
+        storage:
+          cert-manager:
+            cluster-issuer:
+              provider: self-signed
+              name: selfsigned
+          gateway:
+            annotations:
+              cert-manager.io/cluster-issuer: selfsigned
+        ` | fromYaml) }}
+      {{- end }}
+    {{- end }}
+
+    {{- if eq $component "kof-child" }}
+      {{- if $.Values.tls.insecureSkipVerify }}
+        {{- $values = mergeOverwrite $values (`
+        collectors:
+          opentelemetry-kube-stack:
+            defaultCRConfig:
+              config:
+                exporters:
+                  otlphttp/logs:
+                    tls:
+                      insecure_skip_verify: true
+                  otlphttp/logs-audit:
+                    tls:
+                      insecure_skip_verify: true
+                  prometheusremotewrite:
+                    tls:
+                      insecure_skip_verify: true
+                  otlphttp/traces:
+                    tls:
+                      insecure_skip_verify: true
+          opencost:
+            opencost:
+              prometheus:
+                insecureSkipVerify: true
+        ` | fromYaml) }}
+      {{- end }}
     {{- end }}
 
     {{- $values | toYaml | nindent 4 }}

--- a/charts/kof/values-local-cloud.yaml
+++ b/charts/kof/values-local-cloud.yaml
@@ -7,6 +7,7 @@ global:
     kofManaged:
       enabled: false
   storageClass: ""
+
 kof-operators:
   values:
     grafana-operator:

--- a/charts/kof/values-local.yaml
+++ b/charts/kof/values-local.yaml
@@ -11,6 +11,10 @@ global:
       type: oci
       insecure: false
 
+tls:
+  selfSigned: true
+  insecureSkipVerify: true
+
 kof-operators:
   values:
     grafana-operator:
@@ -131,7 +135,6 @@ kof-mothership:
     cert-manager:
       cluster-issuer:
         create: true
-        provider: self-signed
 
     gateway:
       enabled: true
@@ -172,9 +175,6 @@ kof-mothership:
 # KOF Regional - MultiClusterService template for regional clusters
 kof-regional:
   values:
-    cert-manager:
-      cluster-issuer:
-        provider: self-signed
     collectors:
       opentelemetry-kube-stack:
         defaultCRConfig:
@@ -182,13 +182,6 @@ kof-regional:
             - name: PKI_PATH
               value: etc/kubernetes
     storage:
-      cert-manager:
-        cluster-issuer:
-          provider: self-signed
-          name: selfsigned
-      gateway:
-        annotations:
-          cert-manager.io/cluster-issuer: selfsigned
       victoriametrics:
         vmcluster:
           spec:
@@ -228,24 +221,6 @@ kof-child:
             env:
               - name: PKI_PATH
                 value: etc/kubernetes
-            config:
-              exporters:
-                otlphttp/logs:
-                  tls:
-                    insecure_skip_verify: true
-                otlphttp/logs-audit:
-                  tls:
-                    insecure_skip_verify: true
-                prometheusremotewrite:
-                  tls:
-                    insecure_skip_verify: true
-                otlphttp/traces:
-                  tls:
-                    insecure_skip_verify: true
-        opencost:
-          opencost:
-            prometheus:
-              insecureSkipVerify: true
       storage:
         cert-manager:
           cluster-issuer:

--- a/charts/kof/values.yaml
+++ b/charts/kof/values.yaml
@@ -60,6 +60,14 @@ regionless:
   # -- Child clusters send KOF data to `https://vmauth.{domain}` when istio is not used.
   domain: mothership.example.com
 
+# -- TLS auto-configuration propagated to component chart values.
+tls:
+  # -- Use self-signed TLS certificates for KOF gateways.
+  selfSigned: false
+
+  # -- Skip verification of TLS certificates when collectors connect to KOF endpoints.
+  insecureSkipVerify: false
+
 # -- KOF Operators - CRDs and operators required by other KOF charts
 kof-operators:
   enabled: true


### PR DESCRIPTION
* Big piles of manually added values about self-signed and insecure TLS
  were found while testing https://github.com/k0rdent/kof/issues/542
  on a test environment.
* These values may be needed not only for regionless tests,
  and they can be automated now that we have overrides done by `kof` umbrella chart.
* This PR adds `tls.selfSigned` and `tls.insecureSkipVerify` flags,
  which configure other charts automatically to make UX simpler and more reliable.
* It also makes the overrides for each component nested for easy addition of new cases.