### PR TITLE
fix: Cold storage / audit log exporters fail on TLS with real AWS S3

### DIFF
--- a/kof-operator/dockerfiles/audit-logs-exporter.dockerfile
+++ b/kof-operator/dockerfiles/audit-logs-exporter.dockerfile
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 FROM scratch
+COPY --from=curlimages/curl /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY bin/audit-logs-exporter /audit-logs-exporter
 USER 65532:65532
 

--- a/kof-operator/dockerfiles/cold-storage-exporter.dockerfile
+++ b/kof-operator/dockerfiles/cold-storage-exporter.dockerfile
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 FROM scratch
+COPY --from=curlimages/curl /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY bin/cold-storage-exporter /cold-storage-exporter
 USER 65532:65532
 


### PR DESCRIPTION
* Log of `cold-storage-exporter` configured to use the real AWS S3 bucket:
  ```
  kubectl logs -n kof -l job-name=cold-storage-exporter-manual -f

  {"level":"error","ts":"2026-06-30T10:57:06Z","logger":"cold-storage-exporter",
  "msg":"export run failed","error":"collect windows: check success marker
  \"telemetry/tenant=default/cluster=mothership/dt=2026-06-29/hour=10/metrics/_SUCCESS\":
  HeadObject \"telemetry/tenant=default/cluster=mothership/dt=2026-06-29/hour=10/metrics/_SUCCESS\":
  operation error S3: HeadObject, exceeded maximum number of attempts, 3,
  https response error StatusCode: 0, RequestID: , HostID: , request send failed,
  Head \"https://s3.us-west-1.amazonaws.com/REDACTED-us-west-1-an/telemetry/tenant%3Ddefault/cluster%3Dmothership/dt%3D2026-06-29/hour%3D10/metrics/_SUCCESS\":
  tls: failed to verify certificate: x509: certificate signed by unknown authority",

  "stacktrace":"main.main\n\t./main.go:49\nruntime.main\n\truntime/proc.go:290"}
  ```
* **Reason:** no `/etc/ssl/certs/ca-certificates.crt` in `FROM scratch` [cold-storage-exporter.dockerfile](https://github.com/k0rdent/kof/blob/v1.10.0/kof-operator/dockerfiles/cold-storage-exporter.dockerfile#L15).
* As a result, Go TLS client trusts no public CAs, and real AWS HTTPS endpoints fail verification.
* `http://minio.minio.svc.cluster.local:9000` we tested against masks this issue locally.
* This PR fixes it both for `cold-storage-exporter` and for `audit-logs-exporter`.
* Verified the fix up to successful logs and S3 bucket listing:
  ```
  {..."msg":"streaming parquet to S3",
  "key":"telemetry/tenant=default/cluster=mothership/dt=2026-06-29/hour=17/
  metrics/metrics.parquet"}

  aws s3 ls --recursive s3://REDACTED

  2026-06-30 18:18:24  153734056
  telemetry/tenant=default/cluster=mothership/dt=2026-06-29/hour=17/
  metrics/metrics.parquet
  ```