### PR TITLE
ci: Replaced `npm i` with `npm ci` to prevent `git is in a dirty state` error of goreleaser

### DIFF
--- a/.github/workflows/pr_test_helm_chart.yml
+++ b/.github/workflows/pr_test_helm_chart.yml
@@ -45,7 +45,7 @@ jobs:
         uses: ./.github/actions/fetch-pr-ref
       - name: Install dependencies
         working-directory: ./kof-operator/webapp/collector
-        run: npm i
+        run: npm ci
       - name: Run ESLint
         working-directory: ./kof-operator/webapp/collector
         run: npm run lint -- --max-warnings=0
@@ -64,7 +64,7 @@ jobs:
         uses: ./.github/actions/fetch-pr-ref
       - name: Install dependencies
         working-directory: ./kof-operator/webapp/collector
-        run: npm i
+        run: npm ci
       - name: Run Tests
         working-directory: ./kof-operator/webapp/collector
         run: npm test -- --silent

--- a/kof-operator/Makefile
+++ b/kof-operator/Makefile
@@ -144,7 +144,7 @@ run: manifests generate fmt vet ## Run a controller from your host.
 .PHONY: build-web-app
 build-web-app: ## Build web application.
 	@ \
-	npm --prefix ./webapp/collector i
+	npm --prefix ./webapp/collector ci
 	npm --prefix ./webapp/collector run build
 
 .PHONY: generate-dist


### PR DESCRIPTION
* The `goreleaser` failed [here](https://github.com/k0rdent/kof/actions/runs/28512283307/job/84515272635#step:10:63) with:
  ```
  error=
  │ git is in a dirty state
  │ Please check in your pipeline what can be changing the following files:
  │  M kof-operator/webapp/collector/package-lock.json
  │ Learn more at https://goreleaser.com/errors/dirty

  Error: The process '/opt/hostedtoolcache/goreleaser-action/2.16.0/x64/goreleaser' failed with exit code 1
  ```
* Reason: `npm i` can unexpectedly modify `package-lock.json`
* Solution: `npm ci` (clean install), [details](https://docs.npmjs.com/cli/v11/commands/npm-ci#description).
