### PR TITLE
fix: Reloading each promxy pod to avoid flickering metrics

### DIFF
--- a/charts/kof-mothership/templates/kof-operator/operator-deployment.yaml
+++ b/charts/kof-mothership/templates/kof-operator/operator-deployment.yaml
@@ -64,8 +64,8 @@ spec:
             value: "{{ .Values.regionless.domain }}"
           - name: "CROSS_NAMESPACE"
             value: "{{ .Values.kcm.kof.operator.crossNamespace }}"
-          - name: "PROMXY_RELOAD_ENDPOINT"
-            value: "http://{{ .Release.Name }}-promxy:{{ .Values.promxy.service.servicePort }}/-/reload"
+          - name: "PROMXY_POD_LABEL_SELECTOR"
+            value: "app.kubernetes.io/name={{ include "promxy.name" . }}-promxy,app.kubernetes.io/instance={{ .Release.Name }}"
           - name: "RELEASE_NAMESPACE"
             value: {{ .Release.Namespace }}
           - name: "RELEASE_NAME"

--- a/kof-operator/cmd/main.go
+++ b/kof-operator/cmd/main.go
@@ -31,6 +31,7 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 
 	"github.com/k0rdent/kof/kof-operator/internal/controller/record"
+	"github.com/k0rdent/kof/kof-operator/internal/env"
 	"github.com/k0rdent/kof/kof-operator/internal/k8s"
 	"github.com/k0rdent/kof/kof-operator/internal/telemetry"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -89,7 +90,6 @@ func main() {
 	var enableHTTP2 bool
 	var runController bool
 	var remoteWriteUrl string
-	var promxyReloadEnpoint string
 	var enableServerCORS bool
 	var httpServerPort string
 	var managementClusterName string
@@ -103,12 +103,6 @@ func main() {
 		"remote-write-url",
 		"http://vminsert-cluster:8480/insert/0/prometheus/api/v1/write",
 		"The promxy remote_write_url address",
-	)
-	flag.StringVar(
-		&promxyReloadEnpoint,
-		"promxy-reload-endpoint",
-		"http://localhost:8082/-/reload",
-		"The promxy config reload endpoint",
 	)
 	flag.StringVar(
 		&managementClusterName,
@@ -131,9 +125,6 @@ func main() {
 	opts.BindFlags(flag.CommandLine)
 	flag.Parse()
 
-	if endpoint, ok := os.LookupEnv("PROMXY_RELOAD_ENDPOINT"); ok {
-		promxyReloadEnpoint = endpoint
-	}
 	handlers.ManagementClusterName = managementClusterName
 
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
@@ -278,7 +269,15 @@ func main() {
 		Scheme:         mgr.GetScheme(),
 		RemoteWriteUrl: remoteWriteUrl,
 		PromxyConfigReload: func(ctx context.Context) error {
-			return controller.ReloadPromxyConfig(ctx, promxyReloadEnpoint)
+			releaseNamespace, err := env.GetReleaseNamespace()
+			if err != nil {
+				return err
+			}
+			labelSelector, err := env.GetPromxyPodLabelSelector()
+			if err != nil {
+				return err
+			}
+			return controller.ReloadPromxyConfig(ctx, k8s.LocalKubeClient, releaseNamespace, labelSelector)
 		},
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "PromxyServerGroup")

--- a/kof-operator/internal/controller/promxy_reload.go
+++ b/kof-operator/internal/controller/promxy_reload.go
@@ -2,22 +2,78 @@ package controller
 
 import (
 	"context"
-	"net/http"
-	"strings"
+	"errors"
+	"fmt"
+	"time"
 
-	"github.com/k0rdent/kof/kof-operator/internal/telemetry"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/k0rdent/kof/kof-operator/internal/k8s"
 )
 
-func ReloadPromxyConfig(ctx context.Context, endpoint string) error {
-	client := &http.Client{Transport: telemetry.NewTransport(nil)}
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, strings.NewReader(""))
+const (
+	promxyReloadPath        = "/-/reload"
+	promxyContainerName     = "promxy"
+	promxyContainerPortName = "http"
+	promxyReloadTimeout     = 30 * time.Second
+)
+
+func ReloadPromxyConfig(ctx context.Context, kubeClient *k8s.KubeClient, namespace, labelSelector string) error {
+	logger := log.FromContext(ctx)
+
+	selector, err := labels.Parse(labelSelector)
 	if err != nil {
-		return err
+		return fmt.Errorf("invalid promxy pod label selector %q: %w", labelSelector, err)
 	}
-	req.Header.Set("Content-Type", "application/json")
-	res, err := client.Do(req)
+
+	podList, err := k8s.GetPods(
+		ctx,
+		kubeClient.Client,
+		client.InNamespace(namespace),
+		client.MatchingLabelsSelector{Selector: selector},
+	)
 	if err != nil {
-		return err
+		return fmt.Errorf("listing promxy pods: %w", err)
 	}
-	return res.Body.Close()
+	if len(podList.Items) == 0 {
+		return fmt.Errorf("no promxy pods found in namespace %q matching %q", namespace, labelSelector)
+	}
+
+	var reloadErrors []error
+	reloaded := 0
+	for _, pod := range podList.Items {
+		if pod.Status.Phase != corev1.PodRunning {
+			logger.Info(
+				"Skipping promxy config reload for pod that is not running",
+				"pod", pod.Name,
+				"phase", pod.Status.Phase,
+			)
+			continue
+		}
+
+		logger.Info("Reloading promxy config", "pod", pod.Name, "podIP", pod.Status.PodIP)
+		if err := k8s.PostPodHTTPEmpty(ctx, pod, promxyContainerName, promxyContainerPortName, promxyReloadPath, promxyReloadTimeout); err != nil {
+			logger.Error(err, "Failed to reload promxy config", "pod", pod.Name)
+			reloadErrors = append(reloadErrors, fmt.Errorf("pod %s: %w", pod.Name, err))
+			continue
+		}
+		logger.Info("Reloaded promxy config", "pod", pod.Name, "podIP", pod.Status.PodIP)
+		reloaded++
+	}
+
+	if reloaded == 0 {
+		if len(reloadErrors) > 0 {
+			return fmt.Errorf("failed to reload promxy config on all pods: %w", errors.Join(reloadErrors...))
+		}
+		return fmt.Errorf("no running promxy pods to reload in namespace %q matching %q", namespace, labelSelector)
+	}
+
+	if len(reloadErrors) == 0 {
+		logger.Info("Reloaded promxy config on all pods", "reloaded", reloaded)
+	}
+
+	return errors.Join(reloadErrors...)
 }

--- a/kof-operator/internal/controller/promxy_reload_test.go
+++ b/kof-operator/internal/controller/promxy_reload_test.go
@@ -1,0 +1,77 @@
+package controller
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/k0rdent/kof/kof-operator/internal/k8s"
+)
+
+func TestReloadPromxyConfig_InvalidSelector(t *testing.T) {
+	t.Parallel()
+
+	kubeClient := &k8s.KubeClient{
+		Client: fake.NewClientBuilder().Build(),
+	}
+
+	err := ReloadPromxyConfig(context.Background(), kubeClient, "kof", "not a valid selector ==")
+	if err == nil {
+		t.Fatal("expected error for invalid selector")
+	}
+}
+
+func TestReloadPromxyConfig_NoPods(t *testing.T) {
+	t.Parallel()
+
+	kubeClient := &k8s.KubeClient{
+		Client: fake.NewClientBuilder().Build(),
+	}
+
+	err := ReloadPromxyConfig(
+		context.Background(),
+		kubeClient,
+		"kof",
+		"app.kubernetes.io/name=kof-mothership-promxy",
+	)
+	if err == nil {
+		t.Fatal("expected error when no promxy pods exist")
+	}
+}
+
+func TestReloadPromxyConfig_NoRunningPods(t *testing.T) {
+	t.Parallel()
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kof-mothership-promxy-abc",
+			Namespace: "kof",
+			Labels: map[string]string{
+				"app.kubernetes.io/name":     "kof-mothership-promxy",
+				"app.kubernetes.io/instance": "kof-mothership",
+			},
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodPending,
+		},
+	}
+
+	kubeClient := &k8s.KubeClient{
+		Client: fake.NewClientBuilder().
+			WithObjects(pod).
+			Build(),
+	}
+
+	err := ReloadPromxyConfig(
+		context.Background(),
+		kubeClient,
+		"kof",
+		"app.kubernetes.io/name=kof-mothership-promxy,app.kubernetes.io/instance=kof-mothership",
+	)
+	if err == nil {
+		t.Fatal("expected error when no running promxy pods exist")
+	}
+}

