### PR TITLE
fix: Typo in istio case of kof-operator instrumentation

### DIFF
--- a/charts/kof-mothership/README.md
+++ b/charts/kof-mothership/README.md
@@ -113,7 +113,7 @@ KOF Helm chart for KOF Management cluster
 | kcm<br>.kof<br>.operator<br>.enabled | bool | `true` | Enables the `kof-operator`. |
 | kcm<br>.kof<br>.operator<br>.image | object | `{"pullPolicy":"IfNotPresent",`<br>`"registry":"ghcr.io/k0rdent",`<br>`"repository":"kof/kof-operator-controller"}` | Image of the kof operator. |
 | kcm<br>.kof<br>.operator<br>.otlp<br>.enabled | bool | `true` | Enables OTel SDK. |
-| kcm<br>.kof<br>.operator<br>.otlp<br>.endpoint | string | `""` | OTLP endpoint override for the operator's OTel SDK. If empty, defaults to http://kof-collectors-daemon-collector:4317 (Istio) or http://$(NODE_IP):4317 (non-Istio). |
+| kcm<br>.kof<br>.operator<br>.otlp<br>.endpoint | string | `""` | OTLP endpoint override for the operator's OTel SDK. When set, used regardless of Istio injection. When empty, defaults to http://kof-collectors-daemon-collector:4317 (Istio) or http://$(NODE_IP):4317 (non-Istio). |
 | kcm<br>.kof<br>.operator<br>.rbac<br>.create | bool | `true` | Creates the `kof-mothership-kof-operator` cluster role and binds it to the service account of operator. |
 | kcm<br>.kof<br>.operator<br>.replicaCount | int | `1` | Number of the `kof-operator` deployment replicas. |
 | kcm<br>.kof<br>.operator<br>.resources<br>.limits | object | `{"cpu":"500m",`<br>`"memory":"512Mi"}` | Maximum resources available for operator. |

--- a/charts/kof-mothership/README.md
+++ b/charts/kof-mothership/README.md
@@ -113,7 +113,7 @@ KOF Helm chart for KOF Management cluster
 | kcm<br>.kof<br>.operator<br>.enabled | bool | `true` | Enables the `kof-operator`. |
 | kcm<br>.kof<br>.operator<br>.image | object | `{"pullPolicy":"IfNotPresent",`<br>`"registry":"ghcr.io/k0rdent",`<br>`"repository":"kof/kof-operator-controller"}` | Image of the kof operator. |
 | kcm<br>.kof<br>.operator<br>.otlp<br>.enabled | bool | `true` | Enables OTel SDK. |
-| kcm<br>.kof<br>.operator<br>.otlp<br>.endpoint | string | `""` | OTLP endpoint override for the operator's OTel SDK. If empty, defaults to http://kof-collectors-collector-daemon.<namespace>.svc.cluster.local:4317 (Istio) or http://$(NODE_IP):4317 (non-Istio). Set to "" to use the defaults. |
+| kcm<br>.kof<br>.operator<br>.otlp<br>.endpoint | string | `""` | OTLP endpoint override for the operator's OTel SDK. If empty, defaults to http://kof-collectors-daemon-collector:4317 (Istio) or http://$(NODE_IP):4317 (non-Istio). |
 | kcm<br>.kof<br>.operator<br>.rbac<br>.create | bool | `true` | Creates the `kof-mothership-kof-operator` cluster role and binds it to the service account of operator. |
 | kcm<br>.kof<br>.operator<br>.replicaCount | int | `1` | Number of the `kof-operator` deployment replicas. |
 | kcm<br>.kof<br>.operator<br>.resources<br>.limits | object | `{"cpu":"500m",`<br>`"memory":"512Mi"}` | Maximum resources available for operator. |

--- a/charts/kof-mothership/templates/kof-operator/operator-deployment.yaml
+++ b/charts/kof-mothership/templates/kof-operator/operator-deployment.yaml
@@ -84,7 +84,7 @@ spec:
           {{- $ns := lookup "v1" "Namespace" "" .Release.Namespace }}
           {{- if $ns | dig "metadata" "labels" "istio-injection" "" | eq "enabled" }}
           - name: "OTEL_EXPORTER_OTLP_ENDPOINT"
