### PR TITLE
fix: Few places kept using old `gateway` name

### DIFF
--- a/.agents/skills/troubleshoot/SKILL.md
+++ b/.agents/skills/troubleshoot/SKILL.md
@@ -639,7 +639,7 @@ or the patch ran with an empty `$host_ip` due to a Make shell-scoping bug.
 kubectl get configmap coredns -n kube-system -o jsonpath='{.data.Corefile}'
 
 # Re-patch CoreDNS manually with the correct gateway IP
-gateway_ip=$(kubectl get gateway gateway -n kof -o jsonpath='{.status.addresses[0].value}')
+gateway_ip=$(kubectl get gateway mothership-gateway -n kof -o jsonpath='{.status.addresses[0].value}')
 bash scripts/patch-coredns.bash kubectl "dex.example.com" "$gateway_ip"
 kubectl -n kube-system rollout restart deploy/coredns
 

--- a/.github/workflows/test_builds.yml
+++ b/.github/workflows/test_builds.yml
@@ -326,31 +326,41 @@ jobs:
           fi
           success=false
           for attempt in $(seq 1 10); do
-            if ! $gateway_kubectl get gateway gateway -n kof 2>/dev/null; then
+            gateways=$($gateway_kubectl get gateway -n kof \
+              -o jsonpath='{range .items[*]}{.metadata.name}{";"}{end}' 2>/dev/null || true)
+            if [ -z "$gateways" ]; then
+              echo "No gateways found yet, retrying..."
               sleep 10
               continue
             fi
-            gateway_ip=$($gateway_kubectl get gateway gateway -n kof \
-              -o jsonpath='{.status.addresses[0].value}')
-            if [ -z "$gateway_ip" ]; then
-              echo "Gateway IP not ready yet"
-              sleep 5
-              continue
-            fi
-            httproutes=$($gateway_kubectl get httproute -n kof \
-              -o jsonpath='{range .items[*]}{range .spec.hostnames[*]}{@}{";"}{end}{end}' \
-              2>/dev/null || true)
-            if [ -z "$httproutes" ]; then
-              echo "HTTPRoutes not ready yet"
-              sleep 5
-              continue
-            fi
-            for record in $(echo "$httproutes" | tr ';' ' '); do
-              [ -z "$record" ] && continue
-              bash scripts/patch-coredns.bash "kubectl --context kind-child-adopted" \
-                "$record" "$gateway_ip"
-              bash scripts/patch-coredns.bash "kubectl" "$record" "$gateway_ip"
+            all_ready=true
+            for gw in $(echo "$gateways" | tr ';' ' '); do
+              [ -z "$gw" ] && continue
+              gateway_ip=$($gateway_kubectl get gateway "$gw" -n kof \
+                -o jsonpath='{.status.addresses[0].value}' 2>/dev/null || true)
+              if [ -z "$gateway_ip" ]; then
+                echo "Gateway $gw IP address is not ready yet"
+                all_ready=false
+                break
+              fi
+              httproutes=$($gateway_kubectl get httproute -n kof \
+                -o jsonpath="{range .items[?(@.spec.parentRefs[0].name==\"$gw\")]}{range .spec.hostnames[*]}{@}{';'}{end}{end}" \
+                2>/dev/null || true)
+              if [ -z "$httproutes" ]; then
+                echo "No httproutes for gateway $gw, skipping..."
+                continue
+              fi
+              for record in $(echo "$httproutes" | tr ';' ' '); do
+                [ -z "$record" ] && continue
+                bash scripts/patch-coredns.bash "kubectl --context kind-child-adopted" \
+                  "$record" "$gateway_ip"
+                bash scripts/patch-coredns.bash "kubectl" "$record" "$gateway_ip"
+              done
             done
+            if [ "$all_ready" != "true" ]; then
+              sleep 10
+              continue
+            fi
             echo "🔄 Restarting CoreDNS pods..."
             kubectl --context kind-child-adopted -n kube-system rollout restart deploy/coredns
             kubectl -n kube-system rollout restart deploy/coredns

--- a/docs/dex-sso.md
+++ b/docs/dex-sso.md
@@ -80,7 +80,7 @@ Locally, we use Grafana configured with Dex SSO. If you wish to set it up and ru
     ```bash
     kubectl port-forward -n envoy-gateway-system \
       $(kubectl get svc -n envoy-gateway-system \
-        -l "gateway.envoyproxy.io/owning-gateway-name=gateway,gateway.envoyproxy.io/owning-gateway-namespace=kof" \
+        -l "gateway.envoyproxy.io/owning-gateway-name=mothership-gateway,gateway.envoyproxy.io/owning-gateway-namespace=kof" \
         -o name) \
       8443:8443
     ```


### PR DESCRIPTION
* https://github.com/k0rdent/kof/pull/1092
  has renamed `gateway` to `mothership-gateway` and `storage-gateway`.
* After it was merged, CI job creating a build from `main` branch failed - https://github.com/k0rdent/kof/actions/runs/29038508308/job/86192491941#step:32:13
* Few places kept using old `gateway` name, this PR fixes this.