--- a/kof-operator/internal/controller/promxyservergroup_controller.go
+++ b/kof-operator/internal/controller/promxyservergroup_controller.go
@@ -163,7 +163,6 @@ func (r *PromxyServerGroupReconciler) Reconcile(ctx context.Context, req ctrl.Re
 				)
 				return ctrl.Result{}, err
 			}
-			log.Info("Reloading promxy config")
 			if err := r.PromxyConfigReload(ctx); err != nil {
 				record.LogEvent(
 					ctx,
@@ -204,7 +203,6 @@ func (r *PromxyServerGroupReconciler) Reconcile(ctx context.Context, req ctrl.Re
 			)
 			return ctrl.Result{}, err
 		}
-		log.Info("Reloading promxy config")
 		if err := r.PromxyConfigReload(ctx); err != nil {
 			record.LogEvent(
 				ctx,

--- a/kof-operator/internal/controller/suite_test.go
+++ b/kof-operator/internal/controller/suite_test.go
@@ -167,6 +167,8 @@ var _ = BeforeSuite(func() {
 	Expect(k8sClient.Create(ctx, releaseNamespace)).To(Succeed())
 	err = os.Setenv("RELEASE_NAME", ReleaseName)
 	Expect(err).NotTo(HaveOccurred())
+	err = os.Setenv("PROMXY_POD_LABEL_SELECTOR", "app.kubernetes.io/name=kof-mothership-promxy,app.kubernetes.io/instance="+ReleaseName)
+	Expect(err).NotTo(HaveOccurred())
 
 	err = os.Setenv("KOF_GRAFANA_ENABLED", strutil.True)
 	Expect(err).NotTo(HaveOccurred())

--- a/kof-operator/internal/env/env.go
+++ b/kof-operator/internal/env/env.go
@@ -171,3 +171,13 @@ func GetReleaseNamespace() (string, error) {
 	}
 	return namespace, nil
 }
+
+// GetPromxyPodLabelSelector returns the label selector used to find promxy pods
+// for config reload.
+func GetPromxyPodLabelSelector() (string, error) {
+	selector, ok := os.LookupEnv("PROMXY_POD_LABEL_SELECTOR")
+	if !ok || selector == "" {
+		return "", fmt.Errorf("required PROMXY_POD_LABEL_SELECTOR env var is not set")
+	}
+	return selector, nil
+}

--- a/kof-operator/internal/k8s/post_pod_http.go
+++ b/kof-operator/internal/k8s/post_pod_http.go
@@ -1,0 +1,69 @@
+package k8s
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+const defaultPodHTTPTimeout = 5 * time.Second
+
+// PostPodHTTP sends an HTTP POST to a container port on the pod IP.
+// This avoids the apiserver pod proxy subresource, which does not reliably
+// handle POST requests (HTTP/2 stream INTERNAL_ERROR).
+func PostPodHTTP(
+	ctx context.Context,
+	pod corev1.Pod,
+	containerName, portName, path string,
+	body io.Reader,
+	timeout time.Duration,
+) error {
+	if pod.Status.PodIP == "" {
+		return fmt.Errorf("pod %s has no IP assigned", pod.Name)
+	}
+
+	port, err := ExtractContainerPort(&pod, containerName, portName)
+	if err != nil {
+		return fmt.Errorf("pod %s: %w", pod.Name, err)
+	}
+	if timeout <= 0 {
+		timeout = defaultPodHTTPTimeout
+	}
+
+	url := fmt.Sprintf("http://%s:%s%s", pod.Status.PodIP, port, path)
+	reqCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(reqCtx, http.MethodPost, url, body)
+	if err != nil {
+		return fmt.Errorf("pod %s: %w", pod.Name, err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("pod %s: %w", pod.Name, err)
+	}
+	defer func() { _ = res.Body.Close() }()
+
+	if res.StatusCode < http.StatusOK || res.StatusCode >= http.StatusMultipleChoices {
+		return fmt.Errorf("pod %s: unexpected status %s", pod.Name, res.Status)
+	}
+
+	return nil
+}
+
+// PostPodHTTPEmpty sends an HTTP POST with an empty body to a container port on the pod IP.
+func PostPodHTTPEmpty(
+	ctx context.Context,
+	pod corev1.Pod,
+	containerName, portName, path string,
+	timeout time.Duration,
+) error {
+	return PostPodHTTP(ctx, pod, containerName, portName, path, strings.NewReader(""), timeout)
+}

--- a/kof-operator/internal/k8s/post_pod_http_test.go
+++ b/kof-operator/internal/k8s/post_pod_http_test.go
@@ -1,0 +1,45 @@
+package k8s
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestPostPodHTTPEmpty_NoPodIP(t *testing.T) {
+	t.Parallel()
+
+	pod := corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "promxy-1"},
+	}
+
+	err := PostPodHTTPEmpty(context.Background(), pod, "promxy", "http", "/-/reload", 0)
+	if err == nil {
+		t.Fatal("expected error when pod has no IP")
+	}
+	if !strings.Contains(err.Error(), "no IP assigned") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestPostPodHTTPEmpty_MissingPort(t *testing.T) {
+	t.Parallel()
+
+	pod := corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "promxy-1"},
+		Status:     corev1.PodStatus{PodIP: "10.0.0.1"},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{
+				Name: "promxy",
+			}},
+		},
+	}
+
+	err := PostPodHTTPEmpty(context.Background(), pod, "promxy", "http", "/-/reload", 0)
+	if err == nil {
+		t.Fatal("expected error when container port is missing")
+	}
+}


