### PR TITLE
fix: resolve namespace-related issues for clusters deployed in non-system namespaces

### DIFF
--- a/charts/kof-mothership/templates/istio/mcs.yaml
+++ b/charts/kof-mothership/templates/istio/mcs.yaml
@@ -11,7 +11,7 @@ spec:
     services:
       - name: kof-namespace
         namespace: {{ .Values.kcm.namespace }}
-        template: kof-namespace
+        template: kof-namespace-{{ $.Chart.Version | replace "." "-" }}
 ---
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: MultiClusterService

--- a/charts/kof-mothership/templates/istio/svctmpl.yaml
+++ b/charts/kof-mothership/templates/istio/svctmpl.yaml
@@ -1,8 +1,10 @@
 {{- if .Values.istio.enabled }}
+{{- $prefix := "kof-namespace" }}
+{{- $newName := printf "%s-%s" $prefix ($.Chart.Version | replace "." "-") }}
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ServiceTemplate
 metadata:
-  name: kof-namespace
+  name: {{ $newName }}
   namespace: {{ .Values.kcm.namespace }}
   annotations:
     helm.sh/resource-policy: keep
@@ -14,4 +16,27 @@ spec:
       namespace: {{ .Values.kcm.namespace }}
     deploymentType: Remote
     path: ""
+---
+apiVersion: k0rdent.mirantis.com/v1beta1
+kind: ServiceTemplateChain
+metadata:
+  name: {{ $newName }}
+  namespace: {{ .Values.kcm.namespace }}
+  annotations:
+    helm.sh/resource-policy: keep
+spec:
+  supportedTemplates:
+    - name: {{ $newName }}
+    {{- range $template := (lookup
+      "k0rdent.mirantis.com/v1beta1" "ServiceTemplate"
+      $.Values.kcm.namespace ""
+    ).items }}
+      {{- $oldName := $template.metadata.name }}
+      {{- if and ($oldName | hasPrefix $prefix) (ne $oldName $newName) $template.spec.resources }}
+    - name: {{ $oldName }}
+      availableUpgrades:
+        - name: {{ $newName }}
+          version: {{ $.Chart.Version | quote }}
+      {{- end }}
+    {{- end }}
 {{- end }}

