### PR TITLE
fix: Regionless should use hostNetwork for traces sent to node IP

### DIFF
--- a/charts/kof-regional/templates/regional-multi-cluster-service.yaml
+++ b/charts/kof-regional/templates/regional-multi-cluster-service.yaml
@@ -418,13 +418,47 @@ spec:
           global:
             clusterName: {clusterName}
             clusterNamespace: {clusterNamespace}
+
+          {{- if $regionless }}
+          kcm:
+            monitoring: true
+          {{- end }}
+
           opentelemetry-kube-stack:
             clusterName: {clusterName}
             collectors:
+            {{- if $istio }}
+              controller-k0s:
+                enabled: false
+            {{- end }}
               daemon:
                 image:
                   tag: v{{ $.Chart.AppVersion | trimPrefix "v" }}
+              {{- if $istio }}
+                hostNetwork: false
+              {{- else }}
+                hostNetwork: true
+                observability:
+                  metrics:
+                    disablePrometheusAnnotations: false
+                    enableMetrics: false
+                podAnnotations:
+                  prometheus.io/ip4: ${env:OTEL_K8S_NODE_IP}
+              {{- end }}
                 config:
+                {{- if not $istio }}
+                  receivers:
+                    prometheus:
+                      api_server:
+                        server_config:
+                          endpoint: ${env:OTEL_K8S_NODE_IP}:9090
+                    otlp:
+                      protocols:
+                        grpc:
+                          endpoint: 0.0.0.0:4317
+                        http:
+                          endpoint: 0.0.0.0:4318
+                {{- end }}
                   service:
                     extensions:
                       - k8s_observer
@@ -433,10 +467,17 @@ spec:
                       - file_storage/filelogk8sauditreceiver
                       - file_storage/journaldreceiver
                       - file_storage/exporters
-          {{- if $istio }}
-              controller-k0s:
-                enabled: false
-          {{- end }}
+
+                    {{- if not $istio }}
+                    telemetry:
+                      metrics:
+                        readers:
+                          - pull:
+                              exporter:
+                                prometheus:
+                                  host: ${env:OTEL_K8S_NODE_IP}
+                                  port: 8888
+                    {{- end }}
             defaultCRConfig:
               podAnnotations:
                 k0rdent.mirantis.com/kof-vmuser-secret-version: "{vmuserSecretVersion}"


### PR DESCRIPTION
* kof-operator logs in regionless mode, even when receiver is ready:
  ```
  exporter export timeout: rpc error: code = Unavailable desc = connection error:
  desc = "transport: Error while dialing:
  dial tcp 10.6.0.229:4317: connect: connection refused"
  ```
* kof-operator is sending traces to `http://$(NODE_IP):4317`
* kof-collectors should listen on `NODE_IP` due to `hostNetwork` configured e.g. in `kof-child` MCS.
* However the regionless mode uses `kof-regional` MCS which did not support `hostNetwork`.
* This PR fixes this discrepancy in `kof-child` vs `kof-regional` MCS-es.
* Checked that other differences there are intentional.
* Tested by patching live `kof-regional` MCS as in this PR, the error was fixed, traces are seen.
