### PR TITLE
fix: audit-logs-exporter image tag should always start with one v

### DIFF
--- a/charts/audit-logs-exporter/templates/cronjob.yaml
+++ b/charts/audit-logs-exporter/templates/cronjob.yaml
@@ -41,7 +41,9 @@ spec:
               type: RuntimeDefault
           containers:
             - name: audit-logs-exporter
-              image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+              image: "{{ .Values.image.repository }}:
+              {{- with .Values.image.tag }}{{ . }}
+              {{- else }}v{{ .Chart.AppVersion | trimPrefix "v" }}{{ end }}"
               imagePullPolicy: {{ .Values.image.pullPolicy }}
               securityContext:
                 allowPrivilegeEscalation: false


### PR DESCRIPTION
* Related to https://github.com/k0rdent/kof/pull/1043#discussion_r3341738836
* We use e.g. `--version 1.9.0` for releases but `--version v1.9.0-49-gb73400b` for builds from `main`, note the "v" letter.
* This workaround was applied to cold-storage-exporter, but not to audit-logs-exporter.
* This PR fixes this, also verified there are no other cases like this one.