--- a/kof-operator/internal/controller/clusterdeployment_kof_cluster_child_role.go
+++ b/kof-operator/internal/controller/clusterdeployment_kof_cluster_child_role.go
@@ -223,12 +223,19 @@ func (c *ChildClusterRole) DiscoverRegionalClusterCmByLabel(regionalClusterName 
 func (c *ChildClusterRole) DiscoverRegionalClusterConfigMapByLocation() (*corev1.ConfigMap, error) {
 	log := log.FromContext(c.ctx)
 	crossNamespace := env.CrossNamespaceEnabled()
+	isRegionless := env.RegionlessEnabled()
 
 	regionalClusterConfigMapList := &corev1.ConfigMapList{}
 
 	selector := k8slabels.Set{labels.KofClusterRoleLabel: KofRoleRegional}.AsSelector()
 	opts := &client.ListOptions{LabelSelector: selector}
-	if !crossNamespace {
+
+	// Regionless ConfigMap is stored in the default system namespace,
+	// so we need to set the namespace for the list options to avoid
+	// listing all ConfigMaps in the cluster.
+	if isRegionless {
+		opts.Namespace = k8s.DefaultSystemNamespace
+	} else if !crossNamespace {
 		opts.Namespace = c.clusterNamespace
 	}
 
@@ -237,7 +244,7 @@ func (c *ChildClusterRole) DiscoverRegionalClusterConfigMapByLocation() (*corev1
 		return nil, err
 	}
 
-	if env.RegionlessEnabled() {
+	if isRegionless {
 		for _, regionalClusterConfigMap := range regionalClusterConfigMapList.Items {
 			if isRegionlessConfigMap(&regionalClusterConfigMap) {
 				return &regionalClusterConfigMap, nil

--- a/kof-operator/internal/k8s/client.go
+++ b/kof-operator/internal/k8s/client.go
@@ -65,7 +65,7 @@ func NewKubeClientFromClusterDeployment(ctx context.Context, client client.Clien
 		return nil, fmt.Errorf("failed to get secret name: %v", err)
 	}
 
-	return NewKubeClientFromSecret(ctx, client, secretName, DefaultSystemNamespace)
+	return NewKubeClientFromSecret(ctx, client, secretName, cd.Namespace)
 }
 
 func NewKubeClientFromSecret(ctx context.Context, client client.Client, secretName, namespace string) (*KubeClient, error) {

--- a/kof-operator/internal/server/handlers/k8s_objects/cluster_summaries_handler.go
+++ b/kof-operator/internal/server/handlers/k8s_objects/cluster_summaries_handler.go
@@ -28,13 +28,7 @@ func ClusterSummariesHandler(res *server.Response, req *http.Request) {
 	}
 
 	for _, cluster := range regionClusters {
-		kubeconfigSecretName, err := k8s.GetKubeconfigSecretName(ctx, k8s.LocalKubeClient.Client, cluster)
-		if err != nil {
-			res.Logger.Error(err, "Failed to get secret name for cluster deployment", "clusterDeployment", cluster.Name)
-			continue
-		}
-
-		regionKubeClient, err := k8s.NewKubeClientFromSecret(ctx, k8s.LocalKubeClient.Client, kubeconfigSecretName, k8s.DefaultSystemNamespace)
+		regionKubeClient, err := k8s.NewKubeClientFromClusterDeployment(ctx, k8s.LocalKubeClient.Client, cluster)
 		if err != nil {
 			res.Logger.Error(err, "Failed to create kube client for region", "region", cluster.Name)
 			continue

--- a/kof-operator/internal/server/handlers/metrics_handler.go
+++ b/kof-operator/internal/server/handlers/metrics_handler.go
@@ -225,7 +225,7 @@ func (h *BaseMetricsHandler) handleRegionClusters(
 			continue
 		}
 
-		regionClient, err := h.createAndSendKubeClient(ch, regionSecretName, cd.Name, h.kubeClient.Client, processed)
+		regionClient, err := h.createAndSendKubeClient(ch, regionSecretName, cd.Name, cd.Namespace, h.kubeClient.Client, processed)
 		if err != nil {
 			h.logger.Error(err, "failed to create region kubeclient", "secret", regionSecretName)
 			continue
@@ -241,7 +241,7 @@ func (h *BaseMetricsHandler) handleRegionClusters(
 					return
 				}
 
-				if _, err := h.createAndSendKubeClient(ch, secret, cd.Name, client.Client, processed); err != nil {
+				if _, err := h.createAndSendKubeClient(ch, secret, cd.Name, cd.Namespace, client.Client, processed); err != nil {
 					h.logger.Error(err, "failed to create kubeclient for regional cluster", "secret", secret)
 				}
 			}(child, regionClient)
@@ -269,7 +269,7 @@ func (h *BaseMetricsHandler) handleOtherClusters(
 				return
 			}
 
-			if _, err := h.createAndSendKubeClient(ch, secret, cd.Name, h.kubeClient.Client, processed); err != nil {
+			if _, err := h.createAndSendKubeClient(ch, secret, cd.Name, cd.Namespace, h.kubeClient.Client, processed); err != nil {
 				h.logger.Error(err, "failed to create kubeclient for cluster", "secret", secret)
 			}
 		}(cd)
@@ -278,11 +278,11 @@ func (h *BaseMetricsHandler) handleOtherClusters(
 
 func (h *BaseMetricsHandler) createAndSendKubeClient(
 	ch chan *RemoteCluster,
-	secretName, clusterName string,
+	secretName, clusterName, namespace string,
 	client client.Client,
 	processed *sync.Map,
 ) (*k8s.KubeClient, error) {
-	kc, err := k8s.NewKubeClientFromSecret(h.ctx, client, secretName, k8s.DefaultSystemNamespace)
+	kc, err := k8s.NewKubeClientFromSecret(h.ctx, client, secretName, namespace)
 	if err != nil {
 		return nil, err
 	}

--- a/kof-operator/internal/server/handlers/prometheus_handler.go
+++ b/kof-operator/internal/server/handlers/prometheus_handler.go
@@ -80,7 +80,7 @@ func (h *PrometheusTargets) collectClusterDeploymentsTargets(ctx context.Context
 			continue
 		}
 
-		client, err := k8s.NewKubeClientFromSecret(ctx, h.kubeClient.Client, secretName, k8s.DefaultSystemNamespace)
+		client, err := k8s.NewKubeClientFromSecret(ctx, h.kubeClient.Client, secretName, cd.Namespace)
 		if err != nil {
 			h.logger.Error(err, "Failed to create kubeclient from secret", "clusterName", cd.Name)
 			continue


### PR DESCRIPTION
This PR fixes several issues that occur when a cluster is deployed to a namespace other than the default one:
- Fix hardcoded namespace usage for kubeconfig secret lookup. The KOF UI backend now searches for kubeconfig secrets in the target cluster namespace instead of always using `kcm-system`. Closes #1098
- Add a `ServiceTemplateChain` for the `test-namespace` ServiceTemplate to simplify deployments to non-default namespaces.
- Fix regional cluster discovery when a child cluster is defined in a different namespace in the `regionless` scenario.