### PR TITLE
ci: switch kcm repo from `kcm/charts` to `kcm/staging`

### DIFF
--- a/.github/actions/shared-setup/action.yaml
+++ b/.github/actions/shared-setup/action.yaml
@@ -16,8 +16,7 @@ runs:
     - name: Set shared env vars
       shell: bash --noprofile --norc -euo pipefail {0}
       run: |
-        KCM_RELEASE=v1.10.0-release
-        # KCM_RELEASE=main
+        KCM_RELEASE=main
         ISTIO_RELEASE=main
         echo "ISTIO_RELEASE=$ISTIO_RELEASE" >> "$GITHUB_ENV"
         echo "KCM_RELEASE=$KCM_RELEASE" >> "$GITHUB_ENV"

--- a/.github/workflows/pr_test_adopted_upgrade.yml
+++ b/.github/workflows/pr_test_adopted_upgrade.yml
@@ -98,6 +98,7 @@ jobs:
           helm install kcm oci://ghcr.io/k0rdent/kcm/staging/kcm \
             --version ${{ steps.kcm_chart_version.outputs.version }} \
             --set regional.cert-manager.config.enableGatewayAPI=true \
+            --set controller.templatesRepoURL="oci://ghcr.io/k0rdent/kcm/staging/kcm" \
             -n kcm-system \
             --create-namespace \
             --wait \
@@ -187,7 +188,14 @@ jobs:
           KCM_VERSION="${{ steps.main-kcm-chart-version.outputs.version }}"
           KCM_RELEASE="kcm-${KCM_VERSION//./-}"
 
-          kubectl apply -f "https://raw.githubusercontent.com/k0rdent/kcm/refs/tags/v${KCM_VERSION}/templates/provider/kcm-templates/files/release.yaml"
+          curl -sSL "https://raw.githubusercontent.com/k0rdent/kcm/refs/tags/v${KCM_VERSION}/templates/provider/kcm-templates/files/release.yaml" > release.yaml
+
+          jq --arg KCM_RELEASE "$KCM_RELEASE" \
+            --arg KCM_VERSION "$KCM_VERSION" \
+            '.metadata.name = $KCM_RELEASE | .spec.version = $KCM_VERSION | .spec.kcm.template = $KCM_RELEASE' \
+            release.yaml > release.tmp.yaml && mv release.tmp.yaml release.yaml
+
+          kubectl apply -f release.yaml
 
           kubectl wait --for=create "release/$KCM_RELEASE" --timeout=5m
           kubectl wait "release/$KCM_RELEASE" \

--- a/.github/workflows/pr_test_adopted_upgrade.yml
+++ b/.github/workflows/pr_test_adopted_upgrade.yml
@@ -160,6 +160,7 @@ jobs:
 
       - name: Fetch PR Ref and Checkout Repo
         uses: ./.github/actions/fetch-pr-ref
+      - uses: ./.github/actions/setup-yq
       - name: "[Main KCM Branch] Get latest successful KCM CI SHA"
         id: main-kcm-ci
         env:
@@ -187,13 +188,10 @@ jobs:
         run: |
           KCM_VERSION="${{ steps.main-kcm-chart-version.outputs.version }}"
           KCM_RELEASE="kcm-${KCM_VERSION//./-}"
+          export KCM_RELEASE KCM_VERSION
 
           curl -sSL "https://raw.githubusercontent.com/k0rdent/kcm/refs/tags/v${KCM_VERSION}/templates/provider/kcm-templates/files/release.yaml" > release.yaml
-
-          jq --arg KCM_RELEASE "$KCM_RELEASE" \
-            --arg KCM_VERSION "$KCM_VERSION" \
-            '.metadata.name = $KCM_RELEASE | .spec.version = $KCM_VERSION | .spec.kcm.template = $KCM_RELEASE' \
-            release.yaml > release.tmp.yaml && mv release.tmp.yaml release.yaml
+          yq eval -i '.metadata.name = env(KCM_RELEASE) | .spec.version = env(KCM_VERSION) | .spec.kcm.template = env(KCM_RELEASE)' release.yaml
 
           kubectl apply -f release.yaml
 

--- a/.github/workflows/pr_test_adopted_upgrade.yml
+++ b/.github/workflows/pr_test_adopted_upgrade.yml
@@ -95,7 +95,7 @@ jobs:
             --timeout 10m
       - name: "[Latest KCM Release] Install KCM from release chart"
         run: |
-          helm install kcm oci://ghcr.io/k0rdent/kcm/charts/kcm \
+          helm install kcm oci://ghcr.io/k0rdent/kcm/staging/kcm \
             --version ${{ steps.kcm_chart_version.outputs.version }} \
             --set regional.cert-manager.config.enableGatewayAPI=true \
             -n kcm-system \

