### PR TITLE
fix: Use only one version of victoria-logs image

### DIFF
--- a/charts/kof-storage/values.yaml
+++ b/charts/kof-storage/values.yaml
@@ -189,6 +189,10 @@ victoriametrics:
   vlcluster_audit:
     enabled: true
     spec:
+      # vlcluster_audit uses victoria-metrics-operator chart 0.58.1 (image v0.67.0)
+      # which uses victoria-logs image v1.43.1 by default. We align it with
+      # victoria-logs-cluster chart 0.0.33 (image v1.50.0) used in kof-storage/Chart.yaml
+      clusterVersion: v1.50.0
       vlinsert:
         podMetadata:
           labels:


### PR DESCRIPTION
* victoria-logs-multilevel-select feature uses image v1.50.0 [here](https://github.com/k0rdent/kof/blame/release/v1.10.0/charts/kof-mothership/values.yaml#L611).
* This image is supported by victoria-logs-cluster chart 0.0.33 [here](https://github.com/VictoriaMetrics/helm-charts/blob/victoria-logs-cluster-0.0.33/charts/victoria-logs-cluster/Chart.yaml#L4-L7).
* We also used victoria-logs-cluster chart 0.0.25 which used image v1.43.1 [here](https://github.com/VictoriaMetrics/helm-charts/blob/victoria-logs-cluster-0.0.25/charts/victoria-logs-cluster/Chart.yaml#L3-L6).
* So we needed both victoria-logs:v1.50.0 and victoria-logs:v1.43.1
* To avoid this, we upgraded kof to use victoria-logs-cluster chart 0.0.33 [here](https://github.com/k0rdent/kof/pull/1100).
* We still use victoria-metrics-operator chart 0.58.1 [here](https://github.com/k0rdent/kof/blob/release/v1.10.0/charts/kof-mothership/values.yaml#L87) and [here](https://github.com/k0rdent/kof/blob/release/v1.10.0/charts/kof-regional/values.yaml#L38).
* This chart uses operator image v0.67.0 [here](https://github.com/VictoriaMetrics/helm-charts/blob/victoria-metrics-operator-0.58.1/charts/victoria-metrics-operator/Chart.yaml#L10).
* This operator image by default uses logs image v1.43.1 [here](https://github.com/VictoriaMetrics/operator/blob/v0.67.0/internal/config/config.go#L38).
* So we still need both victoria-logs:v1.50.0 and victoria-logs:v1.43.1
* To avoid this, and to avoid issues on upgrade of KOF/victoria-metrics-operator,
  this PR uses [VLCluster.spec.clusterVersion](https://docs.victoriametrics.com/operator/api/#vlclusterspec-clusterversion) to keep image versions in sync.