### PR DESCRIPTION
* Fixes #1123
* Metrics were missing or present randomly on request routed to different promxy pods.
* Reason was service routed reload request to one of pods only.
* Now each promxy replica is reloaded on config change.
* Verified, OK:
  ```
  kubectl logs -n kof kof-mothership-kof-operator-5f56d74dc9-tvl8t 
  
    2026-06-26T21:29:10Z	INFO	Updating promxy config secret	{"controller": "promxyservergroup", "controllerGroup": "kof.k0rdent.mirantis.com", "controllerKind": "PromxyServerGroup", "PromxyServerGroup": {"name":"promxy-server-group-685c5f75","namespace":"kcm-system"}, "namespace": "kcm-system", "name": "promxy-server-group-685c5f75", "reconcileID": "206349d5-996a-43a1-9fa5-2e5ce4ce2d5b", "secretName": "kof-mothership-promxy-config"}

    2026-06-26T21:29:10Z	INFO	Reloading promxy config	{"controller": "promxyservergroup", "controllerGroup": "kof.k0rdent.mirantis.com", "controllerKind": "PromxyServerGroup", "PromxyServerGroup": {"name":"promxy-server-group-685c5f75","namespace":"kcm-system"}, "namespace": "kcm-system", "name": "promxy-server-group-685c5f75", "reconcileID": "206349d5-996a-43a1-9fa5-2e5ce4ce2d5b",
    "pod": "kof-mothership-promxy-b9cc7d66c-8dlhw", "podIP": "10.244.0.153"}
    2026-06-26T21:29:15Z	INFO	Reloaded promxy config	{"controller": "promxyservergroup", "controllerGroup": "kof.k0rdent.mirantis.com", "controllerKind": "PromxyServerGroup", "PromxyServerGroup": {"name":"promxy-server-group-685c5f75","namespace":"kcm-system"}, "namespace": "kcm-system", "name": "promxy-server-group-685c5f75", "reconcileID": "206349d5-996a-43a1-9fa5-2e5ce4ce2d5b",
    "pod": "kof-mothership-promxy-b9cc7d66c-8dlhw", "podIP": "10.244.0.153"}

    2026-06-26T21:29:15Z	INFO	Reloading promxy config	{"controller": "promxyservergroup", "controllerGroup": "kof.k0rdent.mirantis.com", "controllerKind": "PromxyServerGroup", "PromxyServerGroup": {"name":"promxy-server-group-685c5f75","namespace":"kcm-system"}, "namespace": "kcm-system", "name": "promxy-server-group-685c5f75", "reconcileID": "206349d5-996a-43a1-9fa5-2e5ce4ce2d5b",
    "pod": "kof-mothership-promxy-b9cc7d66c-ph5cn", "podIP": "10.244.0.58"}
    2026-06-26T21:29:20Z	INFO	Reloaded promxy config	{"controller": "promxyservergroup", "controllerGroup": "kof.k0rdent.mirantis.com", "controllerKind": "PromxyServerGroup", "PromxyServerGroup": {"name":"promxy-server-group-685c5f75","namespace":"kcm-system"}, "namespace": "kcm-system", "name": "promxy-server-group-685c5f75", "reconcileID": "206349d5-996a-43a1-9fa5-2e5ce4ce2d5b",
    "pod": "kof-mothership-promxy-b9cc7d66c-ph5cn", "podIP": "10.244.0.58"}

    2026-06-26T21:29:20Z	INFO	Reloaded promxy config on all pods	{"controller": "promxyservergroup", "controllerGroup": "kof.k0rdent.mirantis.com", "controllerKind": "PromxyServerGroup", "PromxyServerGroup": {"name":"promxy-server-group-685c5f75","namespace":"kcm-system"}, "namespace": "kcm-system", "name": "promxy-server-group-685c5f75", "reconcileID": "206349d5-996a-43a1-9fa5-2e5ce4ce2d5b",
    "reloaded": 2}

  kubectl logs -n kof kof-mothership-promxy-b9cc7d66c-8dlhw 

    10.244.0.1 - - [26/Jun/2026 21:29:07] "GET /-/healthy HTTP/1.1 200 13" 0.000038 
    time="2026-06-26T21:29:10Z" level=info msg="Reloading config"
    time="2026-06-26T21:29:10Z" level=info fields.msg="Stopping remote storage..." queue="0:http://vminsert-cluster:8480/insert/0/prometheus/api/v1/write"
    time="2026-06-26T21:29:10Z" level=info fields.msg="Remote storage stopped." queue="0:http://vminsert-cluster:8480/insert/0/prometheus/api/v1/write"
    10.244.0.1 - - [26/Jun/2026 21:29:11] "GET /-/ready HTTP/1.1 200 11" 0.000031 
    10.244.0.1 - - [26/Jun/2026 21:29:12] "GET /-/healthy HTTP/1.1 200 13" 0.000041 
    10.244.0.159 - - [26/Jun/2026 21:29:15] "POST /-/reload HTTP/1.1 200 0" 5.029340 

  kubectl logs -n kof kof-mothership-promxy-b9cc7d66c-ph5cn 

    10.244.0.1 - - [26/Jun/2026 21:29:14] "GET /-/healthy HTTP/1.1 200 13" 0.000031 
    time="2026-06-26T21:29:15Z" level=info msg="Reloading config"
    time="2026-06-26T21:29:15Z" level=info fields.msg="Stopping remote storage..." queue="0:http://vminsert-cluster:8480/insert/0/prometheus/api/v1/write"
    time="2026-06-26T21:29:15Z" level=info fields.msg="Remote storage stopped." queue="0:http://vminsert-cluster:8480/insert/0/prometheus/api/v1/write"
    10.244.0.1 - - [26/Jun/2026 21:29:19] "GET /-/ready HTTP/1.1 200 11" 0.000031 
    10.244.0.1 - - [26/Jun/2026 21:29:19] "GET /-/healthy HTTP/1.1 200 13" 0.000025 
    10.244.0.159 - - [26/Jun/2026 21:29:20] "POST /-/reload HTTP/1.1 200 0" 5.038745  
  ```