-            value: {{ .Values.kcm.kof.operator.otlp.endpoint | default (printf "http://kof-collectors-collector-daemon.%s.svc.cluster.local:4317" .Release.Namespace) | quote }}
+            value: {{ .Values.kcm.kof.operator.otlp.endpoint | default "http://kof-collectors-daemon-collector:4317" | quote }}
           {{- else }}
           - name: "NODE_IP"
             valueFrom:

--- a/charts/kof-mothership/templates/kof-operator/operator-deployment.yaml
+++ b/charts/kof-mothership/templates/kof-operator/operator-deployment.yaml
@@ -81,10 +81,14 @@ spec:
             value: "kof-operator"
           - name: "OTEL_RESOURCE_ATTRIBUTES"
             value: "k8s.namespace.name={{ .Release.Namespace }}"
-          {{- $ns := lookup "v1" "Namespace" "" .Release.Namespace }}
+          {{- with .Values.kcm.kof.operator.otlp.endpoint }}
+          - name: "OTEL_EXPORTER_OTLP_ENDPOINT"
+            value: {{ . | quote }}
+          {{- else }}
+          {{- $ns := lookup "v1" "Namespace" "" $.Release.Namespace }}
           {{- if $ns | dig "metadata" "labels" "istio-injection" "" | eq "enabled" }}
           - name: "OTEL_EXPORTER_OTLP_ENDPOINT"
-            value: {{ .Values.kcm.kof.operator.otlp.endpoint | default "http://kof-collectors-daemon-collector:4317" | quote }}
+            value: "http://kof-collectors-daemon-collector:4317"
           {{- else }}
           - name: "NODE_IP"
             valueFrom:
@@ -92,6 +96,7 @@ spec:
                 fieldPath: status.hostIP
           - name: "OTEL_EXPORTER_OTLP_ENDPOINT"
             value: "http://$(NODE_IP):4317"
+          {{- end }}
           {{- end }}
           - name: "OTEL_EXPORTER_OTLP_PROTOCOL"
             value: "grpc"

--- a/charts/kof-mothership/values.yaml
+++ b/charts/kof-mothership/values.yaml
@@ -156,8 +156,8 @@ kcm:
         enabled: true
 
         # -- OTLP endpoint override for the operator's OTel SDK.
-        # If empty, defaults to http://kof-collectors-daemon-collector:4317 (Istio)
-        # or http://$(NODE_IP):4317 (non-Istio).
+        # When set, used regardless of Istio injection. When empty, defaults to
+        # http://kof-collectors-daemon-collector:4317 (Istio) or http://$(NODE_IP):4317 (non-Istio).
         endpoint: ""
 
       serviceAccount:

--- a/charts/kof-mothership/values.yaml
+++ b/charts/kof-mothership/values.yaml
@@ -156,8 +156,8 @@ kcm:
         enabled: true
 
         # -- OTLP endpoint override for the operator's OTel SDK.
-        # If empty, defaults to http://kof-collectors-collector-daemon.<namespace>.svc.cluster.local:4317 (Istio)
-        # or http://$(NODE_IP):4317 (non-Istio). Set to "" to use the defaults.
+        # If empty, defaults to http://kof-collectors-daemon-collector:4317 (Istio)
+        # or http://$(NODE_IP):4317 (non-Istio).
         endpoint: ""
 
       serviceAccount:


### PR DESCRIPTION
* Found while testing https://github.com/k0rdent/kof/issues/542
  but debug showed it was not related to regionless.
* There was a typo in https://github.com/k0rdent/kof/pull/1029
  leading to this error in kof-operator logs in the istio case:
  ```
  traces export: exporter export timeout: rpc error: code = Unavailable
  desc = name resolver error: produced zero addresses  
  ```
* This PR fixes the typo, the error is gone, traces are seen.
* There was a different error in the non-istio case:
  ```
  traces export: exporter export timeout: rpc error: code = Unavailable
  desc = connection error: desc = "transport: Error while dialing:
  dial tcp 172.18.0.2:4317: connect: connection refused"
  ```
* As we discussed, this is expected error log
  because collectors are installed and started way after kof-operator,
  so this is self-healing case.
