### PR TITLE
fix: bump VL chart from 0.0.33 to 0.1.5 to avoid upgrade errors

### DIFF
--- a/charts/kof-storage/Chart.lock
+++ b/charts/kof-storage/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: victoria-logs-cluster
   repository: https://victoriametrics.github.io/helm-charts/
-  version: 0.0.33
+  version: 0.1.5
 - name: victoria-traces-cluster
   repository: https://victoriametrics.github.io/helm-charts/
   version: 0.1.1
@@ -14,5 +14,5 @@ dependencies:
 - name: kof-dashboards
   repository: file://../kof-dashboards/
   version: 1.11.0-rc0
-digest: sha256:18e6e9b36890f4bfb95afd1ef3447055ae23f83aa5174b2b855a1245c3591180
-generated: "2026-06-16T19:14:40.766306+03:00"
+digest: sha256:d776c54ba24dfecf01fc837baac92df0a3466850f48c89ca95dfe1c561320923
+generated: "2026-06-24T15:19:43.48068+03:00"

--- a/charts/kof-storage/Chart.yaml
+++ b/charts/kof-storage/Chart.yaml
@@ -5,7 +5,7 @@ version: "1.11.0-rc0"
 appVersion: "1.11.0-rc0"
 dependencies:
   - name: victoria-logs-cluster
-    version: "0.0.33"
+    version: "0.1.5"
     repository: https://victoriametrics.github.io/helm-charts/
     condition: victoria-logs-cluster.enabled
   - name: victoria-traces-cluster


### PR DESCRIPTION
This PR fixes issues encountered during the KOF upgrade.

The previous KOF version depended on the `victoria-logs-cluster` chart version `0.0.25`, while the new KOF version introduces `victoria-logs-cluster` version `0.0.33`.

In `victoria-logs-cluster` `0.0.33`, changes to the `vlinsert` and `vlselect` deployment specifications modified immutable fields, causing the `kof-storage` chart to be reinstalled on regional clusters during the upgrade.

This PR upgrades `victoria-logs-cluster` to version `0.1.5`, in which these changes have been reverted. As a result, immutable deployment fields are no longer modified, preventing unnecessary `kof-storage` reinstallation during KOF upgrades