--- a/.github/workflows/pr_test_adopted_upgrade.yml
+++ b/.github/workflows/pr_test_adopted_upgrade.yml
@@ -98,7 +98,7 @@ jobs:
           helm install kcm oci://ghcr.io/k0rdent/kcm/staging/kcm \
             --version ${{ steps.kcm_chart_version.outputs.version }} \
             --set regional.cert-manager.config.enableGatewayAPI=true \
-            --set controller.templatesRepoURL="oci://ghcr.io/k0rdent/kcm/staging/kcm" \
+            --set controller.templatesRepoURL="oci://ghcr.io/k0rdent/kcm/staging" \
             -n kcm-system \
             --create-namespace \
             --wait \

--- a/.github/workflows/pr_test_cross_namespace.yaml
+++ b/.github/workflows/pr_test_cross_namespace.yaml
@@ -65,7 +65,7 @@ jobs:
       - name: "[Latest KCM Release] Install KCM from release chart"
         run: |
           KCM_TAG="${{ steps.kcm_release.outputs.release }}"
-          helm install kcm oci://ghcr.io/k0rdent/kcm/charts/kcm \
+          helm install kcm oci://ghcr.io/k0rdent/kcm/staging/kcm \
             --version "${KCM_TAG#v}" \
             --set regional.cert-manager.config.enableGatewayAPI=true \
             -n kcm-system \

--- a/.github/workflows/pr_test_helm_chart.yml
+++ b/.github/workflows/pr_test_helm_chart.yml
@@ -116,7 +116,7 @@ jobs:
       - name: "[Latest KCM Release] Install KCM from release chart"
         run: |
           KCM_TAG="${{ steps.kcm_release.outputs.release }}"
-          helm install kcm oci://ghcr.io/k0rdent/kcm/charts/kcm \
+          helm install kcm oci://ghcr.io/k0rdent/kcm/staging/kcm \
             --version "${KCM_TAG#v}" \
             --set regional.cert-manager.config.enableGatewayAPI=true \
             -n kcm-system \

--- a/.github/workflows/pr_test_kcm_region_with_kof.yaml
+++ b/.github/workflows/pr_test_kcm_region_with_kof.yaml
@@ -69,7 +69,7 @@ jobs:
       - name: "[Latest KCM Release] Install KCM from release chart"
         run: |
           KCM_TAG="${{ steps.kcm_release.outputs.release }}"
-          helm install kcm oci://ghcr.io/k0rdent/kcm/charts/kcm \
+          helm install kcm oci://ghcr.io/k0rdent/kcm/staging/kcm \
             --version "${KCM_TAG#v}" \
             --set regional.cert-manager.config.enableGatewayAPI=true \
             -n kcm-system \

--- a/.github/workflows/pr_test_kof_installation.yaml
+++ b/.github/workflows/pr_test_kof_installation.yaml
@@ -69,7 +69,7 @@ jobs:
       - name: "[Latest KCM Release] Install KCM from release chart"
         run: |
           KCM_TAG="${{ steps.kcm_release.outputs.release }}"
-          helm install kcm oci://ghcr.io/k0rdent/kcm/charts/kcm \
+          helm install kcm oci://ghcr.io/k0rdent/kcm/staging/kcm \
             --version "${KCM_TAG#v}" \
             --set regional.cert-manager.config.enableGatewayAPI=true \
             -n kcm-system \

--- a/.github/workflows/pr_test_mgmt_upgrade.yml
+++ b/.github/workflows/pr_test_mgmt_upgrade.yml
@@ -93,6 +93,7 @@ jobs:
           kubectl wait --for=condition=Ready helmreleases --all -n kof --timeout=10m
       - name: Fetch PR Ref and Checkout Repo
         uses: ./.github/actions/fetch-pr-ref
+      - uses: ./.github/actions/setup-yq
       - name: "[Main KCM Branch] Get latest successful KCM CI SHA"
         id: main-kcm-ci
         env:
@@ -120,14 +121,11 @@ jobs:
         run: |
           KCM_VERSION="${{ steps.main-kcm-chart-version.outputs.version }}"
           KCM_RELEASE="kcm-${KCM_VERSION//./-}"
+          export KCM_RELEASE KCM_VERSION
 
           curl -sSL "https://raw.githubusercontent.com/k0rdent/kcm/refs/tags/v${KCM_VERSION}/templates/provider/kcm-templates/files/release.yaml" > release.yaml
-
-          jq --arg KCM_RELEASE "$KCM_RELEASE" \
-            --arg KCM_VERSION "$KCM_VERSION" \
-            '.metadata.name = $KCM_RELEASE | .spec.version = $KCM_VERSION | .spec.kcm.template = $KCM_RELEASE' \
-            release.yaml > release.tmp.yaml && mv release.tmp.yaml release.yaml
-
+          yq eval -i '.metadata.name = env(KCM_RELEASE) | .spec.version = env(KCM_VERSION) | .spec.kcm.template = env(KCM_RELEASE)' release.yaml
+          
           kubectl apply -f release.yaml
 
           kubectl wait --for=create "release/$KCM_RELEASE" --timeout=5m

