### PR TITLE
chore: bump OpenTelemetry collector from v0.143.0 to v0.155.0

### DIFF
--- a/charts/kof-collectors/values.yaml
+++ b/charts/kof-collectors/values.yaml
@@ -157,7 +157,7 @@ opentelemetry-kube-stack:
             disablePrometheusAnnotations: true
             enableMetrics: true
         enabled: true
-        image: ghcr.io/open-telemetry/opentelemetry-operator/target-allocator:v0.143.0
+        image: ghcr.io/open-telemetry/opentelemetry-operator/target-allocator:v0.153.0
         prometheusCR:
           enabled: true
           podMonitorSelector: {}
@@ -1138,14 +1138,7 @@ opentelemetry-kube-stack:
     additionalContainers: []
     affinity: {}
     annotations: {}
-    args:
-      # NOTE: Keep resource detection error propagation disabled by default.
-      # This prevents collectors from failing hard when cloud metadata endpoints
-      # (EC2, GCP, Azure, etc.) are unreachable or misconfigured, which is common
-      # in hybrid/on‑prem and restricted-network environments. Set this to `true`
-      # if you need stricter error handling from the resourcedetection processor
-      # for troubleshooting purposes.
-      feature-gates: -processor.resourcedetection.propagateerrors
+    args: {}
     autoscaler: {}
     clusterRoleBinding:
       clusterRoleName: ""

--- a/charts/kof-operators/values.yaml
+++ b/charts/kof-operators/values.yaml
@@ -7,7 +7,7 @@ opentelemetry-operator:
       repository: ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator
     collectorImage:
       repository: "otel/opentelemetry-collector-contrib"
-      tag: "0.143.0"
+      tag: "0.155.0"
     createRbacPermissions: false
     extraArgs:
       - "--enable-go-instrumentation=true"

--- a/docker/opentelemetry-collector-contrib/Dockerfile
+++ b/docker/opentelemetry-collector-contrib/Dockerfile
@@ -1,4 +1,4 @@
-FROM otel/opentelemetry-collector-contrib:0.143.0 AS orig
+FROM otel/opentelemetry-collector-contrib:0.155.0 AS orig
 
 FROM linuxcontainers/debian-slim:latest
 RUN apt-get -y update && apt-get -y install systemd ca-certificates && apt-get clean && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
In this PR, the OpenTelemetry Collector version has been bumped.

Updating to the newer version fixes the following issues:
* Fixes https://github.com/k0rdent/kof/issues/549 - the newer version adds the following labels to every metric:
```
otel_scope_name="github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver"
otel_scope_version="0.155.0"
```
* Closes https://github.com/k0rdent/kof/issues/570 - upgraded the OpenTelemetry Collector to v0.155.0.
 