--- a/.github/workflows/pr_test_mgmt_upgrade.yml
+++ b/.github/workflows/pr_test_mgmt_upgrade.yml
@@ -70,6 +70,7 @@ jobs:
           helm install kcm oci://ghcr.io/k0rdent/kcm/staging/kcm \
             --version "${KCM_TAG#v}" \
             --set regional.cert-manager.config.enableGatewayAPI=true \
+            --set controller.templatesRepoURL="oci://ghcr.io/k0rdent/kcm/staging/kcm" \
             -n kcm-system \
             --create-namespace \
             --wait \
@@ -120,7 +121,14 @@ jobs:
           KCM_VERSION="${{ steps.main-kcm-chart-version.outputs.version }}"
           KCM_RELEASE="kcm-${KCM_VERSION//./-}"
 
-          kubectl apply -f "https://raw.githubusercontent.com/k0rdent/kcm/refs/tags/v${KCM_VERSION}/templates/provider/kcm-templates/files/release.yaml"
+          curl -sSL "https://raw.githubusercontent.com/k0rdent/kcm/refs/tags/v${KCM_VERSION}/templates/provider/kcm-templates/files/release.yaml" > release.yaml
+
+          jq --arg KCM_RELEASE "$KCM_RELEASE" \
+            --arg KCM_VERSION "$KCM_VERSION" \
+            '.metadata.name = $KCM_RELEASE | .spec.version = $KCM_VERSION | .spec.kcm.template = $KCM_RELEASE' \
+            release.yaml > release.tmp.yaml && mv release.tmp.yaml release.yaml
+
+          kubectl apply -f release.yaml
 
           kubectl wait --for=create "release/$KCM_RELEASE" --timeout=5m
           kubectl wait "release/$KCM_RELEASE" \

--- a/.github/workflows/pr_test_mgmt_upgrade.yml
+++ b/.github/workflows/pr_test_mgmt_upgrade.yml
@@ -70,7 +70,7 @@ jobs:
           helm install kcm oci://ghcr.io/k0rdent/kcm/staging/kcm \
             --version "${KCM_TAG#v}" \
             --set regional.cert-manager.config.enableGatewayAPI=true \
-            --set controller.templatesRepoURL="oci://ghcr.io/k0rdent/kcm/staging/kcm" \
+            --set controller.templatesRepoURL="oci://ghcr.io/k0rdent/kcm/staging" \
             -n kcm-system \
             --create-namespace \
             --wait \

--- a/.github/workflows/pr_test_mgmt_upgrade.yml
+++ b/.github/workflows/pr_test_mgmt_upgrade.yml
@@ -67,7 +67,7 @@ jobs:
       - name: "[Latest KCM Release] Install KCM from release chart"
         run: |
           KCM_TAG="${{ steps.kcm_release.outputs.release }}"
-          helm install kcm oci://ghcr.io/k0rdent/kcm/charts/kcm \
+          helm install kcm oci://ghcr.io/k0rdent/kcm/staging/kcm \
             --version "${KCM_TAG#v}" \
             --set regional.cert-manager.config.enableGatewayAPI=true \
             -n kcm-system \

--- a/.github/workflows/pr_test_tenant_isolation_test.yaml
+++ b/.github/workflows/pr_test_tenant_isolation_test.yaml
@@ -65,7 +65,7 @@ jobs:
       - name: "[Latest KCM Release] Install KCM from release chart"
         run: |
           KCM_TAG="${{ steps.kcm_release.outputs.release }}"
-          helm install kcm oci://ghcr.io/k0rdent/kcm/charts/kcm \
+          helm install kcm oci://ghcr.io/k0rdent/kcm/staging/kcm \
             --version "${KCM_TAG#v}" \
             --set regional.cert-manager.config.enableGatewayAPI=true \
             -n kcm-system \

--- a/.github/workflows/test_builds.yml
+++ b/.github/workflows/test_builds.yml
@@ -132,7 +132,7 @@ jobs:
 
       - name: Install KCM from latest CI build
         run: |
-          helm install kcm oci://ghcr.io/k0rdent/kcm/charts/kcm \
+          helm install kcm oci://ghcr.io/k0rdent/kcm/staging/kcm \
             --version ${{ steps.kcm_version.outputs.version }} \
             --set regional.cert-manager.config.enableGatewayAPI=true \
             -n kcm-system \


### PR DESCRIPTION
This PR introduces two changes:

1. Switch the KCM repository from [kcm/charts](https://github.com/k0rdent/kcm/pkgs/container/kcm%2Fcharts%2Fkcm) to [kcm/staging](https://github.com/k0rdent/kcm/pkgs/container/kcm%2Fstaging%2Fkcm) to enable downloading artifacts from the latest commit.
2. Create a new `Release` resource during the update step, rather than updating the existing resource.